### PR TITLE
feat: support for preIPO assets

### DIFF
--- a/contracts/mirror_factory/schema/handle_msg.json
+++ b/contracts/mirror_factory/schema/handle_msg.json
@@ -280,6 +280,16 @@
             "from_token": {
               "$ref": "#/definitions/HumanAddr"
             },
+            "min_collateral_ratio": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Decimal"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
             "name": {
               "type": "string"
             },
@@ -337,6 +347,15 @@
               "$ref": "#/definitions/Decimal"
             }
           ]
+        },
+        "mint_period": {
+          "description": "For pre-IPO assets, time period after asset creation in which minting is enabled",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0.0
         },
         "weight": {
           "description": "Distribution weight (default is 30, which is 1/10 of MIR distribution weight)",

--- a/contracts/mirror_factory/src/contract.rs
+++ b/contracts/mirror_factory/src/contract.rs
@@ -117,8 +117,16 @@ pub fn handle<S: Storage, A: Api, Q: Querier>(
             symbol,
             from_token,
             end_price,
-            new_min_cr,
-        } => migrate_asset(deps, env, name, symbol, from_token, end_price, new_min_cr),
+            min_collateral_ratio,
+        } => migrate_asset(
+            deps,
+            env,
+            name,
+            symbol,
+            from_token,
+            end_price,
+            min_collateral_ratio,
+        ),
     }
 }
 

--- a/contracts/mirror_factory/src/contract.rs
+++ b/contracts/mirror_factory/src/contract.rs
@@ -117,7 +117,8 @@ pub fn handle<S: Storage, A: Api, Q: Querier>(
             symbol,
             from_token,
             end_price,
-        } => migrate_asset(deps, env, name, symbol, from_token, end_price),
+            new_min_cr,
+        } => migrate_asset(deps, env, name, symbol, from_token, end_price, new_min_cr),
     }
 }
 
@@ -330,6 +331,13 @@ pub fn token_creation_hook<S: Storage, A: Api, Q: Querier>(
     // Remove params == clear flag
     remove_params(&mut deps.storage);
 
+    // If it is a pre-IPO asset, calculate the end of the minting period
+    let mint_end = if let Some(mint_period) = params.mint_period {
+        Some(env.block.height + mint_period)
+    } else {
+        None
+    };
+
     // Register asset to mint contract
     // Register asset to oracle contract
     // Create terraswap pair
@@ -342,6 +350,7 @@ pub fn token_creation_hook<S: Storage, A: Api, Q: Querier>(
                     asset_token: asset_token.clone(),
                     auction_discount: params.auction_discount,
                     min_collateral_ratio: params.min_collateral_ratio,
+                    mint_end,
                 })?,
             }),
             CosmosMsg::Wasm(WasmMsg::Execute {
@@ -550,6 +559,7 @@ pub fn migrate_asset<S: Storage, A: Api, Q: Querier>(
     symbol: String,
     asset_token: HumanAddr,
     end_price: Decimal,
+    new_min_cr: Option<Decimal>,
 ) -> HandleResult {
     let config: Config = read_config(&deps.storage)?;
     let asset_token_raw: CanonicalAddr = deps.api.canonical_address(&asset_token)?;
@@ -570,13 +580,20 @@ pub fn migrate_asset<S: Storage, A: Api, Q: Querier>(
     let mint_contract = deps.api.human_address(&config.mint_contract)?;
     let mint_config: (Decimal, Decimal) =
         load_mint_asset_config(&deps, &mint_contract, &asset_token_raw)?;
+    // If there is a new MCR given, update. Otherwise, import from previous
+    let min_cr = if let Some(new_min_cr) = new_min_cr {
+        new_min_cr
+    } else {
+        mint_config.1
+    };
 
     store_params(
         &mut deps.storage,
         &Params {
             auction_discount: mint_config.0,
-            min_collateral_ratio: mint_config.1,
+            min_collateral_ratio: min_cr,
             weight: Some(weight),
+            mint_period: None,
         },
     )?;
 

--- a/contracts/mirror_factory/src/testing.rs
+++ b/contracts/mirror_factory/src/testing.rs
@@ -286,6 +286,7 @@ fn test_whitelist() {
             auction_discount: Decimal::percent(5),
             min_collateral_ratio: Decimal::percent(150),
             weight: Some(100u32),
+            mint_period: None,
         },
     };
     let env = mock_env("owner0000", &[]);
@@ -335,6 +336,7 @@ fn test_whitelist() {
             auction_discount: Decimal::percent(5),
             min_collateral_ratio: Decimal::percent(150),
             weight: Some(100u32),
+            mint_period: None,
         }
     );
 
@@ -397,6 +399,7 @@ fn test_token_creation_hook() {
             auction_discount: Decimal::percent(5),
             min_collateral_ratio: Decimal::percent(150),
             weight: Some(100u32),
+            mint_period: None,
         },
     };
     let env = mock_env("owner0000", &[]);
@@ -417,6 +420,7 @@ fn test_token_creation_hook() {
                     asset_token: HumanAddr::from("asset0000"),
                     auction_discount: Decimal::percent(5),
                     min_collateral_ratio: Decimal::percent(150),
+                    mint_end: None,
                 })
                 .unwrap(),
             }),
@@ -523,6 +527,7 @@ fn test_token_creation_hook_without_weight() {
             auction_discount: Decimal::percent(5),
             min_collateral_ratio: Decimal::percent(150),
             weight: None,
+            mint_period: None,
         },
     };
     let env = mock_env("owner0000", &[]);
@@ -543,6 +548,7 @@ fn test_token_creation_hook_without_weight() {
                     asset_token: HumanAddr::from("asset0000"),
                     auction_discount: Decimal::percent(5),
                     min_collateral_ratio: Decimal::percent(150),
+                    mint_end: None,
                 })
                 .unwrap(),
             }),
@@ -638,6 +644,7 @@ fn test_terraswap_creation_hook() {
             auction_discount: Decimal::percent(5),
             min_collateral_ratio: Decimal::percent(150),
             weight: Some(100u32),
+            mint_period: None,
         },
     };
     let env = mock_env("owner0000", &[]);
@@ -708,6 +715,7 @@ fn test_distribute() {
             auction_discount: Decimal::percent(5),
             min_collateral_ratio: Decimal::percent(150),
             weight: Some(100u32),
+            mint_period: None,
         },
     };
     let env = mock_env("owner0000", &[]);
@@ -734,6 +742,7 @@ fn test_distribute() {
             auction_discount: Decimal::percent(5),
             min_collateral_ratio: Decimal::percent(150),
             weight: Some(100u32),
+            mint_period: None,
         },
     };
     let env = mock_env("owner0000", &[]);
@@ -859,6 +868,7 @@ fn test_revocation() {
             auction_discount: Decimal::percent(5),
             min_collateral_ratio: Decimal::percent(150),
             weight: Some(100u32),
+            mint_period: None,
         },
     };
     let env = mock_env("owner0000", &[]);
@@ -945,6 +955,7 @@ fn test_migration() {
             auction_discount: Decimal::percent(5),
             min_collateral_ratio: Decimal::percent(150),
             weight: Some(100u32),
+            mint_period: None,
         },
     };
     let env = mock_env("owner0000", &[]);
@@ -978,6 +989,7 @@ fn test_migration() {
         symbol: "mAPPL2".to_string(),
         from_token: HumanAddr::from("asset0000"),
         end_price: Decimal::from_ratio(2u128, 1u128),
+        new_min_cr: None, // use previous cr
     };
     let env = mock_env("owner0000", &[]);
     let res = handle(&mut deps, env, msg.clone()).unwrap_err();
@@ -1018,6 +1030,252 @@ fn test_migration() {
                         contract_addr: HumanAddr::from(MOCK_CONTRACT_ADDR),
                         msg: to_binary(&HandleMsg::TokenCreationHook {
                             oracle_feeder: HumanAddr::from("feeder0000")
+                        })
+                        .unwrap(),
+                    }),
+                })
+                .unwrap(),
+            })
+        ]
+    );
+}
+
+#[test]
+fn test_whitelist_pre_ipo_asset() {
+    let mut deps = mock_dependencies(20, &[]);
+
+    let msg = InitMsg {
+        base_denom: BASE_DENOM.to_string(),
+        token_code_id: TOKEN_CODE_ID,
+        distribution_schedule: vec![],
+    };
+
+    let env = mock_env("addr0000", &[]);
+    let _res = init(&mut deps, env.clone(), msg).unwrap();
+
+    let msg = HandleMsg::PostInitialize {
+        owner: HumanAddr::from("owner0000"),
+        mirror_token: HumanAddr::from("mirror0000"),
+        mint_contract: HumanAddr::from("mint0000"),
+        staking_contract: HumanAddr::from("staking0000"),
+        commission_collector: HumanAddr::from("collector0000"),
+        oracle_contract: HumanAddr::from("oracle0000"),
+        terraswap_factory: HumanAddr::from("terraswapfactory"),
+    };
+    let _res = handle(&mut deps, env.clone(), msg).unwrap();
+
+    let msg = HandleMsg::Whitelist {
+        name: "pre-IPO asset".to_string(),
+        symbol: "mPreIPO".to_string(),
+        oracle_feeder: HumanAddr::from("feeder0000"),
+        params: Params {
+            auction_discount: Decimal::percent(5),
+            min_collateral_ratio: Decimal::percent(1000),
+            weight: Some(100u32),
+            mint_period: Some(10000u64),
+        },
+    };
+    let env = mock_env("owner0000", &[]);
+    let res = handle(&mut deps, env.clone(), msg.clone()).unwrap();
+
+    // token creation msg should be returned
+    assert_eq!(
+        res.messages,
+        vec![CosmosMsg::Wasm(WasmMsg::Instantiate {
+            code_id: TOKEN_CODE_ID,
+            send: vec![],
+            label: None,
+            msg: to_binary(&TokenInitMsg {
+                name: "pre-IPO asset".to_string(),
+                symbol: "mPreIPO".to_string(),
+                decimals: 6u8,
+                initial_balances: vec![],
+                mint: Some(MinterResponse {
+                    minter: HumanAddr::from("mint0000"),
+                    cap: None,
+                }),
+                init_hook: Some(InitHook {
+                    contract_addr: HumanAddr::from(MOCK_CONTRACT_ADDR),
+                    msg: to_binary(&HandleMsg::TokenCreationHook {
+                        oracle_feeder: HumanAddr::from("feeder0000")
+                    })
+                    .unwrap(),
+                }),
+            })
+            .unwrap(),
+        })]
+    );
+
+    let params: Params = read_params(&deps.storage).unwrap();
+    assert_eq!(
+        params,
+        Params {
+            auction_discount: Decimal::percent(5),
+            min_collateral_ratio: Decimal::percent(1000),
+            weight: Some(100u32),
+            mint_period: Some(10000u64),
+        }
+    );
+
+    // execute token creation hook
+    let msg = HandleMsg::TokenCreationHook {
+        oracle_feeder: HumanAddr::from("feeder0000"),
+    };
+
+    let env = mock_env("asset0000", &[]);
+    let res = handle(&mut deps, env.clone(), msg.clone()).unwrap();
+    assert_eq!(
+        res.messages,
+        vec![
+            CosmosMsg::Wasm(WasmMsg::Execute {
+                contract_addr: HumanAddr::from("mint0000"),
+                send: vec![],
+                msg: to_binary(&MintHandleMsg::RegisterAsset {
+                    asset_token: HumanAddr::from("asset0000"),
+                    auction_discount: Decimal::percent(5),
+                    min_collateral_ratio: Decimal::percent(1000),
+                    mint_end: Some(env.block.height + 10000u64),
+                })
+                .unwrap(),
+            }),
+            CosmosMsg::Wasm(WasmMsg::Execute {
+                contract_addr: HumanAddr::from("oracle0000"),
+                send: vec![],
+                msg: to_binary(&OracleHandleMsg::RegisterAsset {
+                    asset_token: HumanAddr::from("asset0000"),
+                    feeder: HumanAddr::from("feeder0000"),
+                })
+                .unwrap(),
+            }),
+            CosmosMsg::Wasm(WasmMsg::Execute {
+                contract_addr: HumanAddr::from("terraswapfactory"),
+                send: vec![],
+                msg: to_binary(&TerraswapFactoryHandleMsg::CreatePair {
+                    asset_infos: [
+                        AssetInfo::NativeToken {
+                            denom: BASE_DENOM.to_string(),
+                        },
+                        AssetInfo::Token {
+                            contract_addr: HumanAddr::from("asset0000"),
+                        },
+                    ],
+                    init_hook: Some(InitHook {
+                        msg: to_binary(&HandleMsg::TerraswapCreationHook {
+                            asset_token: HumanAddr::from("asset0000"),
+                        })
+                        .unwrap(),
+                        contract_addr: HumanAddr::from(MOCK_CONTRACT_ADDR),
+                    }),
+                })
+                .unwrap(),
+            })
+        ]
+    );
+}
+
+#[test]
+fn test_migrate_pre_ipo_asset() {
+    let mut deps = mock_dependencies(20, &[]);
+    deps.querier
+        .with_terraswap_pairs(&[(&"uusdpreIPOasset0000".to_string(), &HumanAddr::from("LP0000"))]);
+
+    let msg = InitMsg {
+        base_denom: BASE_DENOM.to_string(),
+        token_code_id: TOKEN_CODE_ID,
+        distribution_schedule: vec![],
+    };
+
+    let env = mock_env("addr0000", &[]);
+    let _res = init(&mut deps, env.clone(), msg).unwrap();
+
+    let msg = HandleMsg::PostInitialize {
+        owner: HumanAddr::from("owner0000"),
+        mirror_token: HumanAddr::from("mirror0000"),
+        mint_contract: HumanAddr::from("mint0000"),
+        staking_contract: HumanAddr::from("staking0000"),
+        commission_collector: HumanAddr::from("collector0000"),
+        oracle_contract: HumanAddr::from("oracle0000"),
+        terraswap_factory: HumanAddr::from("terraswapfactory"),
+    };
+    let _res = handle(&mut deps, env, msg).unwrap();
+
+    // whitelist pre-IPO asset
+    let msg = HandleMsg::Whitelist {
+        name: "Pre-IPO asset".to_string(),
+        symbol: "mPreIPO".to_string(),
+        oracle_feeder: HumanAddr::from("feeder0000"),
+        params: Params {
+            auction_discount: Decimal::percent(5),
+            min_collateral_ratio: Decimal::percent(1000),
+            weight: Some(100u32),
+            mint_period: Some(1000u64),
+        },
+    };
+    let env = mock_env("owner0000", &[]);
+    let _res = handle(&mut deps, env, msg).unwrap();
+
+    let msg = HandleMsg::TokenCreationHook {
+        oracle_feeder: HumanAddr::from("feeder0000"),
+    };
+    let env = mock_env("preIPOasset0000", &[]);
+    let _res = handle(&mut deps, env, msg).unwrap();
+
+    let msg = HandleMsg::TerraswapCreationHook {
+        asset_token: HumanAddr::from("preIPOasset0000"),
+    };
+    let env = mock_env("terraswapfactory", &[]);
+    let _res = handle(&mut deps, env, msg).unwrap();
+
+    // register queriers
+    deps.querier.with_mint_configs(&[(
+        &HumanAddr::from("preIPOasset0000"),
+        &(Decimal::percent(1), Decimal::percent(1)),
+    )]);
+    deps.querier.with_oracle_feeders(&[(
+        &HumanAddr::from("preIPOasset0000"),
+        &HumanAddr::from("feeder0000"),
+    )]);
+
+    // migration triggered by feeder
+    let msg = HandleMsg::MigrateAsset {
+        name: "Post-IPO asset".to_string(),
+        symbol: "mPostIPO".to_string(),
+        from_token: HumanAddr::from("preIPOasset0000"),
+        end_price: Decimal::from_ratio(2u128, 1u128), // give first IPO price
+        new_min_cr: Some(Decimal::percent(150)), // new mcr
+    };
+
+    let env = mock_env("feeder0000", &[]);
+    let res = handle(&mut deps, env, msg).unwrap();
+    assert_eq!(
+        res.messages,
+        vec![
+            CosmosMsg::Wasm(WasmMsg::Execute {
+                contract_addr: HumanAddr::from("mint0000"),
+                send: vec![],
+                msg: to_binary(&MintHandleMsg::RegisterMigration {
+                    asset_token: HumanAddr::from("preIPOasset0000"),
+                    end_price: Decimal::from_ratio(2u128, 1u128),
+                })
+                .unwrap(),
+            }),
+            CosmosMsg::Wasm(WasmMsg::Instantiate {
+                code_id: TOKEN_CODE_ID,
+                send: vec![],
+                label: None,
+                msg: to_binary(&TokenInitMsg {
+                    name: "Post-IPO asset".to_string(),
+                    symbol: "mPostIPO".to_string(),
+                    decimals: 6u8,
+                    initial_balances: vec![],
+                    mint: Some(MinterResponse {
+                        minter: HumanAddr::from("mint0000"),
+                        cap: None,
+                    }),
+                    init_hook: Some(InitHook {
+                        contract_addr: HumanAddr::from(MOCK_CONTRACT_ADDR),
+                        msg: to_binary(&HandleMsg::TokenCreationHook {
+                            oracle_feeder: HumanAddr::from("feeder0000") // same feeder
                         })
                         .unwrap(),
                     }),

--- a/contracts/mirror_factory/src/testing.rs
+++ b/contracts/mirror_factory/src/testing.rs
@@ -989,7 +989,7 @@ fn test_migration() {
         symbol: "mAPPL2".to_string(),
         from_token: HumanAddr::from("asset0000"),
         end_price: Decimal::from_ratio(2u128, 1u128),
-        new_min_cr: None, // use previous cr
+        min_collateral_ratio: None, // use previous cr
     };
     let env = mock_env("owner0000", &[]);
     let res = handle(&mut deps, env, msg.clone()).unwrap_err();
@@ -1176,8 +1176,10 @@ fn test_whitelist_pre_ipo_asset() {
 #[test]
 fn test_migrate_pre_ipo_asset() {
     let mut deps = mock_dependencies(20, &[]);
-    deps.querier
-        .with_terraswap_pairs(&[(&"uusdpreIPOasset0000".to_string(), &HumanAddr::from("LP0000"))]);
+    deps.querier.with_terraswap_pairs(&[(
+        &"uusdpreIPOasset0000".to_string(),
+        &HumanAddr::from("LP0000"),
+    )]);
 
     let msg = InitMsg {
         base_denom: BASE_DENOM.to_string(),
@@ -1242,7 +1244,7 @@ fn test_migrate_pre_ipo_asset() {
         symbol: "mPostIPO".to_string(),
         from_token: HumanAddr::from("preIPOasset0000"),
         end_price: Decimal::from_ratio(2u128, 1u128), // give first IPO price
-        new_min_cr: Some(Decimal::percent(150)), // new mcr
+        min_collateral_ratio: Some(Decimal::percent(150)), // new mcr
     };
 
     let env = mock_env("feeder0000", &[]);

--- a/contracts/mirror_mint/schema/handle_msg.json
+++ b/contracts/mirror_mint/schema/handle_msg.json
@@ -138,6 +138,14 @@
             },
             "min_collateral_ratio": {
               "$ref": "#/definitions/Decimal"
+            },
+            "mint_end": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint64",
+              "minimum": 0.0
             }
           }
         }

--- a/contracts/mirror_mint/src/lib.rs
+++ b/contracts/mirror_mint/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod contract;
 pub mod math;
+pub mod migration;
 pub mod querier;
 pub mod state;
 

--- a/contracts/mirror_mint/src/migration.rs
+++ b/contracts/mirror_mint/src/migration.rs
@@ -1,0 +1,47 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use cosmwasm_std::{CanonicalAddr, Decimal, Order, StdResult, Storage};
+use cosmwasm_storage::ReadonlyBucket;
+
+use crate::state::{store_asset_config, AssetConfig, PREFIX_ASSET_CONFIG};
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct LegacyAssetConfig {
+    pub token: CanonicalAddr,
+    pub auction_discount: Decimal,
+    pub min_collateral_ratio: Decimal,
+    pub end_price: Option<Decimal>,
+    pub mint_end: Option<u64>,
+}
+
+fn read_legacy_asset_configs<S: Storage>(storage: &S) -> StdResult<Vec<LegacyAssetConfig>> {
+    let asset_config_bucket: ReadonlyBucket<S, LegacyAssetConfig> =
+        ReadonlyBucket::new(PREFIX_ASSET_CONFIG, storage);
+    asset_config_bucket
+        .range(None, None, Order::Ascending)
+        .map(|item| {
+            let (_, v) = item?;
+            Ok(v)
+        })
+        .collect()
+}
+
+pub fn migrate_asset_configs<S: Storage>(storage: &mut S) -> StdResult<()> {
+    let legacy_asset_configs: Vec<LegacyAssetConfig> = read_legacy_asset_configs(storage)?;
+
+    for legacy_config in legacy_asset_configs {
+        store_asset_config(
+            storage,
+            &legacy_config.token,
+            &AssetConfig {
+                token: legacy_config.token.clone(),
+                auction_discount: legacy_config.auction_discount,
+                min_collateral_ratio: legacy_config.min_collateral_ratio,
+                end_price: legacy_config.end_price,
+                mint_end: None,
+            },
+        )?
+    }
+    Ok(())
+}

--- a/contracts/mirror_mint/src/migration.rs
+++ b/contracts/mirror_mint/src/migration.rs
@@ -1,10 +1,19 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use cosmwasm_std::{CanonicalAddr, Decimal, Order, StdResult, Storage};
-use cosmwasm_storage::ReadonlyBucket;
+use cosmwasm_std::{CanonicalAddr, Decimal, Order, StdResult, Storage, Api, HumanAddr};
+use cosmwasm_storage::{ReadonlyBucket, Bucket};
 
-use crate::state::{store_asset_config, AssetConfig, PREFIX_ASSET_CONFIG};
+use crate::state::{store_asset_config, AssetConfig};
+
+static PREFIX_ASSET_CONFIG: &[u8] = b"asset_config";
+
+#[cfg(test)]
+pub fn asset_config_old_store<'a, S: Storage>(
+    storage: &'a mut S,
+) -> Bucket<'a, S, LegacyAssetConfig> {
+    Bucket::new(PREFIX_ASSET_CONFIG, storage)
+}
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct LegacyAssetConfig {
@@ -12,7 +21,6 @@ pub struct LegacyAssetConfig {
     pub auction_discount: Decimal,
     pub min_collateral_ratio: Decimal,
     pub end_price: Option<Decimal>,
-    pub mint_end: Option<u64>,
 }
 
 fn read_legacy_asset_configs<S: Storage>(storage: &S) -> StdResult<Vec<LegacyAssetConfig>> {
@@ -44,4 +52,57 @@ pub fn migrate_asset_configs<S: Storage>(storage: &mut S) -> StdResult<()> {
         )?
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod migrate_tests {
+    use super::*;
+    use crate::state::read_asset_config;
+    use cosmwasm_std::testing::mock_dependencies;
+
+    #[test]
+    fn test_asset_config_migration() {
+        let mut deps = mock_dependencies(20, &[]);
+
+        let asset_token = deps.api.canonical_address(&HumanAddr::from("token0001")).unwrap(); 
+        let legacy_asset_config = LegacyAssetConfig {
+            token: asset_token.clone(),
+            auction_discount: Decimal::percent(10),
+            min_collateral_ratio: Decimal::percent(150),
+            end_price: None,
+        };
+        let asset_token_2 = deps.api.canonical_address(&HumanAddr::from("token0002")).unwrap(); 
+        let legacy_asset_config_2 = LegacyAssetConfig {
+            token: asset_token_2.clone(),
+            auction_discount: Decimal::percent(20),
+            min_collateral_ratio: Decimal::percent(200),
+            end_price: Some(Decimal::percent(1)),
+        };
+
+        asset_config_old_store(&mut deps.storage).save(asset_token.as_slice(), &legacy_asset_config).unwrap();
+        asset_config_old_store(&mut deps.storage).save(asset_token_2.as_slice(), &legacy_asset_config_2).unwrap();
+
+        migrate_asset_configs(&mut deps.storage).unwrap();
+
+        assert_eq!(
+            read_asset_config(&mut deps.storage, &asset_token).unwrap(),
+            AssetConfig {
+                token: legacy_asset_config.token.clone(),
+                auction_discount: legacy_asset_config.auction_discount,
+                min_collateral_ratio: legacy_asset_config.min_collateral_ratio,
+                end_price: legacy_asset_config.end_price,
+                mint_end: None,
+            }
+        );
+        assert_eq!(
+            read_asset_config(&mut deps.storage, &asset_token_2).unwrap(),
+            AssetConfig {
+                token: legacy_asset_config_2.token.clone(),
+                auction_discount: legacy_asset_config_2.auction_discount,
+                min_collateral_ratio: legacy_asset_config_2.min_collateral_ratio,
+                end_price: legacy_asset_config_2.end_price,
+                mint_end: None,
+            }
+        );
+    }
 }

--- a/contracts/mirror_mint/src/state.rs
+++ b/contracts/mirror_mint/src/state.rs
@@ -50,6 +50,7 @@ pub struct AssetConfig {
     pub auction_discount: Decimal,
     pub min_collateral_ratio: Decimal,
     pub end_price: Option<Decimal>,
+    pub mint_end: Option<u64>,
 }
 
 pub fn store_asset_config<S: Storage>(

--- a/contracts/mirror_mint/src/state.rs
+++ b/contracts/mirror_mint/src/state.rs
@@ -10,7 +10,9 @@ use mirror_protocol::common::OrderBy;
 use std::convert::TryInto;
 use terraswap::asset::{AssetInfoRaw, AssetRaw};
 
-static PREFIX_ASSET_CONFIG: &[u8] = b"asset_config";
+// make public for migration
+pub static PREFIX_ASSET_CONFIG: &[u8] = b"asset_config";
+
 static PREFIX_POSITION: &[u8] = b"position";
 static PREFIX_INDEX_BY_USER: &[u8] = b"by_user";
 static PREFIX_INDEX_BY_ASSET: &[u8] = b"by_asset";

--- a/contracts/mirror_mint/src/state.rs
+++ b/contracts/mirror_mint/src/state.rs
@@ -10,9 +10,7 @@ use mirror_protocol::common::OrderBy;
 use std::convert::TryInto;
 use terraswap::asset::{AssetInfoRaw, AssetRaw};
 
-// make public for migration
-pub static PREFIX_ASSET_CONFIG: &[u8] = b"asset_config";
-
+static PREFIX_ASSET_CONFIG: &[u8] = b"asset_config";
 static PREFIX_POSITION: &[u8] = b"position";
 static PREFIX_INDEX_BY_USER: &[u8] = b"by_user";
 static PREFIX_INDEX_BY_ASSET: &[u8] = b"by_asset";

--- a/contracts/mirror_mint/src/testing.rs
+++ b/contracts/mirror_mint/src/testing.rs
@@ -119,6 +119,7 @@ fn register_asset() {
         asset_token: HumanAddr::from("asset0000"),
         auction_discount: Decimal::percent(20),
         min_collateral_ratio: Decimal::percent(150),
+        mint_end: None,
     };
 
     let env = mock_env("owner0000", &[]);
@@ -148,6 +149,7 @@ fn register_asset() {
         asset_token: HumanAddr::from("asset0000"),
         auction_discount: Decimal::percent(20),
         min_collateral_ratio: Decimal::percent(150),
+        mint_end: None,
     };
     let env = mock_env("owner0000", &[]);
     let res = handle(&mut deps, env, msg).unwrap_err();
@@ -161,6 +163,7 @@ fn register_asset() {
         asset_token: HumanAddr::from("asset0000"),
         auction_discount: Decimal::percent(20),
         min_collateral_ratio: Decimal::percent(150),
+        mint_end: None,
     };
     let env = mock_env("owner0001", &[]);
     let res = handle(&mut deps, env, msg).unwrap_err();
@@ -174,6 +177,7 @@ fn register_asset() {
         asset_token: HumanAddr::from("asset0000"),
         auction_discount: Decimal::percent(150),
         min_collateral_ratio: Decimal::percent(150),
+        mint_end: None,
     };
     let env = mock_env("owner0000", &[]);
     let res = handle(&mut deps, env, msg).unwrap_err();
@@ -189,6 +193,7 @@ fn register_asset() {
         asset_token: HumanAddr::from("asset0000"),
         auction_discount: Decimal::percent(20),
         min_collateral_ratio: Decimal::percent(50),
+        mint_end: None,
     };
     let env = mock_env("owner0000", &[]);
     let res = handle(&mut deps, env, msg).unwrap_err();
@@ -222,6 +227,7 @@ fn update_asset() {
         asset_token: HumanAddr::from("asset0000"),
         auction_discount: Decimal::percent(20),
         min_collateral_ratio: Decimal::percent(150),
+        mint_end: None,
     };
 
     let env = mock_env("owner0000", &[]);
@@ -231,6 +237,7 @@ fn update_asset() {
         asset_token: HumanAddr::from("asset0000"),
         auction_discount: Some(Decimal::percent(30)),
         min_collateral_ratio: Some(Decimal::percent(200)),
+        mint_end: None,
     };
     let env = mock_env("owner0000", &[]);
     let _res = handle(&mut deps, env, msg).unwrap();
@@ -257,6 +264,7 @@ fn update_asset() {
         asset_token: HumanAddr::from("asset0000"),
         auction_discount: Some(Decimal::percent(130)),
         min_collateral_ratio: Some(Decimal::percent(150)),
+        mint_end: None,
     };
     let env = mock_env("owner0000", &[]);
     let res = handle(&mut deps, env, msg).unwrap_err();
@@ -271,6 +279,7 @@ fn update_asset() {
         asset_token: HumanAddr::from("asset0000"),
         auction_discount: Some(Decimal::percent(30)),
         min_collateral_ratio: Some(Decimal::percent(50)),
+        mint_end: None,
     };
     let env = mock_env("owner0000", &[]);
     let res = handle(&mut deps, env, msg).unwrap_err();
@@ -285,6 +294,7 @@ fn update_asset() {
         asset_token: HumanAddr::from("asset0000"),
         auction_discount: Some(Decimal::percent(30)),
         min_collateral_ratio: Some(Decimal::percent(200)),
+        mint_end: None,
     };
     let env = mock_env("owner0001", &[]);
     let res = handle(&mut deps, env, msg).unwrap_err();
@@ -323,6 +333,7 @@ fn register_migration() {
         asset_token: HumanAddr::from("asset0000"),
         auction_discount: Decimal::percent(20),
         min_collateral_ratio: Decimal::percent(150),
+        mint_end: None,
     };
 
     let env = mock_env("owner0000", &[]);
@@ -411,6 +422,7 @@ fn open_position() {
         asset_token: HumanAddr::from("asset0000"),
         auction_discount: Decimal::percent(20),
         min_collateral_ratio: Decimal::percent(150),
+        mint_end: None,
     };
 
     let env = mock_env("owner0000", &[]);
@@ -420,6 +432,7 @@ fn open_position() {
         asset_token: HumanAddr::from("asset0001"),
         auction_discount: Decimal::percent(20),
         min_collateral_ratio: Decimal::percent(150),
+        mint_end: None,
     };
 
     let env = mock_env("owner0000", &[]);
@@ -764,6 +777,7 @@ fn migrated_asset() {
         asset_token: HumanAddr::from("asset0000"),
         auction_discount: Decimal::percent(20),
         min_collateral_ratio: Decimal::percent(150),
+        mint_end: None,
     };
     let env = mock_env("owner0000", &[]);
     let _res = handle(&mut deps, env, msg).unwrap();
@@ -772,6 +786,7 @@ fn migrated_asset() {
         asset_token: HumanAddr::from("asset0001"),
         auction_discount: Decimal::percent(20),
         min_collateral_ratio: Decimal::percent(150),
+        mint_end: None,
     };
     let env = mock_env("owner0000", &[]);
     let _res = handle(&mut deps, env, msg).unwrap();
@@ -1120,6 +1135,7 @@ fn burn_migrated_asset_position() {
         asset_token: HumanAddr::from("asset0000"),
         auction_discount: Decimal::percent(20),
         min_collateral_ratio: Decimal::percent(150),
+        mint_end: None,
     };
     let env = mock_env("owner0000", &[]);
     let _res = handle(&mut deps, env, msg).unwrap();
@@ -1128,6 +1144,7 @@ fn burn_migrated_asset_position() {
         asset_token: HumanAddr::from("asset0001"),
         auction_discount: Decimal::percent(20),
         min_collateral_ratio: Decimal::percent(150),
+        mint_end: None,
     };
     let env = mock_env("owner0000", &[]);
     let _res = handle(&mut deps, env, msg).unwrap();
@@ -1319,6 +1336,7 @@ fn deposit() {
         asset_token: HumanAddr::from("asset0000"),
         auction_discount: Decimal::percent(20),
         min_collateral_ratio: Decimal::percent(150),
+        mint_end: None,
     };
 
     let env = mock_env("owner0000", &[]);
@@ -1328,6 +1346,7 @@ fn deposit() {
         asset_token: HumanAddr::from("asset0001"),
         auction_discount: Decimal::percent(20),
         min_collateral_ratio: Decimal::percent(150),
+        mint_end: None,
     };
 
     let env = mock_env("owner0000", &[]);
@@ -1513,6 +1532,7 @@ fn mint() {
         asset_token: HumanAddr::from("asset0000"),
         auction_discount: Decimal::percent(20),
         min_collateral_ratio: Decimal::percent(150),
+        mint_end: None,
     };
 
     let env = mock_env("owner0000", &[]);
@@ -1522,6 +1542,7 @@ fn mint() {
         asset_token: HumanAddr::from("asset0001"),
         auction_discount: Decimal::percent(20),
         min_collateral_ratio: Decimal::percent(150),
+        mint_end: None,
     };
 
     let env = mock_env("owner0000", &[]);
@@ -1741,6 +1762,7 @@ fn burn() {
         asset_token: HumanAddr::from("asset0000"),
         auction_discount: Decimal::percent(20),
         min_collateral_ratio: Decimal::percent(150),
+        mint_end: None,
     };
 
     let env = mock_env("owner0000", &[]);
@@ -1750,6 +1772,7 @@ fn burn() {
         asset_token: HumanAddr::from("asset0001"),
         auction_discount: Decimal::percent(20),
         min_collateral_ratio: Decimal::percent(150),
+        mint_end: None,
     };
 
     let env = mock_env("owner0000", &[]);
@@ -1992,6 +2015,7 @@ fn withdraw() {
         asset_token: HumanAddr::from("asset0000"),
         auction_discount: Decimal::percent(20),
         min_collateral_ratio: Decimal::percent(150),
+        mint_end: None,
     };
 
     let env = mock_env("owner0000", &[]);
@@ -2001,6 +2025,7 @@ fn withdraw() {
         asset_token: HumanAddr::from("asset0001"),
         auction_discount: Decimal::percent(20),
         min_collateral_ratio: Decimal::percent(150),
+        mint_end: None,
     };
 
     let env = mock_env("owner0000", &[]);
@@ -2171,6 +2196,7 @@ fn auction() {
         asset_token: HumanAddr::from("asset0000"),
         auction_discount: Decimal::percent(20),
         min_collateral_ratio: Decimal::percent(130),
+        mint_end: None,
     };
 
     let env = mock_env("owner0000", &[]);
@@ -2180,6 +2206,7 @@ fn auction() {
         asset_token: HumanAddr::from("asset0001"),
         auction_discount: Decimal::percent(20),
         min_collateral_ratio: Decimal::percent(150),
+        mint_end: None,
     };
 
     let env = mock_env("owner0000", &[]);
@@ -2475,6 +2502,230 @@ fn auction() {
             log("protocol_fee", "10000asset0001"),
         ]
     );
+}
+
+#[test]
+fn pre_ipo_assets() {
+    let mut deps = mock_dependencies(20, &[]);
+    deps.querier.with_oracle_price(&[
+        (&"uusd".to_string(), &Decimal::one()),
+        (
+            &"preIPOAsset0000".to_string(),
+            &Decimal::from_ratio(10u128, 1u128),
+        ),
+    ]);
+
+    let base_denom = "uusd".to_string();
+
+    let msg = InitMsg {
+        owner: HumanAddr::from("owner0000"),
+        oracle: HumanAddr::from("oracle0000"),
+        collector: HumanAddr::from("collector0000"),
+        base_denom: base_denom.clone(),
+        token_code_id: TOKEN_CODE_ID,
+        protocol_fee_rate: Decimal::percent(1),
+    };
+    let creator_env = mock_env("addr0000", &[]);
+    let _res = init(&mut deps, creator_env.clone(), msg).unwrap();
+
+    // register preIPO asset with mint_end parameter (10 blocks)
+    let mint_end = creator_env.clone().block.height + 10u64;
+    let msg = HandleMsg::RegisterAsset {
+        asset_token: HumanAddr::from("preIPOAsset0000"),
+        auction_discount: Decimal::percent(20),
+        min_collateral_ratio: Decimal::percent(1000),
+        mint_end: Some(mint_end),
+    };
+    let env = mock_env("owner0000", &[]);
+    let _res = handle(&mut deps, env, msg).unwrap();
+
+    ///////////////////
+    // Minting phase
+    ///////////////////
+    let mut current_height = creator_env.block.height + 1;
+
+    // open position successfully at creation_height + 1
+    let msg = HandleMsg::OpenPosition {
+        collateral: Asset {
+            info: AssetInfo::NativeToken {
+                denom: "uusd".to_string(),
+            },
+            amount: Uint128(1000000000u128),
+        },
+        asset_info: AssetInfo::Token {
+            contract_addr: HumanAddr::from("preIPOAsset0000"),
+        },
+        collateral_ratio: Decimal::percent(10000),
+    };
+    let mut env = mock_env_with_block_time(
+        "addr0000",
+        &[Coin {
+            denom: "uusd".to_string(),
+            amount: Uint128(1000000000u128),
+        }],
+        1000u64,
+    );
+    env.block.height = current_height;
+    let _res = handle(&mut deps, env.clone(), msg).unwrap();
+
+    // mint successfully at creation_height + 1
+    let msg = HandleMsg::Mint {
+        position_idx: Uint128(1u128),
+        asset: Asset {
+            info: AssetInfo::Token {
+                contract_addr: HumanAddr::from("preIPOAsset0000"),
+            },
+            amount: Uint128(2000000u128),
+        },
+    };
+    let _res = handle(&mut deps, env.clone(), msg).unwrap();
+
+    // burn successfully at creation_height + 1
+    let msg = HandleMsg::Receive(Cw20ReceiveMsg {
+        sender: HumanAddr::from("addr0000"),
+        amount: Uint128::from(1000000u128),
+        msg: Some(
+            to_binary(&Cw20HookMsg::Burn {
+                position_idx: Uint128(1u128),
+            })
+            .unwrap(),
+        ),
+    });
+    let mut env = mock_env("preIPOAsset0000", &[]);
+    env.block.height = current_height;
+    let _res = handle(&mut deps, env, msg).unwrap();
+
+    ///////////////////
+    // Trading phase
+    ///////////////////
+    current_height = creator_env.block.height + 11; // > mint_end
+
+    // open position disabled
+    let msg = HandleMsg::OpenPosition {
+        collateral: Asset {
+            info: AssetInfo::NativeToken {
+                denom: "uusd".to_string(),
+            },
+            amount: Uint128(1000000000u128),
+        },
+        asset_info: AssetInfo::Token {
+            contract_addr: HumanAddr::from("preIPOAsset0000"),
+        },
+        collateral_ratio: Decimal::percent(10000),
+    };
+    let mut env = mock_env_with_block_time(
+        "addr0000",
+        &[Coin {
+            denom: "uusd".to_string(),
+            amount: Uint128(1000000000u128),
+        }],
+        1000u64,
+    );
+    env.block.height = current_height;
+    let res = handle(&mut deps, env.clone(), msg).unwrap_err();
+    assert_eq!(
+        res,
+        StdError::generic_err(format!(
+            "The minting period for this asset ended at height {}",
+            mint_end
+        ))
+    );
+
+    // mint disabled
+    let msg = HandleMsg::Mint {
+        position_idx: Uint128(1u128),
+        asset: Asset {
+            info: AssetInfo::Token {
+                contract_addr: HumanAddr::from("preIPOAsset0000"),
+            },
+            amount: Uint128(2000000u128),
+        },
+    };
+    let res = handle(&mut deps, env.clone(), msg).unwrap_err();
+    assert_eq!(
+        res,
+        StdError::generic_err(format!(
+            "The minting period for this asset ended at height {}",
+            mint_end
+        ))
+    );
+
+    // burn disabled
+    let msg = HandleMsg::Receive(Cw20ReceiveMsg {
+        sender: HumanAddr::from("addr0000"),
+        amount: Uint128::from(1000000u128),
+        msg: Some(
+            to_binary(&Cw20HookMsg::Burn {
+                position_idx: Uint128(1u128),
+            })
+            .unwrap(),
+        ),
+    });
+    let mut env = mock_env("preIPOAsset0000", &[]);
+    env.block.height = current_height;
+    let res = handle(&mut deps, env, msg).unwrap_err();
+    assert_eq!(
+        res,
+        StdError::generic_err(format!(
+            "Burning is disabled for assets with limitied minting time. Mint period ended at {}",
+            mint_end
+        ))
+    );
+
+    ///////////////////
+    // IPO/Migration
+    ///////////////////
+    current_height = creator_env.block.height + 20;
+
+    // register migration initiated by the feeder
+    let msg = HandleMsg::RegisterMigration {
+        asset_token: HumanAddr::from("preIPOAsset0000"),
+        end_price: Decimal::percent(50), // first IPO price
+    };
+    let mut env = mock_env("owner0000", &[]);
+    env.block.height = current_height;
+    let res = handle(&mut deps, env, msg).unwrap();
+    assert_eq!(
+        res.log,
+        vec![
+            log("action", "migrate_asset"),
+            log("asset_token", "preIPOAsset0000"),
+            log("end_price", "0.5"),
+        ]
+    );
+
+    let res = query(
+        &deps,
+        QueryMsg::AssetConfig {
+            asset_token: HumanAddr::from("preIPOAsset0000"),
+        },
+    )
+    .unwrap();
+    let asset_config_res: AssetConfigResponse = from_binary(&res).unwrap();
+    assert_eq!(
+        asset_config_res,
+        AssetConfigResponse {
+            token: HumanAddr::from("preIPOAsset0000"),
+            auction_discount: Decimal::percent(20),
+            min_collateral_ratio: Decimal::percent(100),
+            end_price: Some(Decimal::percent(50)),
+        }
+    );
+
+    // anyone can burn the preIPO asset at the first IPO price
+    let msg = HandleMsg::Receive(Cw20ReceiveMsg {
+        sender: HumanAddr::from("addr0001"),
+        amount: Uint128::from(133u128),
+        msg: Some(
+            to_binary(&Cw20HookMsg::Burn {
+                position_idx: Uint128(1u128),
+            })
+            .unwrap(),
+        ),
+    });
+    let mut env = mock_env_with_block_time("preIPOAsset0000", &[], 1000);
+    env.block.height = current_height + 1;
+    let _res = handle(&mut deps, env, msg).unwrap();
 }
 
 fn mock_env_with_block_time<U: Into<HumanAddr>>(sender: U, sent: &[Coin], time: u64) -> Env {

--- a/contracts/mirror_mint/src/testing.rs
+++ b/contracts/mirror_mint/src/testing.rs
@@ -237,7 +237,6 @@ fn update_asset() {
         asset_token: HumanAddr::from("asset0000"),
         auction_discount: Some(Decimal::percent(30)),
         min_collateral_ratio: Some(Decimal::percent(200)),
-        mint_end: None,
     };
     let env = mock_env("owner0000", &[]);
     let _res = handle(&mut deps, env, msg).unwrap();
@@ -264,7 +263,6 @@ fn update_asset() {
         asset_token: HumanAddr::from("asset0000"),
         auction_discount: Some(Decimal::percent(130)),
         min_collateral_ratio: Some(Decimal::percent(150)),
-        mint_end: None,
     };
     let env = mock_env("owner0000", &[]);
     let res = handle(&mut deps, env, msg).unwrap_err();
@@ -279,7 +277,6 @@ fn update_asset() {
         asset_token: HumanAddr::from("asset0000"),
         auction_discount: Some(Decimal::percent(30)),
         min_collateral_ratio: Some(Decimal::percent(50)),
-        mint_end: None,
     };
     let env = mock_env("owner0000", &[]);
     let res = handle(&mut deps, env, msg).unwrap_err();
@@ -294,7 +291,6 @@ fn update_asset() {
         asset_token: HumanAddr::from("asset0000"),
         auction_discount: Some(Decimal::percent(30)),
         min_collateral_ratio: Some(Decimal::percent(200)),
-        mint_end: None,
     };
     let env = mock_env("owner0001", &[]);
     let res = handle(&mut deps, env, msg).unwrap_err();

--- a/packages/mirror_protocol/src/factory.rs
+++ b/packages/mirror_protocol/src/factory.rs
@@ -75,7 +75,7 @@ pub enum HandleMsg {
         symbol: String,
         from_token: HumanAddr,
         end_price: Decimal,
-        new_min_cr: Option<Decimal>,
+        min_collateral_ratio: Option<Decimal>,
     },
 
     ///////////////////

--- a/packages/mirror_protocol/src/factory.rs
+++ b/packages/mirror_protocol/src/factory.rs
@@ -75,6 +75,7 @@ pub enum HandleMsg {
         symbol: String,
         from_token: HumanAddr,
         end_price: Decimal,
+        new_min_cr: Option<Decimal>,
     },
 
     ///////////////////
@@ -126,4 +127,6 @@ pub struct Params {
     pub min_collateral_ratio: Decimal,
     /// Distribution weight (default is 30, which is 1/10 of MIR distribution weight)
     pub weight: Option<u32>,
+    /// For pre-IPO assets, time period after asset creation in which minting is enabled
+    pub mint_period: Option<u64>,
 }

--- a/packages/mirror_protocol/src/mint.rs
+++ b/packages/mirror_protocol/src/mint.rs
@@ -39,7 +39,6 @@ pub enum HandleMsg {
         asset_token: HumanAddr,
         auction_discount: Option<Decimal>,
         min_collateral_ratio: Option<Decimal>,
-        mint_end: Option<u64>,
     },
     /// Generate asset token initialize msg and register required infos except token address
     RegisterAsset {

--- a/packages/mirror_protocol/src/mint.rs
+++ b/packages/mirror_protocol/src/mint.rs
@@ -39,12 +39,14 @@ pub enum HandleMsg {
         asset_token: HumanAddr,
         auction_discount: Option<Decimal>,
         min_collateral_ratio: Option<Decimal>,
+        mint_end: Option<u64>,
     },
     /// Generate asset token initialize msg and register required infos except token address
     RegisterAsset {
         asset_token: HumanAddr,
         auction_discount: Decimal,
         min_collateral_ratio: Decimal,
+        mint_end: Option<u64>,
     },
     RegisterMigration {
         asset_token: HumanAddr,


### PR DESCRIPTION
https://forum.mirror.finance/t/pre-ipo-mirrored-assets-v2/469

**Mechanism Overview:** 
1. PreIPO asset is whitelisted:
    - The whitelisted asset points to a custom feeder.
    - The CR of the proposal is setup to 1000% (or whatever high value)
    - The proposal contains an additional parameter (mint_period)
        - Mint period ends at (time_assset_is_whitelisted + mint_period) in blocks. We call this event “mint_end”
2. Whitelist passes, the pre-ipo asset enters “Minting phase”.
    - The asset behaves like a traditional asset
    - The custom feeder will feed a fixed price.
    - Anyone can mint (at the CR ratio specified in the proposal)
3. After current_height > mint_end (asset enters “Trading phase”)
    - Open position/minting is disabled
    - Burning is also disabled
    - Every other operation with this asset is the same
4. When IPO happens:
    - Feeder will execute a “migrate_asset” operation with:
        - postIPO asset name
        - postIPO symbol
        - preIPO asset address
        - preIPO end_price -> the feeder will set end_price with the first price after IPO
        - postIPO new_min_cr -> instead of copying the same CR from the preIPO, we specify a new one. e.g (1000% to 150%)
5. Ater postIPO is whitelisted:
    - Everyone that holds preIPO can burn against any position without permission
    - Instead of feeding a fixed price, feeder now feeds the real price to the postIPO asset
    - postIPO asset behaves as a normal asset.