### PR TITLE
feat/preIPO: minCR of postIPO asset voted when whitelisting preIPO asset

### DIFF
--- a/contracts/mirror_factory/schema/handle_msg.json
+++ b/contracts/mirror_factory/schema/handle_msg.json
@@ -280,16 +280,6 @@
             "from_token": {
               "$ref": "#/definitions/HumanAddr"
             },
-            "min_collateral_ratio": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/Decimal"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            },
             "name": {
               "type": "string"
             },
@@ -319,7 +309,7 @@
       "type": "string"
     },
     "Decimal": {
-      "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0 The greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
+      "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
       "type": "string"
     },
     "HumanAddr": {
@@ -345,6 +335,17 @@
           "allOf": [
             {
               "$ref": "#/definitions/Decimal"
+            }
+          ]
+        },
+        "min_collateral_ratio_after_migration": {
+          "description": "For pre-IPO assets, collateral ratio for the asset after migration",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Decimal"
+            },
+            {
+              "type": "null"
             }
           ]
         },

--- a/contracts/mirror_factory/src/mock_querier.rs
+++ b/contracts/mirror_factory/src/mock_querier.rs
@@ -86,11 +86,11 @@ pub(crate) fn address_pair_to_map(
 
 #[derive(Clone, Default)]
 pub struct MintQuerier {
-    configs: HashMap<HumanAddr, (Decimal, Decimal)>,
+    configs: HashMap<HumanAddr, (Decimal, Decimal, Option<Decimal>)>,
 }
 
 impl MintQuerier {
-    pub fn new(configs: &[(&HumanAddr, &(Decimal, Decimal))]) -> Self {
+    pub fn new(configs: &[(&HumanAddr, &(Decimal, Decimal, Option<Decimal>))]) -> Self {
         MintQuerier {
             configs: configs_to_map(configs),
         }
@@ -98,11 +98,14 @@ impl MintQuerier {
 }
 
 pub(crate) fn configs_to_map(
-    configs: &[(&HumanAddr, &(Decimal, Decimal))],
-) -> HashMap<HumanAddr, (Decimal, Decimal)> {
-    let mut configs_map: HashMap<HumanAddr, (Decimal, Decimal)> = HashMap::new();
-    for (contract_addr, pair) in configs.iter() {
-        configs_map.insert(HumanAddr::from(contract_addr), (pair.0, pair.1));
+    configs: &[(&HumanAddr, &(Decimal, Decimal, Option<Decimal>))],
+) -> HashMap<HumanAddr, (Decimal, Decimal, Option<Decimal>)> {
+    let mut configs_map: HashMap<HumanAddr, (Decimal, Decimal, Option<Decimal>)> = HashMap::new();
+    for (contract_addr, touple) in configs.iter() {
+        configs_map.insert(
+            HumanAddr::from(contract_addr),
+            (touple.0, touple.1, touple.2),
+        );
     }
     configs_map
 }
@@ -217,6 +220,7 @@ impl WasmMockQuerier {
                             token: api.canonical_address(&asset_token).unwrap(),
                             auction_discount: config.0,
                             min_collateral_ratio: config.1,
+                            min_collateral_ratio_after_migration: config.2,
                         })
                         .unwrap(),
                     ))
@@ -249,7 +253,10 @@ impl WasmMockQuerier {
         self.oracle_querier = OracleQuerier::new(feeders);
     }
 
-    pub fn with_mint_configs(&mut self, configs: &[(&HumanAddr, &(Decimal, Decimal))]) {
+    pub fn with_mint_configs(
+        &mut self,
+        configs: &[(&HumanAddr, &(Decimal, Decimal, Option<Decimal>))],
+    ) {
         self.mint_querier = MintQuerier::new(configs);
     }
 }

--- a/contracts/mirror_factory/src/querier.rs
+++ b/contracts/mirror_factory/src/querier.rs
@@ -42,13 +42,14 @@ pub struct MintAssetConfig {
     pub token: CanonicalAddr,
     pub auction_discount: Decimal,
     pub min_collateral_ratio: Decimal,
+    pub min_collateral_ratio_after_migration: Option<Decimal>,
 }
 
 pub fn load_mint_asset_config<S: Storage, A: Api, Q: Querier>(
     deps: &Extern<S, A, Q>,
     contract_addr: &HumanAddr,
     asset_token: &CanonicalAddr,
-) -> StdResult<(Decimal, Decimal)> {
+) -> StdResult<(Decimal, Decimal, Option<Decimal>)> {
     let res: StdResult<Binary> = deps.querier.query(&QueryRequest::Wasm(WasmQuery::Raw {
         contract_addr: HumanAddr::from(contract_addr),
         key: Binary::from(concat(
@@ -79,6 +80,7 @@ pub fn load_mint_asset_config<S: Storage, A: Api, Q: Querier>(
     Ok((
         asset_config.auction_discount,
         asset_config.min_collateral_ratio,
+        asset_config.min_collateral_ratio_after_migration,
     ))
 }
 

--- a/contracts/mirror_factory/src/testing.rs
+++ b/contracts/mirror_factory/src/testing.rs
@@ -287,6 +287,7 @@ fn test_whitelist() {
             min_collateral_ratio: Decimal::percent(150),
             weight: Some(100u32),
             mint_period: None,
+            min_collateral_ratio_after_migration: None,
         },
     };
     let env = mock_env("owner0000", &[]);
@@ -337,6 +338,7 @@ fn test_whitelist() {
             min_collateral_ratio: Decimal::percent(150),
             weight: Some(100u32),
             mint_period: None,
+            min_collateral_ratio_after_migration: None,
         }
     );
 
@@ -400,6 +402,7 @@ fn test_token_creation_hook() {
             min_collateral_ratio: Decimal::percent(150),
             weight: Some(100u32),
             mint_period: None,
+            min_collateral_ratio_after_migration: None,
         },
     };
     let env = mock_env("owner0000", &[]);
@@ -421,6 +424,7 @@ fn test_token_creation_hook() {
                     auction_discount: Decimal::percent(5),
                     min_collateral_ratio: Decimal::percent(150),
                     mint_end: None,
+                    min_collateral_ratio_after_migration: None,
                 })
                 .unwrap(),
             }),
@@ -528,6 +532,7 @@ fn test_token_creation_hook_without_weight() {
             min_collateral_ratio: Decimal::percent(150),
             weight: None,
             mint_period: None,
+            min_collateral_ratio_after_migration: None,
         },
     };
     let env = mock_env("owner0000", &[]);
@@ -549,6 +554,7 @@ fn test_token_creation_hook_without_weight() {
                     auction_discount: Decimal::percent(5),
                     min_collateral_ratio: Decimal::percent(150),
                     mint_end: None,
+                    min_collateral_ratio_after_migration: None,
                 })
                 .unwrap(),
             }),
@@ -645,6 +651,7 @@ fn test_terraswap_creation_hook() {
             min_collateral_ratio: Decimal::percent(150),
             weight: Some(100u32),
             mint_period: None,
+            min_collateral_ratio_after_migration: None,
         },
     };
     let env = mock_env("owner0000", &[]);
@@ -716,6 +723,7 @@ fn test_distribute() {
             min_collateral_ratio: Decimal::percent(150),
             weight: Some(100u32),
             mint_period: None,
+            min_collateral_ratio_after_migration: None,
         },
     };
     let env = mock_env("owner0000", &[]);
@@ -743,6 +751,7 @@ fn test_distribute() {
             min_collateral_ratio: Decimal::percent(150),
             weight: Some(100u32),
             mint_period: None,
+            min_collateral_ratio_after_migration: None,
         },
     };
     let env = mock_env("owner0000", &[]);
@@ -869,6 +878,7 @@ fn test_revocation() {
             min_collateral_ratio: Decimal::percent(150),
             weight: Some(100u32),
             mint_period: None,
+            min_collateral_ratio_after_migration: None,
         },
     };
     let env = mock_env("owner0000", &[]);
@@ -956,6 +966,7 @@ fn test_migration() {
             min_collateral_ratio: Decimal::percent(150),
             weight: Some(100u32),
             mint_period: None,
+            min_collateral_ratio_after_migration: None,
         },
     };
     let env = mock_env("owner0000", &[]);
@@ -976,7 +987,7 @@ fn test_migration() {
     // register queriers
     deps.querier.with_mint_configs(&[(
         &HumanAddr::from("asset0000"),
-        &(Decimal::percent(1), Decimal::percent(1)),
+        &(Decimal::percent(1), Decimal::percent(1), None),
     )]);
     deps.querier.with_oracle_feeders(&[(
         &HumanAddr::from("asset0000"),
@@ -989,7 +1000,6 @@ fn test_migration() {
         symbol: "mAPPL2".to_string(),
         from_token: HumanAddr::from("asset0000"),
         end_price: Decimal::from_ratio(2u128, 1u128),
-        min_collateral_ratio: None, // use previous cr
     };
     let env = mock_env("owner0000", &[]);
     let res = handle(&mut deps, env, msg.clone()).unwrap_err();
@@ -1073,6 +1083,7 @@ fn test_whitelist_pre_ipo_asset() {
             min_collateral_ratio: Decimal::percent(1000),
             weight: Some(100u32),
             mint_period: Some(10000u64),
+            min_collateral_ratio_after_migration: Some(Decimal::percent(150)),
         },
     };
     let env = mock_env("owner0000", &[]);
@@ -1114,6 +1125,7 @@ fn test_whitelist_pre_ipo_asset() {
             min_collateral_ratio: Decimal::percent(1000),
             weight: Some(100u32),
             mint_period: Some(10000u64),
+            min_collateral_ratio_after_migration: Some(Decimal::percent(150)),
         }
     );
 
@@ -1135,6 +1147,7 @@ fn test_whitelist_pre_ipo_asset() {
                     auction_discount: Decimal::percent(5),
                     min_collateral_ratio: Decimal::percent(1000),
                     mint_end: Some(env.block.height + 10000u64),
+                    min_collateral_ratio_after_migration: Some(Decimal::percent(150)),
                 })
                 .unwrap(),
             }),
@@ -1211,6 +1224,7 @@ fn test_migrate_pre_ipo_asset() {
             min_collateral_ratio: Decimal::percent(1000),
             weight: Some(100u32),
             mint_period: Some(1000u64),
+            min_collateral_ratio_after_migration: Some(Decimal::percent(150)),
         },
     };
     let env = mock_env("owner0000", &[]);
@@ -1231,7 +1245,11 @@ fn test_migrate_pre_ipo_asset() {
     // register queriers
     deps.querier.with_mint_configs(&[(
         &HumanAddr::from("preIPOasset0000"),
-        &(Decimal::percent(1), Decimal::percent(1)),
+        &(
+            Decimal::percent(5),
+            Decimal::percent(1000),
+            Some(Decimal::percent(150)),
+        ),
     )]);
     deps.querier.with_oracle_feeders(&[(
         &HumanAddr::from("preIPOasset0000"),
@@ -1244,7 +1262,6 @@ fn test_migrate_pre_ipo_asset() {
         symbol: "mPostIPO".to_string(),
         from_token: HumanAddr::from("preIPOasset0000"),
         end_price: Decimal::from_ratio(2u128, 1u128), // give first IPO price
-        min_collateral_ratio: Some(Decimal::percent(150)), // new mcr
     };
 
     let env = mock_env("feeder0000", &[]);
@@ -1280,6 +1297,60 @@ fn test_migrate_pre_ipo_asset() {
                             oracle_feeder: HumanAddr::from("feeder0000") // same feeder
                         })
                         .unwrap(),
+                    }),
+                })
+                .unwrap(),
+            })
+        ]
+    );
+
+    let msg = HandleMsg::TokenCreationHook {
+        oracle_feeder: HumanAddr::from("feeder0000"),
+    };
+    let env = mock_env("postIPOasset", &[]);
+    let res = handle(&mut deps, env.clone(), msg.clone()).unwrap();
+    assert_eq!(
+        res.messages,
+        vec![
+            CosmosMsg::Wasm(WasmMsg::Execute {
+                contract_addr: HumanAddr::from("mint0000"),
+                send: vec![],
+                msg: to_binary(&MintHandleMsg::RegisterAsset {
+                    asset_token: HumanAddr::from("postIPOasset"),
+                    auction_discount: Decimal::percent(5),
+                    min_collateral_ratio: Decimal::percent(150), // new collateral ratio
+                    mint_end: None,                              // reset to None
+                    min_collateral_ratio_after_migration: None,  // reset to None
+                })
+                .unwrap(),
+            }),
+            CosmosMsg::Wasm(WasmMsg::Execute {
+                contract_addr: HumanAddr::from("oracle0000"),
+                send: vec![],
+                msg: to_binary(&OracleHandleMsg::RegisterAsset {
+                    asset_token: HumanAddr::from("postIPOasset"),
+                    feeder: HumanAddr::from("feeder0000"),
+                })
+                .unwrap(),
+            }),
+            CosmosMsg::Wasm(WasmMsg::Execute {
+                contract_addr: HumanAddr::from("terraswapfactory"),
+                send: vec![],
+                msg: to_binary(&TerraswapFactoryHandleMsg::CreatePair {
+                    asset_infos: [
+                        AssetInfo::NativeToken {
+                            denom: BASE_DENOM.to_string(),
+                        },
+                        AssetInfo::Token {
+                            contract_addr: HumanAddr::from("postIPOasset"),
+                        },
+                    ],
+                    init_hook: Some(InitHook {
+                        msg: to_binary(&HandleMsg::TerraswapCreationHook {
+                            asset_token: HumanAddr::from("postIPOasset"),
+                        })
+                        .unwrap(),
+                        contract_addr: HumanAddr::from(MOCK_CONTRACT_ADDR),
                     }),
                 })
                 .unwrap(),

--- a/contracts/mirror_mint/schema/handle_msg.json
+++ b/contracts/mirror_mint/schema/handle_msg.json
@@ -139,6 +139,16 @@
             "min_collateral_ratio": {
               "$ref": "#/definitions/Decimal"
             },
+            "min_collateral_ratio_after_migration": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Decimal"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
             "mint_end": {
               "type": [
                 "integer",

--- a/contracts/mirror_mint/src/contract.rs
+++ b/contracts/mirror_mint/src/contract.rs
@@ -79,6 +79,7 @@ pub fn handle<S: Storage, A: Api, Q: Querier>(
             auction_discount,
             min_collateral_ratio,
             mint_end,
+            min_collateral_ratio_after_migration,
         } => try_register_asset(
             deps,
             env,
@@ -86,6 +87,7 @@ pub fn handle<S: Storage, A: Api, Q: Querier>(
             auction_discount,
             min_collateral_ratio,
             mint_end,
+            min_collateral_ratio_after_migration,
         ),
         HandleMsg::RegisterMigration {
             asset_token,
@@ -261,6 +263,7 @@ pub fn try_register_asset<S: Storage, A: Api, Q: Querier>(
     auction_discount: Decimal,
     min_collateral_ratio: Decimal,
     mint_end: Option<u64>,
+    min_collateral_ratio_after_migration: Option<Decimal>,
 ) -> StdResult<HandleResponse> {
     assert_auction_discount(auction_discount)?;
     assert_min_collateral_ratio(min_collateral_ratio)?;
@@ -287,6 +290,7 @@ pub fn try_register_asset<S: Storage, A: Api, Q: Querier>(
             min_collateral_ratio,
             end_price: None,
             mint_end,
+            min_collateral_ratio_after_migration,
         },
     )?;
 
@@ -1160,7 +1164,6 @@ pub fn migrate<S: Storage, A: Api, Q: Querier>(
     _env: Env,
     _msg: MigrateMsg,
 ) -> MigrateResult {
-
     // migrate all asset configurations to use new add mint_end parameter
     migrate_asset_configs(&mut deps.storage)?;
 

--- a/contracts/mirror_mint/src/contract.rs
+++ b/contracts/mirror_mint/src/contract.rs
@@ -999,6 +999,8 @@ pub fn query_asset_config<S: Storage, A: Api, Q: Querier>(
         auction_discount: asset_config.auction_discount,
         min_collateral_ratio: asset_config.min_collateral_ratio,
         end_price: asset_config.end_price,
+        mint_end: asset_config.mint_end,
+        min_collateral_ratio_after_migration: asset_config.min_collateral_ratio_after_migration,
     };
 
     Ok(resp)

--- a/contracts/mirror_mint/src/state.rs
+++ b/contracts/mirror_mint/src/state.rs
@@ -51,6 +51,7 @@ pub struct AssetConfig {
     pub min_collateral_ratio: Decimal,
     pub end_price: Option<Decimal>,
     pub mint_end: Option<u64>,
+    pub min_collateral_ratio_after_migration: Option<Decimal>,
 }
 
 pub fn store_asset_config<S: Storage>(

--- a/contracts/mirror_mint/src/testing.rs
+++ b/contracts/mirror_mint/src/testing.rs
@@ -142,6 +142,8 @@ fn register_asset() {
             auction_discount: Decimal::percent(20),
             min_collateral_ratio: Decimal::percent(150),
             end_price: None,
+            mint_end: None,
+            min_collateral_ratio_after_migration: None,
         }
     );
 
@@ -262,6 +264,8 @@ fn update_asset() {
             auction_discount: Decimal::percent(30),
             min_collateral_ratio: Decimal::percent(200),
             end_price: None,
+            mint_end: None,
+            min_collateral_ratio_after_migration: None,
         }
     );
 
@@ -394,6 +398,8 @@ fn register_migration() {
             auction_discount: Decimal::percent(20),
             min_collateral_ratio: Decimal::percent(100),
             end_price: Some(Decimal::percent(50)),
+            mint_end: None,
+            min_collateral_ratio_after_migration: None,
         }
     );
 }
@@ -2729,6 +2735,8 @@ fn pre_ipo_assets() {
             auction_discount: Decimal::percent(20),
             min_collateral_ratio: Decimal::percent(100),
             end_price: Some(Decimal::percent(50)),
+            mint_end: None,
+            min_collateral_ratio_after_migration: None,
         }
     );
 

--- a/contracts/mirror_mint/src/testing.rs
+++ b/contracts/mirror_mint/src/testing.rs
@@ -120,6 +120,7 @@ fn register_asset() {
         auction_discount: Decimal::percent(20),
         min_collateral_ratio: Decimal::percent(150),
         mint_end: None,
+        min_collateral_ratio_after_migration: None,
     };
 
     let env = mock_env("owner0000", &[]);
@@ -150,6 +151,7 @@ fn register_asset() {
         auction_discount: Decimal::percent(20),
         min_collateral_ratio: Decimal::percent(150),
         mint_end: None,
+        min_collateral_ratio_after_migration: None,
     };
     let env = mock_env("owner0000", &[]);
     let res = handle(&mut deps, env, msg).unwrap_err();
@@ -164,6 +166,7 @@ fn register_asset() {
         auction_discount: Decimal::percent(20),
         min_collateral_ratio: Decimal::percent(150),
         mint_end: None,
+        min_collateral_ratio_after_migration: None,
     };
     let env = mock_env("owner0001", &[]);
     let res = handle(&mut deps, env, msg).unwrap_err();
@@ -178,6 +181,7 @@ fn register_asset() {
         auction_discount: Decimal::percent(150),
         min_collateral_ratio: Decimal::percent(150),
         mint_end: None,
+        min_collateral_ratio_after_migration: None,
     };
     let env = mock_env("owner0000", &[]);
     let res = handle(&mut deps, env, msg).unwrap_err();
@@ -194,6 +198,7 @@ fn register_asset() {
         auction_discount: Decimal::percent(20),
         min_collateral_ratio: Decimal::percent(50),
         mint_end: None,
+        min_collateral_ratio_after_migration: None,
     };
     let env = mock_env("owner0000", &[]);
     let res = handle(&mut deps, env, msg).unwrap_err();
@@ -228,6 +233,7 @@ fn update_asset() {
         auction_discount: Decimal::percent(20),
         min_collateral_ratio: Decimal::percent(150),
         mint_end: None,
+        min_collateral_ratio_after_migration: None,
     };
 
     let env = mock_env("owner0000", &[]);
@@ -330,6 +336,7 @@ fn register_migration() {
         auction_discount: Decimal::percent(20),
         min_collateral_ratio: Decimal::percent(150),
         mint_end: None,
+        min_collateral_ratio_after_migration: None,
     };
 
     let env = mock_env("owner0000", &[]);
@@ -419,6 +426,7 @@ fn open_position() {
         auction_discount: Decimal::percent(20),
         min_collateral_ratio: Decimal::percent(150),
         mint_end: None,
+        min_collateral_ratio_after_migration: None,
     };
 
     let env = mock_env("owner0000", &[]);
@@ -429,6 +437,7 @@ fn open_position() {
         auction_discount: Decimal::percent(20),
         min_collateral_ratio: Decimal::percent(150),
         mint_end: None,
+        min_collateral_ratio_after_migration: None,
     };
 
     let env = mock_env("owner0000", &[]);
@@ -774,6 +783,7 @@ fn migrated_asset() {
         auction_discount: Decimal::percent(20),
         min_collateral_ratio: Decimal::percent(150),
         mint_end: None,
+        min_collateral_ratio_after_migration: None,
     };
     let env = mock_env("owner0000", &[]);
     let _res = handle(&mut deps, env, msg).unwrap();
@@ -783,6 +793,7 @@ fn migrated_asset() {
         auction_discount: Decimal::percent(20),
         min_collateral_ratio: Decimal::percent(150),
         mint_end: None,
+        min_collateral_ratio_after_migration: None,
     };
     let env = mock_env("owner0000", &[]);
     let _res = handle(&mut deps, env, msg).unwrap();
@@ -1132,6 +1143,7 @@ fn burn_migrated_asset_position() {
         auction_discount: Decimal::percent(20),
         min_collateral_ratio: Decimal::percent(150),
         mint_end: None,
+        min_collateral_ratio_after_migration: None,
     };
     let env = mock_env("owner0000", &[]);
     let _res = handle(&mut deps, env, msg).unwrap();
@@ -1141,6 +1153,7 @@ fn burn_migrated_asset_position() {
         auction_discount: Decimal::percent(20),
         min_collateral_ratio: Decimal::percent(150),
         mint_end: None,
+        min_collateral_ratio_after_migration: None,
     };
     let env = mock_env("owner0000", &[]);
     let _res = handle(&mut deps, env, msg).unwrap();
@@ -1333,6 +1346,7 @@ fn deposit() {
         auction_discount: Decimal::percent(20),
         min_collateral_ratio: Decimal::percent(150),
         mint_end: None,
+        min_collateral_ratio_after_migration: None,
     };
 
     let env = mock_env("owner0000", &[]);
@@ -1343,6 +1357,7 @@ fn deposit() {
         auction_discount: Decimal::percent(20),
         min_collateral_ratio: Decimal::percent(150),
         mint_end: None,
+        min_collateral_ratio_after_migration: None,
     };
 
     let env = mock_env("owner0000", &[]);
@@ -1529,6 +1544,7 @@ fn mint() {
         auction_discount: Decimal::percent(20),
         min_collateral_ratio: Decimal::percent(150),
         mint_end: None,
+        min_collateral_ratio_after_migration: None,
     };
 
     let env = mock_env("owner0000", &[]);
@@ -1539,6 +1555,7 @@ fn mint() {
         auction_discount: Decimal::percent(20),
         min_collateral_ratio: Decimal::percent(150),
         mint_end: None,
+        min_collateral_ratio_after_migration: None,
     };
 
     let env = mock_env("owner0000", &[]);
@@ -1759,6 +1776,7 @@ fn burn() {
         auction_discount: Decimal::percent(20),
         min_collateral_ratio: Decimal::percent(150),
         mint_end: None,
+        min_collateral_ratio_after_migration: None,
     };
 
     let env = mock_env("owner0000", &[]);
@@ -1769,6 +1787,7 @@ fn burn() {
         auction_discount: Decimal::percent(20),
         min_collateral_ratio: Decimal::percent(150),
         mint_end: None,
+        min_collateral_ratio_after_migration: None,
     };
 
     let env = mock_env("owner0000", &[]);
@@ -2012,6 +2031,7 @@ fn withdraw() {
         auction_discount: Decimal::percent(20),
         min_collateral_ratio: Decimal::percent(150),
         mint_end: None,
+        min_collateral_ratio_after_migration: None,
     };
 
     let env = mock_env("owner0000", &[]);
@@ -2022,6 +2042,7 @@ fn withdraw() {
         auction_discount: Decimal::percent(20),
         min_collateral_ratio: Decimal::percent(150),
         mint_end: None,
+        min_collateral_ratio_after_migration: None,
     };
 
     let env = mock_env("owner0000", &[]);
@@ -2193,6 +2214,7 @@ fn auction() {
         auction_discount: Decimal::percent(20),
         min_collateral_ratio: Decimal::percent(130),
         mint_end: None,
+        min_collateral_ratio_after_migration: None,
     };
 
     let env = mock_env("owner0000", &[]);
@@ -2203,6 +2225,7 @@ fn auction() {
         auction_discount: Decimal::percent(20),
         min_collateral_ratio: Decimal::percent(150),
         mint_end: None,
+        min_collateral_ratio_after_migration: None,
     };
 
     let env = mock_env("owner0000", &[]);
@@ -2531,6 +2554,7 @@ fn pre_ipo_assets() {
         auction_discount: Decimal::percent(20),
         min_collateral_ratio: Decimal::percent(1000),
         mint_end: Some(mint_end),
+        min_collateral_ratio_after_migration: None,
     };
     let env = mock_env("owner0000", &[]);
     let _res = handle(&mut deps, env, msg).unwrap();

--- a/packages/mirror_protocol/src/factory.rs
+++ b/packages/mirror_protocol/src/factory.rs
@@ -75,7 +75,6 @@ pub enum HandleMsg {
         symbol: String,
         from_token: HumanAddr,
         end_price: Decimal,
-        min_collateral_ratio: Option<Decimal>,
     },
 
     ///////////////////
@@ -129,4 +128,6 @@ pub struct Params {
     pub weight: Option<u32>,
     /// For pre-IPO assets, time period after asset creation in which minting is enabled
     pub mint_period: Option<u64>,
+    /// For pre-IPO assets, collateral ratio for the asset after migration
+    pub min_collateral_ratio_after_migration: Option<Decimal>,
 }

--- a/packages/mirror_protocol/src/mint.rs
+++ b/packages/mirror_protocol/src/mint.rs
@@ -46,6 +46,7 @@ pub enum HandleMsg {
         auction_discount: Decimal,
         min_collateral_ratio: Decimal,
         mint_end: Option<u64>,
+        min_collateral_ratio_after_migration: Option<Decimal>,
     },
     RegisterMigration {
         asset_token: HumanAddr,

--- a/packages/mirror_protocol/src/mint.rs
+++ b/packages/mirror_protocol/src/mint.rs
@@ -133,6 +133,8 @@ pub struct AssetConfigResponse {
     pub auction_discount: Decimal,
     pub min_collateral_ratio: Decimal,
     pub end_price: Option<Decimal>,
+    pub mint_end: Option<u64>,
+    pub min_collateral_ratio_after_migration: Option<Decimal>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]


### PR DESCRIPTION
Instead of allowing the feeder to submit a new MCR for migrated assets, allow voted proposals for preIPO assets to contain a min_cr_after_migration parameter.