### PR TITLE
[Feature] Voting rewards, abstain votes and factory revoke asset auth change

### DIFF
--- a/contracts/mirror_collector/src/contract.rs
+++ b/contracts/mirror_collector/src/contract.rs
@@ -7,6 +7,7 @@ use crate::state::{read_config, store_config, Config};
 
 use cw20::Cw20HandleMsg;
 use mirror_protocol::collector::{ConfigResponse, HandleMsg, InitMsg, MigrateMsg, QueryMsg};
+use mirror_protocol::gov::Cw20HookMsg::DepositReward;
 use terraswap::asset::{Asset, AssetInfo, PairInfo};
 use terraswap::pair::{Cw20HookMsg as TerraswapCw20HookMsg, HandleMsg as TerraswapHandleMsg};
 use terraswap::querier::{query_balance, query_pair_info, query_token_balance};
@@ -139,9 +140,10 @@ pub fn distribute<S: Storage, A: Api, Q: Querier>(
     Ok(HandleResponse {
         messages: vec![CosmosMsg::Wasm(WasmMsg::Execute {
             contract_addr: deps.api.human_address(&config.mirror_token)?,
-            msg: to_binary(&Cw20HandleMsg::Transfer {
-                recipient: deps.api.human_address(&config.distribution_contract)?,
+            msg: to_binary(&Cw20HandleMsg::Send {
+                contract: deps.api.human_address(&config.distribution_contract)?,
                 amount,
+                msg: Some(to_binary(&DepositReward {})?),
             })?,
             send: vec![],
         })],

--- a/contracts/mirror_collector/src/testing.rs
+++ b/contracts/mirror_collector/src/testing.rs
@@ -4,6 +4,7 @@ use cosmwasm_std::testing::{mock_env, MOCK_CONTRACT_ADDR};
 use cosmwasm_std::{to_binary, Coin, CosmosMsg, Decimal, HumanAddr, Uint128, WasmMsg};
 use cw20::Cw20HandleMsg;
 use mirror_protocol::collector::{ConfigResponse, HandleMsg, InitMsg};
+use mirror_protocol::gov::Cw20HookMsg::DepositReward;
 use terraswap::asset::{Asset, AssetInfo};
 use terraswap::pair::{Cw20HookMsg as TerraswapCw20HookMsg, HandleMsg as TerraswapHandleMsg};
 
@@ -151,9 +152,10 @@ fn test_send() {
         res.messages,
         vec![CosmosMsg::Wasm(WasmMsg::Execute {
             contract_addr: HumanAddr::from("mirror0000"),
-            msg: to_binary(&Cw20HandleMsg::Transfer {
-                recipient: HumanAddr::from("gov0000"),
+            msg: to_binary(&Cw20HandleMsg::Send {
+                contract: HumanAddr::from("gov0000"),
                 amount: Uint128(100u128),
+                msg: Some(to_binary(&DepositReward {}).unwrap()),
             })
             .unwrap(),
             send: vec![],

--- a/contracts/mirror_factory/src/contract.rs
+++ b/contracts/mirror_factory/src/contract.rs
@@ -534,8 +534,10 @@ pub fn revoke_asset<S: Storage, A: Api, Q: Querier>(
         &deps.api.human_address(&config.oracle_contract)?,
         &asset_token_raw,
     )?)?;
+    let sender_raw = deps.api.canonical_address(&env.message.sender)?;
 
-    if oracle_feeder != env.message.sender {
+    // revoke asset can only be executed by the feeder or the owner (gov contract)
+    if oracle_feeder != env.message.sender && config.owner != sender_raw {
         return Err(StdError::unauthorized());
     }
 

--- a/contracts/mirror_gov/schema/config_response.json
+++ b/contracts/mirror_gov/schema/config_response.json
@@ -10,6 +10,7 @@
     "proposal_deposit",
     "quorum",
     "threshold",
+    "voter_weight",
     "voting_period"
   ],
   "properties": {
@@ -36,6 +37,9 @@
       "$ref": "#/definitions/Decimal"
     },
     "threshold": {
+      "$ref": "#/definitions/Decimal"
+    },
+    "voter_weight": {
       "$ref": "#/definitions/Decimal"
     },
     "voting_period": {

--- a/contracts/mirror_gov/schema/cw20_hook_msg.json
+++ b/contracts/mirror_gov/schema/cw20_hook_msg.json
@@ -53,6 +53,18 @@
           }
         }
       }
+    },
+    {
+      "description": "Deposit rewards to be distributed among stakers and voters",
+      "type": "object",
+      "required": [
+        "deposit_reward"
+      ],
+      "properties": {
+        "deposit_reward": {
+          "type": "object"
+        }
+      }
     }
   ],
   "definitions": {

--- a/contracts/mirror_gov/schema/handle_msg.json
+++ b/contracts/mirror_gov/schema/handle_msg.json
@@ -78,6 +78,16 @@
                 }
               ]
             },
+            "voter_weight": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Decimal"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
             "voting_period": {
               "type": [
                 "integer",
@@ -145,6 +155,17 @@
     {
       "type": "object",
       "required": [
+        "withdraw_voting_rewards"
+      ],
+      "properties": {
+        "withdraw_voting_rewards": {
+          "type": "object"
+        }
+      }
+    },
+    {
+      "type": "object",
+      "required": [
         "end_poll"
       ],
       "properties": {
@@ -204,27 +225,6 @@
           }
         }
       }
-    },
-    {
-      "type": "object",
-      "required": [
-        "undo_expire_poll"
-      ],
-      "properties": {
-        "undo_expire_poll": {
-          "type": "object",
-          "required": [
-            "poll_id"
-          ],
-          "properties": {
-            "poll_id": {
-              "type": "integer",
-              "format": "uint64",
-              "minimum": 0.0
-            }
-          }
-        }
-      }
     }
   ],
   "definitions": {
@@ -259,7 +259,7 @@
       }
     },
     "Decimal": {
-      "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0 The greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
+      "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
       "type": "string"
     },
     "HumanAddr": {
@@ -272,7 +272,8 @@
       "type": "string",
       "enum": [
         "yes",
-        "no"
+        "no",
+        "abstain"
       ]
     }
   }

--- a/contracts/mirror_gov/schema/init_msg.json
+++ b/contracts/mirror_gov/schema/init_msg.json
@@ -9,6 +9,7 @@
     "proposal_deposit",
     "quorum",
     "threshold",
+    "voter_weight",
     "voting_period"
   ],
   "properties": {
@@ -32,6 +33,9 @@
       "$ref": "#/definitions/Decimal"
     },
     "threshold": {
+      "$ref": "#/definitions/Decimal"
+    },
+    "voter_weight": {
       "$ref": "#/definitions/Decimal"
     },
     "voting_period": {

--- a/contracts/mirror_gov/schema/migrate_msg.json
+++ b/contracts/mirror_gov/schema/migrate_msg.json
@@ -1,6 +1,16 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "MigrateMsg",
-  "description": "We currently take no arguments for migrations",
-  "type": "object"
+  "description": "Migrates the contract state, currently taking a state version argument",
+  "type": "object",
+  "required": [
+    "version"
+  ],
+  "properties": {
+    "version": {
+      "type": "integer",
+      "format": "uint64",
+      "minimum": 0.0
+    }
+  }
 }

--- a/contracts/mirror_gov/schema/poll_response.json
+++ b/contracts/mirror_gov/schema/poll_response.json
@@ -3,6 +3,7 @@
   "title": "PollResponse",
   "type": "object",
   "required": [
+    "abstain_votes",
     "creator",
     "deposit_amount",
     "description",
@@ -11,9 +12,13 @@
     "no_votes",
     "status",
     "title",
+    "voters_reward",
     "yes_votes"
   ],
   "properties": {
+    "abstain_votes": {
+      "$ref": "#/definitions/Uint128"
+    },
     "creator": {
       "$ref": "#/definitions/HumanAddr"
     },
@@ -67,6 +72,9 @@
           "type": "null"
         }
       ]
+    },
+    "voters_reward": {
+      "$ref": "#/definitions/Uint128"
     },
     "yes_votes": {
       "$ref": "#/definitions/Uint128"

--- a/contracts/mirror_gov/schema/staker_response.json
+++ b/contracts/mirror_gov/schema/staker_response.json
@@ -5,6 +5,7 @@
   "required": [
     "balance",
     "locked_balance",
+    "pending_voting_rewards",
     "share"
   ],
   "properties": {
@@ -29,6 +30,9 @@
         "minItems": 2
       }
     },
+    "pending_voting_rewards": {
+      "$ref": "#/definitions/Uint128"
+    },
     "share": {
       "$ref": "#/definitions/Uint128"
     }
@@ -41,7 +45,8 @@
       "type": "string",
       "enum": [
         "yes",
-        "no"
+        "no",
+        "abstain"
       ]
     },
     "VoterInfo": {

--- a/contracts/mirror_gov/src/contract.rs
+++ b/contracts/mirror_gov/src/contract.rs
@@ -706,7 +706,7 @@ fn query_polls<S: Storage, A: Api, Q: Querier>(
     limit: Option<u32>,
     order_by: Option<OrderBy>,
 ) -> StdResult<PollsResponse> {
-    let polls = read_polls(&deps.storage, filter, start_after, limit, order_by)?;
+    let polls = read_polls(&deps.storage, filter, start_after, limit, order_by, None)?;
     let poll_responses: StdResult<Vec<PollResponse>> = polls
         .iter()
         .map(|poll| {

--- a/contracts/mirror_gov/src/contract.rs
+++ b/contracts/mirror_gov/src/contract.rs
@@ -1,5 +1,8 @@
 use crate::querier::load_token_balance;
-use crate::staking::{query_staker, stake_voting_tokens, withdraw_voting_tokens};
+use crate::staking::{
+    deposit_reward, query_staker, stake_voting_tokens, withdraw_voting_rewards,
+    withdraw_voting_tokens,
+};
 use crate::state::{
     bank_read, bank_store, config_read, config_store, poll_indexer_store, poll_read, poll_store,
     poll_voter_read, poll_voter_store, read_poll_voters, read_polls, state_read, state_store,
@@ -43,6 +46,7 @@ pub fn init<S: Storage, A: Api, Q: Querier>(
         effective_delay: msg.effective_delay,
         expiration_period: msg.expiration_period,
         proposal_deposit: msg.proposal_deposit,
+        voter_weight: msg.voter_weight,
     };
 
     let state = State {
@@ -50,6 +54,7 @@ pub fn init<S: Storage, A: Api, Q: Querier>(
         poll_count: 0,
         total_share: Uint128::zero(),
         total_deposit: Uint128::zero(),
+        pending_voting_rewards: Uint128::zero(),
     };
 
     config_store(&mut deps.storage).save(&config)?;
@@ -73,6 +78,7 @@ pub fn handle<S: Storage, A: Api, Q: Querier>(
             effective_delay,
             expiration_period,
             proposal_deposit,
+            voter_weight,
         } => update_config(
             deps,
             env,
@@ -83,8 +89,10 @@ pub fn handle<S: Storage, A: Api, Q: Querier>(
             effective_delay,
             expiration_period,
             proposal_deposit,
+            voter_weight,
         ),
         HandleMsg::WithdrawVotingTokens { amount } => withdraw_voting_tokens(deps, env, amount),
+        HandleMsg::WithdrawVotingRewards {} => withdraw_voting_rewards(deps, env),
         HandleMsg::CastVote {
             poll_id,
             vote,
@@ -127,6 +135,13 @@ pub fn receive_cw20<S: Storage, A: Api, Q: Querier>(
                 link,
                 execute_msg,
             ),
+            Cw20HookMsg::DepositReward {} => {
+                // only reward token contract can execute this message
+                if config.mirror_token != deps.api.canonical_address(&env.message.sender)? {
+                    return Err(StdError::unauthorized());
+                }
+                deposit_reward(deps, env, cw20_msg.sender, cw20_msg.amount)
+            }
         }
     } else {
         Err(StdError::generic_err("data should be given"))
@@ -144,6 +159,7 @@ pub fn update_config<S: Storage, A: Api, Q: Querier>(
     effective_delay: Option<u64>,
     expiration_period: Option<u64>,
     proposal_deposit: Option<Uint128>,
+    voter_weight: Option<Decimal>,
 ) -> HandleResult {
     let api = deps.api;
     config_store(&mut deps.storage).update(|mut config| {
@@ -177,6 +193,10 @@ pub fn update_config<S: Storage, A: Api, Q: Querier>(
 
         if let Some(proposal_deposit) = proposal_deposit {
             config.proposal_deposit = proposal_deposit;
+        }
+
+        if let Some(voter_weight) = voter_weight {
+            config.voter_weight = voter_weight;
         }
 
         Ok(config)
@@ -288,6 +308,7 @@ pub fn create_poll<S: Storage, A: Api, Q: Querier>(
         status: PollStatus::InProgress,
         yes_votes: Uint128::zero(),
         no_votes: Uint128::zero(),
+        abstain_votes: Uint128::zero(),
         end_height: env.block.height + config.voting_period,
         title,
         description,
@@ -295,6 +316,7 @@ pub fn create_poll<S: Storage, A: Api, Q: Querier>(
         execute_data,
         deposit_amount,
         total_balance_at_end_poll: None,
+        voters_reward: Uint128::zero(),
     };
 
     poll_store(&mut deps.storage).save(&poll_id.to_be_bytes(), &new_poll)?;
@@ -339,8 +361,9 @@ pub fn end_poll<S: Storage, A: Api, Q: Querier>(
 
     let no = a_poll.no_votes.u128();
     let yes = a_poll.yes_votes.u128();
+    let abstain = a_poll.abstain_votes.u128();
 
-    let tallied_weight = yes + no;
+    let tallied_weight = yes + no + abstain;
 
     let mut poll_status = PollStatus::Rejected;
     let mut rejected_reason = "";
@@ -370,7 +393,7 @@ pub fn end_poll<S: Storage, A: Api, Q: Querier>(
         // period need to have participated in the vote.
         rejected_reason = "Quorum not reached";
     } else {
-        if Decimal::from_ratio(yes, tallied_weight) > config.threshold {
+        if Decimal::from_ratio(yes, yes + no) > config.threshold {
             //Threshold: More than 50% of the tokens that participated in the vote
             // (after excluding “Abstain” votes) need to have voted in favor of the proposal (“Yes”).
             poll_status = PollStatus::Passed;
@@ -553,10 +576,10 @@ pub fn cast_vote<S: Storage, A: Api, Q: Querier>(
     }
 
     // update tally info
-    if VoteOption::Yes == vote {
-        a_poll.yes_votes += amount;
-    } else {
-        a_poll.no_votes += amount;
+    match vote {
+        VoteOption::Yes => a_poll.yes_votes += amount,
+        VoteOption::No => a_poll.no_votes += amount,
+        VoteOption::Abstain => a_poll.abstain_votes += amount,
     }
 
     let vote_info = VoterInfo {
@@ -627,6 +650,7 @@ fn query_config<S: Storage, A: Api, Q: Querier>(
         effective_delay: config.effective_delay,
         expiration_period: config.expiration_period,
         proposal_deposit: config.proposal_deposit,
+        voter_weight: config.voter_weight,
     })
 }
 
@@ -636,6 +660,7 @@ fn query_state<S: Storage, A: Api, Q: Querier>(deps: &Extern<S, A, Q>) -> StdRes
         poll_count: state.poll_count,
         total_share: state.total_share,
         total_deposit: state.total_deposit,
+        pending_voting_rewards: state.pending_voting_rewards,
     })
 }
 
@@ -668,7 +693,9 @@ fn query_poll<S: Storage, A: Api, Q: Querier>(
         },
         yes_votes: poll.yes_votes,
         no_votes: poll.no_votes,
+        abstain_votes: poll.abstain_votes,
         total_balance_at_end_poll: poll.total_balance_at_end_poll,
+        voters_reward: poll.voters_reward,
     })
 }
 
@@ -702,7 +729,9 @@ fn query_polls<S: Storage, A: Api, Q: Querier>(
                 },
                 yes_votes: poll.yes_votes,
                 no_votes: poll.no_votes,
+                abstain_votes: poll.abstain_votes,
                 total_balance_at_end_poll: poll.total_balance_at_end_poll,
+                voters_reward: poll.voters_reward,
             })
         })
         .collect();

--- a/contracts/mirror_gov/src/contract.rs
+++ b/contracts/mirror_gov/src/contract.rs
@@ -784,17 +784,23 @@ fn query_voters<S: Storage, A: Api, Q: Querier>(
     })
 }
 
-use crate::migrate::migrate_poll_indexer;
+use crate::migrate::{migrate_config, migrate_poll_indexer, migrate_polls, migrate_state};
 pub fn migrate<S: Storage, A: Api, Q: Querier>(
     deps: &mut Extern<S, A, Q>,
     _env: Env,
     _msg: MigrateMsg,
 ) -> MigrateResult {
+    // comment for testnet
     migrate_poll_indexer(&mut deps.storage, &PollStatus::InProgress)?;
     migrate_poll_indexer(&mut deps.storage, &PollStatus::Passed)?;
     migrate_poll_indexer(&mut deps.storage, &PollStatus::Rejected)?;
     migrate_poll_indexer(&mut deps.storage, &PollStatus::Executed)?;
     migrate_poll_indexer(&mut deps.storage, &PollStatus::Expired)?;
+
+    // migrations for voting rewards and abstain votes
+    migrate_config(&mut deps.storage, Decimal::percent(50u64))?; // 50% rewards for voters
+    migrate_state(&mut deps.storage)?;
+    migrate_polls(&mut deps.storage)?;
 
     Ok(MigrateResponse::default())
 }

--- a/contracts/mirror_gov/src/migrate.rs
+++ b/contracts/mirror_gov/src/migrate.rs
@@ -1,12 +1,22 @@
-use cosmwasm_std::{Order, StdError, StdResult, Storage};
-use cosmwasm_storage::Bucket;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
 
+use cosmwasm_std::{CanonicalAddr, Decimal, Order, StdError, StdResult, Storage, Uint128};
+use cosmwasm_storage::{singleton, singleton_read, Bucket, ReadonlySingleton, Singleton};
+
+use crate::state::{Config, ExecuteData, Poll, State};
 use mirror_protocol::gov::PollStatus;
 
 use std::convert::TryInto;
 
+#[cfg(test)]
+use crate::state::{config_read, poll_read, state_read};
+
 static PREFIX_POLL_INDEXER_OLD: &[u8] = b"poll_voter";
 static PREFIX_POLL_INDEXER: &[u8] = b"poll_indexer";
+static KEY_CONFIG: &[u8] = b"config";
+static KEY_STATE: &[u8] = b"state";
+static PREFIX_POLL: &[u8] = b"poll";
 
 #[cfg(test)]
 pub fn poll_indexer_old_store<'a, S: Storage>(
@@ -17,6 +27,54 @@ pub fn poll_indexer_old_store<'a, S: Storage>(
         &[PREFIX_POLL_INDEXER_OLD, status.to_string().as_bytes()],
         storage,
     )
+}
+#[cfg(test)]
+pub fn polls_old_store<'a, S: Storage>(storage: &'a mut S) -> Bucket<'a, S, LegacyPoll> {
+    Bucket::new(PREFIX_POLL, storage)
+}
+#[cfg(test)]
+pub fn state_old_store<'a, S: Storage>(storage: &'a mut S) -> Singleton<'a, S, LegacyState> {
+    Singleton::new(storage, KEY_STATE)
+}
+#[cfg(test)]
+pub fn config_old_store<'a, S: Storage>(storage: &'a mut S) -> Singleton<'a, S, LegacyConfig> {
+    Singleton::new(storage, KEY_CONFIG)
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct LegacyConfig {
+    pub owner: CanonicalAddr,
+    pub mirror_token: CanonicalAddr,
+    pub quorum: Decimal,
+    pub threshold: Decimal,
+    pub voting_period: u64,
+    pub effective_delay: u64,
+    pub expiration_period: u64,
+    pub proposal_deposit: Uint128,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct LegacyState {
+    pub contract_addr: CanonicalAddr,
+    pub poll_count: u64,
+    pub total_share: Uint128,
+    pub total_deposit: Uint128,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct LegacyPoll {
+    pub id: u64,
+    pub creator: CanonicalAddr,
+    pub status: PollStatus,
+    pub yes_votes: Uint128,
+    pub no_votes: Uint128,
+    pub end_height: u64,
+    pub title: String,
+    pub description: String,
+    pub link: Option<String>,
+    pub execute_data: Option<ExecuteData>,
+    pub deposit_amount: Uint128,
+    pub total_balance_at_end_poll: Option<Uint128>,
 }
 
 pub fn migrate_poll_indexer<S: Storage>(storage: &mut S, status: &PollStatus) -> StdResult<()> {
@@ -56,6 +114,78 @@ fn bytes_to_u64(data: &[u8]) -> StdResult<u64> {
     }
 }
 
+pub fn migrate_config<S: Storage>(storage: &mut S, voter_weight: Decimal) -> StdResult<()> {
+    let legacty_store: ReadonlySingleton<S, LegacyConfig> = singleton_read(storage, KEY_CONFIG);
+    let legacy_config: LegacyConfig = legacty_store.load()?;
+    let config = Config {
+        mirror_token: legacy_config.mirror_token,
+        owner: legacy_config.owner,
+        quorum: legacy_config.quorum,
+        threshold: legacy_config.threshold,
+        voting_period: legacy_config.voting_period,
+        effective_delay: legacy_config.effective_delay,
+        expiration_period: legacy_config.expiration_period,
+        proposal_deposit: legacy_config.proposal_deposit,
+        voter_weight: voter_weight,
+    };
+    let mut store: Singleton<S, Config> = singleton(storage, KEY_CONFIG);
+    store.save(&config)?;
+    Ok(())
+}
+
+pub fn migrate_state<S: Storage>(storage: &mut S) -> StdResult<()> {
+    let legacy_store: ReadonlySingleton<S, LegacyState> = singleton_read(storage, KEY_STATE);
+    let legacy_state: LegacyState = legacy_store.load()?;
+    let state = State {
+        contract_addr: legacy_state.contract_addr,
+        poll_count: legacy_state.poll_count,
+        total_share: legacy_state.total_share,
+        total_deposit: legacy_state.total_deposit,
+        pending_voting_rewards: Uint128::zero(),
+    };
+    let mut store: Singleton<S, State> = singleton(storage, KEY_STATE);
+    store.save(&state)?;
+    Ok(())
+}
+
+pub fn migrate_polls<S: Storage>(storage: &mut S) -> StdResult<()> {
+    let mut legacy_polls_bucket: Bucket<S, LegacyPoll> = Bucket::new(PREFIX_POLL, storage);
+
+    let mut read_polls: Vec<(u64, LegacyPoll)> = vec![];
+    for item in legacy_polls_bucket.range(None, None, Order::Ascending) {
+        let (k, p) = item?;
+        read_polls.push((bytes_to_u64(&k)?, p));
+    }
+
+    for (id, _) in read_polls.clone().into_iter() {
+        legacy_polls_bucket.remove(&id.to_be_bytes());
+    }
+
+    let mut new_polls_bucket: Bucket<S, Poll> = Bucket::new(PREFIX_POLL, storage);
+
+    for (id, poll) in read_polls.into_iter() {
+        let new_poll = &Poll {
+            id: poll.id,
+            creator: poll.creator,
+            status: poll.status,
+            yes_votes: poll.yes_votes,
+            no_votes: poll.no_votes,
+            abstain_votes: Uint128::zero(),
+            end_height: poll.end_height,
+            title: poll.title,
+            description: poll.description,
+            link: poll.link,
+            execute_data: poll.execute_data,
+            deposit_amount: poll.deposit_amount,
+            total_balance_at_end_poll: poll.total_balance_at_end_poll,
+            voters_reward: Uint128::zero(),
+        };
+        new_polls_bucket.save(&id.to_be_bytes(), new_poll)?;
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod migrate_tests {
     use super::*;
@@ -90,5 +220,159 @@ mod migrate_tests {
                 .unwrap(),
             true
         );
+    }
+
+    #[test]
+    fn test_polls_migration() {
+        let mut deps = mock_dependencies(20, &[]);
+        polls_old_store(&mut deps.storage)
+            .save(
+                &1u64.to_be_bytes(),
+                &LegacyPoll {
+                    id: 1u64,
+                    creator: CanonicalAddr::default(),
+                    status: PollStatus::InProgress,
+                    yes_votes: Uint128::zero(),
+                    no_votes: Uint128::zero(),
+                    end_height: 1u64,
+                    title: "test".to_string(),
+                    description: "description".to_string(),
+                    link: None,
+                    execute_data: None,
+                    deposit_amount: Uint128::zero(),
+                    total_balance_at_end_poll: None,
+                },
+            )
+            .unwrap();
+        polls_old_store(&mut deps.storage)
+            .save(
+                &2u64.to_be_bytes(),
+                &LegacyPoll {
+                    id: 2u64,
+                    creator: CanonicalAddr::default(),
+                    status: PollStatus::InProgress,
+                    yes_votes: Uint128::zero(),
+                    no_votes: Uint128::zero(),
+                    end_height: 1u64,
+                    title: "test2".to_string(),
+                    description: "description".to_string(),
+                    link: None,
+                    execute_data: None,
+                    deposit_amount: Uint128::zero(),
+                    total_balance_at_end_poll: None,
+                },
+            )
+            .unwrap();
+
+        migrate_polls(&mut deps.storage).unwrap();
+
+        let poll1: Poll = poll_read(&mut deps.storage)
+            .load(&1u64.to_be_bytes())
+            .unwrap();
+        assert_eq!(
+            poll1,
+            Poll {
+                id: 1u64,
+                creator: CanonicalAddr::default(),
+                status: PollStatus::InProgress,
+                yes_votes: Uint128::zero(),
+                no_votes: Uint128::zero(),
+                end_height: 1u64,
+                title: "test".to_string(),
+                description: "description".to_string(),
+                link: None,
+                execute_data: None,
+                deposit_amount: Uint128::zero(),
+                total_balance_at_end_poll: None,
+                abstain_votes: Uint128::zero(),
+                voters_reward: Uint128::zero(),
+            }
+        );
+        let poll2: Poll = poll_read(&mut deps.storage)
+            .load(&2u64.to_be_bytes())
+            .unwrap();
+        assert_eq!(
+            poll2,
+            Poll {
+                id: 2u64,
+                creator: CanonicalAddr::default(),
+                status: PollStatus::InProgress,
+                yes_votes: Uint128::zero(),
+                no_votes: Uint128::zero(),
+                end_height: 1u64,
+                title: "test2".to_string(),
+                description: "description".to_string(),
+                link: None,
+                execute_data: None,
+                deposit_amount: Uint128::zero(),
+                total_balance_at_end_poll: None,
+                abstain_votes: Uint128::zero(),
+                voters_reward: Uint128::zero(),
+            }
+        );
+    }
+
+    #[test]
+    fn test_config_migration() {
+        let mut deps = mock_dependencies(20, &[]);
+        let mut legacy_config_store = config_old_store(&mut deps.storage);
+        legacy_config_store
+            .save(&LegacyConfig {
+                mirror_token: CanonicalAddr::default(),
+                owner: CanonicalAddr::default(),
+                quorum: Decimal::one(),
+                threshold: Decimal::one(),
+                voting_period: 100u64,
+                effective_delay: 100u64,
+                expiration_period: 100u64,
+                proposal_deposit: Uint128(100000u128),
+            })
+            .unwrap();
+
+        migrate_config(&mut deps.storage, Decimal::percent(50u64)).unwrap();
+
+        let config: Config = config_read(&deps.storage).load().unwrap();
+        assert_eq!(
+            config,
+            Config {
+                mirror_token: CanonicalAddr::default(),
+                owner: CanonicalAddr::default(),
+                quorum: Decimal::one(),
+                threshold: Decimal::one(),
+                voting_period: 100u64,
+                effective_delay: 100u64,
+                expiration_period: 100u64,
+                proposal_deposit: Uint128(100000u128),
+                voter_weight: Decimal::percent(50u64),
+            }
+        )
+    }
+
+    #[test]
+    fn test_state_migration() {
+        let mut deps = mock_dependencies(20, &[]);
+        let mut legacy_state_store = state_old_store(&mut deps.storage);
+        legacy_state_store
+            .save(&LegacyState {
+                contract_addr: CanonicalAddr::default(),
+                poll_count: 0,
+                total_share: Uint128::zero(),
+                total_deposit: Uint128::zero(),
+            })
+            .unwrap();
+
+        migrate_state(&mut deps.storage).unwrap();
+
+        let state: State = state_read(&deps.storage).load().unwrap();
+        assert_eq!(
+            state,
+            State {
+                contract_addr: CanonicalAddr::default(),
+                poll_count: 0,
+                total_share: Uint128::zero(),
+                total_deposit: Uint128::zero(),
+                pending_voting_rewards: Uint128::zero(),
+            }
+        )
     }
 }

--- a/contracts/mirror_gov/src/staking.rs
+++ b/contracts/mirror_gov/src/staking.rs
@@ -1,7 +1,7 @@
 use crate::querier::load_token_balance;
 use crate::state::{
-    bank_read, bank_store, config_read, config_store, poll_read, poll_voter_store, state_read,
-    state_store, Config, Poll, State, TokenManager,
+    bank_read, bank_store, config_read, config_store, poll_read, poll_store, poll_voter_read,
+    poll_voter_store, read_polls, state_read, state_store, Config, Poll, State, TokenManager,
 };
 
 use cosmwasm_std::{
@@ -9,7 +9,7 @@ use cosmwasm_std::{
     HumanAddr, Querier, StdError, StdResult, Storage, Uint128, WasmMsg,
 };
 use cw20::Cw20HandleMsg;
-use mirror_protocol::gov::{PollStatus, StakerResponse};
+use mirror_protocol::gov::{PollStatus, StakerResponse, VoterInfo};
 
 pub fn stake_voting_tokens<S: Storage, A: Api, Q: Querier>(
     deps: &mut Extern<S, A, Q>,
@@ -74,25 +74,26 @@ pub fn withdraw_voting_tokens<S: Storage, A: Api, Q: Querier>(
 
         // Load total share & total balance except proposal deposit amount
         let total_share = state.total_share.u128();
+        let total_locked_balance = state.total_deposit + state.pending_voting_rewards;
         let total_balance = (load_token_balance(
             &deps,
             &deps.api.human_address(&config.mirror_token)?,
             &state.contract_addr,
-        )? - state.total_deposit)?
+        )? - total_locked_balance)?
             .u128();
 
-        let locked_balance = compute_locked_balance(deps, &mut token_manager, &sender_address_raw)?;
-        let locked_share = locked_balance * total_share / total_balance;
+        let user_locked_balance = compute_locked_balance(deps, &mut token_manager)?;
+        let user_locked_share = user_locked_balance * total_share / total_balance;
         let user_share = token_manager.share.u128();
 
         let withdraw_share = amount
             .map(|v| std::cmp::max(v.multiply_ratio(total_share, total_balance).u128(), 1u128))
-            .unwrap_or_else(|| user_share - locked_share);
+            .unwrap_or_else(|| user_share - user_locked_share);
         let withdraw_amount = amount
             .map(|v| v.u128())
             .unwrap_or_else(|| withdraw_share * total_balance / total_share);
 
-        if locked_share + withdraw_share > user_share {
+        if user_locked_share + withdraw_share > user_share {
             Err(StdError::generic_err(
                 "User is trying to withdraw too many tokens.",
             ))
@@ -118,23 +119,16 @@ pub fn withdraw_voting_tokens<S: Storage, A: Api, Q: Querier>(
     }
 }
 
-// removes not in-progress poll voter info & unlock tokens
-// and returns the largest locked amount in participated polls.
+// returns the largest locked amount in participated polls.
 fn compute_locked_balance<S: Storage, A: Api, Q: Querier>(
     deps: &mut Extern<S, A, Q>,
     token_manager: &mut TokenManager,
-    voter: &CanonicalAddr,
 ) -> StdResult<u128> {
     // filter out not in-progress polls
     token_manager.locked_balance.retain(|(poll_id, _)| {
         let poll: Poll = poll_read(&deps.storage)
             .load(&poll_id.to_be_bytes())
             .unwrap();
-
-        if poll.status != PollStatus::InProgress {
-            // remove voter info from the poll
-            poll_voter_store(&mut deps.storage, *poll_id).remove(&voter.as_slice());
-        }
 
         poll.status == PollStatus::InProgress
     });
@@ -145,6 +139,129 @@ fn compute_locked_balance<S: Storage, A: Api, Q: Querier>(
         .map(|(_, v)| v.balance.u128())
         .max()
         .unwrap_or_default())
+}
+
+pub fn deposit_reward<S: Storage, A: Api, Q: Querier>(
+    deps: &mut Extern<S, A, Q>,
+    _env: Env,
+    _sender: HumanAddr,
+    amount: Uint128,
+) -> HandleResult {
+    let config = config_read(&deps.storage).load()?;
+
+    let mut polls_in_progress = read_polls(
+        &deps.storage,
+        Some(PollStatus::InProgress),
+        None,
+        None,
+        None,
+    )?;
+
+    if config.voter_weight.is_zero() || polls_in_progress.is_empty() {
+        return Ok(HandleResponse {
+            messages: vec![],
+            log: vec![
+                log("action", "deposit_reward"),
+                log("amount", amount.to_string()),
+            ],
+            data: None,
+        });
+    }
+
+    let voter_rewards = amount * config.voter_weight;
+    let rewards_per_poll =
+        voter_rewards.multiply_ratio(Uint128(1), polls_in_progress.len() as u128);
+    if rewards_per_poll.is_zero() {
+        return Err(StdError::generic_err("Reward deposited is too small"));
+    }
+    for poll in polls_in_progress.iter_mut() {
+        poll.voters_reward += rewards_per_poll;
+        poll_store(&mut deps.storage)
+            .save(&poll.id.to_be_bytes(), &poll)
+            .unwrap()
+    }
+
+    state_store(&mut deps.storage).update(|mut state| {
+        state.pending_voting_rewards += voter_rewards;
+        Ok(state)
+    })?;
+
+    Ok(HandleResponse {
+        messages: vec![],
+        log: vec![
+            log("action", "deposit_reward"),
+            log("amount", amount.to_string()),
+        ],
+        data: None,
+    })
+}
+
+pub fn withdraw_voting_rewards<S: Storage, A: Api, Q: Querier>(
+    deps: &mut Extern<S, A, Q>,
+    env: Env,
+) -> HandleResult {
+    let config: Config = config_store(&mut deps.storage).load()?;
+    let sender_address_raw = deps.api.canonical_address(&env.message.sender)?;
+    let key = sender_address_raw.as_slice();
+
+    let token_manager = bank_read(&deps.storage)
+        .load(key)
+        .or(Err(StdError::generic_err("Nothing staked")))?;
+
+    let w_polls: Vec<(Poll, VoterInfo)> =
+        get_withdrawable_polls(&deps.storage, &token_manager, &sender_address_raw);
+
+    let user_reward_amount: u128 = w_polls
+        .iter()
+        .map(|(poll, voting_info)| {
+            // remove voter info from the poll
+            poll_voter_store(&mut deps.storage, poll.id).remove(&sender_address_raw.as_slice());
+
+            // calculate reward share
+            let total_votes =
+                poll.no_votes.u128() + poll.yes_votes.u128() + poll.abstain_votes.u128();
+            let poll_voting_reward = poll
+                .voters_reward
+                .multiply_ratio(voting_info.balance, total_votes);
+            poll_voting_reward.u128()
+        })
+        .sum();
+
+    state_store(&mut deps.storage).update(|mut state| {
+        state.pending_voting_rewards =
+            (state.pending_voting_rewards - Uint128(user_reward_amount))?;
+        Ok(state)
+    })?;
+
+    send_tokens(
+        &deps.api,
+        &config.mirror_token,
+        &sender_address_raw,
+        user_reward_amount,
+        "withdraw_voting_rewards",
+    )
+}
+
+fn get_withdrawable_polls<S: Storage>(
+    storage: &S,
+    token_manager: &TokenManager,
+    user_address: &CanonicalAddr,
+) -> Vec<(Poll, VoterInfo)> {
+    let w_polls: Vec<(Poll, VoterInfo)> = token_manager
+        .locked_balance
+        .iter()
+        .map(|(poll_id, _)| {
+            let poll: Poll = poll_read(storage).load(&poll_id.to_be_bytes()).unwrap();
+            let voter_info_res: StdResult<VoterInfo> =
+                poll_voter_read(storage, *poll_id).load(&user_address.as_slice());
+            (poll, voter_info_res)
+        })
+        .filter(|(poll, voter_info_res)| {
+            poll.status != PollStatus::InProgress && voter_info_res.is_ok()
+        })
+        .map(|(poll, voter_info_res)| (poll, voter_info_res.unwrap()))
+        .collect();
+    w_polls
 }
 
 fn send_tokens<A: Api>(
@@ -188,6 +305,22 @@ pub fn query_staker<S: Storage, A: Api, Q: Querier>(
         .may_load(addr_raw.as_slice())?
         .unwrap_or_default();
 
+    // calculate pending voting rewards
+    let w_polls: Vec<(Poll, VoterInfo)> =
+        get_withdrawable_polls(&deps.storage, &token_manager, &addr_raw);
+    let user_reward_amount: u128 = w_polls
+        .iter()
+        .map(|(poll, voting_info)| {
+            // calculate reward share
+            let total_votes =
+                poll.no_votes.u128() + poll.yes_votes.u128() + poll.abstain_votes.u128();
+            let poll_voting_reward = poll
+                .voters_reward
+                .multiply_ratio(voting_info.balance, total_votes);
+            poll_voting_reward.u128()
+        })
+        .sum();
+
     // filter out not in-progress polls
     token_manager.locked_balance.retain(|(poll_id, _)| {
         let poll: Poll = poll_read(&deps.storage)
@@ -197,11 +330,12 @@ pub fn query_staker<S: Storage, A: Api, Q: Querier>(
         poll.status == PollStatus::InProgress
     });
 
+    let total_locked_balance = state.total_deposit + state.pending_voting_rewards;
     let total_balance = (load_token_balance(
         &deps,
         &deps.api.human_address(&config.mirror_token)?,
         &state.contract_addr,
-    )? - state.total_deposit)?;
+    )? - total_locked_balance)?;
 
     Ok(StakerResponse {
         balance: if !state.total_share.is_zero() {
@@ -213,5 +347,6 @@ pub fn query_staker<S: Storage, A: Api, Q: Querier>(
         },
         share: token_manager.share,
         locked_balance: token_manager.locked_balance,
+        pending_voting_rewards: Uint128(user_reward_amount),
     })
 }

--- a/contracts/mirror_gov/src/staking.rs
+++ b/contracts/mirror_gov/src/staking.rs
@@ -155,6 +155,7 @@ pub fn deposit_reward<S: Storage, A: Api, Q: Querier>(
         None,
         None,
         None,
+        Some(true), // remove hard cap to get all polls
     )?;
 
     if config.voter_weight.is_zero() || polls_in_progress.is_empty() {

--- a/contracts/mirror_gov/src/state.rs
+++ b/contracts/mirror_gov/src/state.rs
@@ -149,8 +149,14 @@ pub fn read_polls<'a, S: ReadonlyStorage>(
     start_after: Option<u64>,
     limit: Option<u32>,
     order_by: Option<OrderBy>,
+    remove_hard_cap: Option<bool>,
 ) -> StdResult<Vec<Poll>> {
-    let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
+    let mut limit: usize = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
+    if let Some(remove_hard_cap) = remove_hard_cap {
+        if remove_hard_cap {
+            limit = usize::MAX;
+        }
+    }
     let (start, end, order_by) = match order_by {
         Some(OrderBy::Asc) => (calc_range_start(start_after), None, OrderBy::Asc),
         _ => (None, calc_range_end(start_after), OrderBy::Desc),

--- a/contracts/mirror_gov/src/state.rs
+++ b/contracts/mirror_gov/src/state.rs
@@ -27,6 +27,7 @@ pub struct Config {
     pub effective_delay: u64,
     pub expiration_period: u64,
     pub proposal_deposit: Uint128,
+    pub voter_weight: Decimal,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
@@ -35,6 +36,7 @@ pub struct State {
     pub poll_count: u64,
     pub total_share: Uint128,
     pub total_deposit: Uint128,
+    pub pending_voting_rewards: Uint128,
 }
 
 #[derive(Default, Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
@@ -51,6 +53,7 @@ pub struct Poll {
     pub status: PollStatus,
     pub yes_votes: Uint128,
     pub no_votes: Uint128,
+    pub abstain_votes: Uint128,
     pub end_height: u64,
     pub title: String,
     pub description: String,
@@ -59,6 +62,7 @@ pub struct Poll {
     pub deposit_amount: Uint128,
     /// Total balance at the end poll
     pub total_balance_at_end_poll: Option<Uint128>,
+    pub voters_reward: Uint128,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/contracts/mirror_gov/src/tests.rs
+++ b/contracts/mirror_gov/src/tests.rs
@@ -1,8 +1,8 @@
 use crate::contract::{handle, init, query};
 use crate::mock_querier::{mock_dependencies, WasmMockQuerier};
 use crate::state::{
-    bank_read, bank_store, config_read, poll_store, poll_voter_read, poll_voter_store, state_read,
-    Config, Poll, State, TokenManager,
+    bank_read, bank_store, config_read, poll_indexer_store, poll_store, poll_voter_read,
+    poll_voter_store, state_read, Config, Poll, State, TokenManager,
 };
 
 use cosmwasm_std::testing::{mock_env, MockApi, MockStorage, MOCK_CONTRACT_ADDR};
@@ -14,7 +14,7 @@ use cw20::{Cw20HandleMsg, Cw20ReceiveMsg};
 use mirror_protocol::common::OrderBy;
 use mirror_protocol::gov::{
     ConfigResponse, Cw20HookMsg, ExecuteMsg, HandleMsg, InitMsg, PollResponse, PollStatus,
-    PollsResponse, QueryMsg, StakerResponse, VoteOption, VoterInfo, VotersResponse,
+    PollsResponse, QueryMsg, StakerResponse, StateResponse, VoteOption, VoterInfo, VotersResponse,
     VotersResponseItem,
 };
 
@@ -22,12 +22,15 @@ const VOTING_TOKEN: &str = "voting_token";
 const TEST_CREATOR: &str = "creator";
 const TEST_VOTER: &str = "voter1";
 const TEST_VOTER_2: &str = "voter2";
+const TEST_COLLECTOR: &str = "collector";
 const DEFAULT_QUORUM: u64 = 30u64;
 const DEFAULT_THRESHOLD: u64 = 50u64;
 const DEFAULT_VOTING_PERIOD: u64 = 10000u64;
 const DEFAULT_EFFECTIVE_DELAY: u64 = 10000u64;
 const DEFAULT_EXPIRATION_PERIOD: u64 = 20000u64;
 const DEFAULT_PROPOSAL_DEPOSIT: u128 = 10000000000u128;
+const DEFAULT_VOTER_WEIGHT: Decimal = Decimal::zero();
+
 fn mock_init(mut deps: &mut Extern<MockStorage, MockApi, WasmMockQuerier>) {
     let msg = InitMsg {
         mirror_token: HumanAddr::from(VOTING_TOKEN),
@@ -37,6 +40,7 @@ fn mock_init(mut deps: &mut Extern<MockStorage, MockApi, WasmMockQuerier>) {
         effective_delay: DEFAULT_EFFECTIVE_DELAY,
         expiration_period: DEFAULT_EXPIRATION_PERIOD,
         proposal_deposit: Uint128(DEFAULT_PROPOSAL_DEPOSIT),
+        voter_weight: DEFAULT_VOTER_WEIGHT,
     };
 
     let env = mock_env(TEST_CREATOR, &[]);
@@ -59,6 +63,7 @@ fn init_msg() -> InitMsg {
         effective_delay: DEFAULT_EFFECTIVE_DELAY,
         expiration_period: DEFAULT_EXPIRATION_PERIOD,
         proposal_deposit: Uint128(DEFAULT_PROPOSAL_DEPOSIT),
+        voter_weight: DEFAULT_VOTER_WEIGHT,
     }
 }
 
@@ -89,6 +94,7 @@ fn proper_initialization() {
             effective_delay: DEFAULT_EFFECTIVE_DELAY,
             expiration_period: DEFAULT_EXPIRATION_PERIOD,
             proposal_deposit: Uint128(DEFAULT_PROPOSAL_DEPOSIT),
+            voter_weight: DEFAULT_VOTER_WEIGHT,
         }
     );
 
@@ -103,6 +109,7 @@ fn proper_initialization() {
             poll_count: 0,
             total_share: Uint128::zero(),
             total_deposit: Uint128::zero(),
+            pending_voting_rewards: Uint128::zero(),
         }
     );
 }
@@ -133,6 +140,7 @@ fn fails_create_poll_invalid_quorum() {
         effective_delay: DEFAULT_EFFECTIVE_DELAY,
         expiration_period: DEFAULT_EXPIRATION_PERIOD,
         proposal_deposit: Uint128(DEFAULT_PROPOSAL_DEPOSIT),
+        voter_weight: DEFAULT_VOTER_WEIGHT,
     };
 
     let res = init(&mut deps, env, msg);
@@ -156,6 +164,7 @@ fn fails_create_poll_invalid_threshold() {
         effective_delay: DEFAULT_EFFECTIVE_DELAY,
         expiration_period: DEFAULT_EXPIRATION_PERIOD,
         proposal_deposit: Uint128(DEFAULT_PROPOSAL_DEPOSIT),
+        voter_weight: DEFAULT_VOTER_WEIGHT,
     };
 
     let res = init(&mut deps, env, msg);
@@ -365,6 +374,8 @@ fn query_polls() {
                 yes_votes: Uint128::zero(),
                 no_votes: Uint128::zero(),
                 total_balance_at_end_poll: None,
+                voters_reward: Uint128::zero(),
+                abstain_votes: Uint128::zero(),
             },
             PollResponse {
                 id: 2u64,
@@ -379,6 +390,8 @@ fn query_polls() {
                 yes_votes: Uint128::zero(),
                 no_votes: Uint128::zero(),
                 total_balance_at_end_poll: None,
+                voters_reward: Uint128::zero(),
+                abstain_votes: Uint128::zero(),
             },
         ]
     );
@@ -409,6 +422,8 @@ fn query_polls() {
             yes_votes: Uint128::zero(),
             no_votes: Uint128::zero(),
             total_balance_at_end_poll: None,
+            voters_reward: Uint128::zero(),
+            abstain_votes: Uint128::zero(),
         },]
     );
 
@@ -438,6 +453,8 @@ fn query_polls() {
             yes_votes: Uint128::zero(),
             no_votes: Uint128::zero(),
             total_balance_at_end_poll: None,
+            voters_reward: Uint128::zero(),
+            abstain_votes: Uint128::zero(),
         }]
     );
 
@@ -467,6 +484,8 @@ fn query_polls() {
             yes_votes: Uint128::zero(),
             no_votes: Uint128::zero(),
             total_balance_at_end_poll: None,
+            voters_reward: Uint128::zero(),
+            abstain_votes: Uint128::zero(),
         },]
     );
 
@@ -754,7 +773,8 @@ fn happy_days_end_poll() {
         StakerResponse {
             balance: Uint128(stake_amount),
             share: Uint128(stake_amount),
-            locked_balance: vec![]
+            locked_balance: vec![],
+            pending_voting_rewards: Uint128::zero(),
         }
     );
 }
@@ -1351,7 +1371,8 @@ fn happy_days_cast_vote() {
                     vote: VoteOption::Yes,
                     balance: Uint128::from(amount),
                 }
-            )]
+            )],
+            pending_voting_rewards: Uint128::zero(),
         }
     );
 
@@ -1421,6 +1442,7 @@ fn happy_days_withdraw_voting_tokens() {
             poll_count: 0,
             total_share: Uint128::from(11u128),
             total_deposit: Uint128::zero(),
+            pending_voting_rewards: Uint128::zero(),
         }
     );
 
@@ -1462,6 +1484,7 @@ fn happy_days_withdraw_voting_tokens() {
             poll_count: 0,
             total_share: Uint128::from(6u128),
             total_deposit: Uint128::zero(),
+            pending_voting_rewards: Uint128::zero(),
         }
     );
 }
@@ -1497,6 +1520,7 @@ fn happy_days_withdraw_voting_tokens_all() {
             poll_count: 0,
             total_share: Uint128::from(11u128),
             total_deposit: Uint128::zero(),
+            pending_voting_rewards: Uint128::zero(),
         }
     );
 
@@ -1536,12 +1560,13 @@ fn happy_days_withdraw_voting_tokens_all() {
             poll_count: 0,
             total_share: Uint128::zero(),
             total_deposit: Uint128::zero(),
+            pending_voting_rewards: Uint128::zero(),
         }
     );
 }
 
 #[test]
-fn withdraw_voting_tokens_remove_not_in_progress_poll_voter_info() {
+fn withdraw_voting_tokens() {
     let mut deps = mock_dependencies(20, &[]);
     mock_init(&mut deps);
 
@@ -1570,6 +1595,7 @@ fn withdraw_voting_tokens_remove_not_in_progress_poll_voter_info() {
                 status: PollStatus::InProgress,
                 yes_votes: Uint128::zero(),
                 no_votes: Uint128::zero(),
+                abstain_votes: Uint128::zero(),
                 end_height: 0u64,
                 title: "title".to_string(),
                 description: "description".to_string(),
@@ -1577,6 +1603,7 @@ fn withdraw_voting_tokens_remove_not_in_progress_poll_voter_info() {
                 link: None,
                 execute_data: None,
                 total_balance_at_end_poll: None,
+                voters_reward: Uint128::zero(),
             },
         )
         .unwrap();
@@ -1590,6 +1617,7 @@ fn withdraw_voting_tokens_remove_not_in_progress_poll_voter_info() {
                 status: PollStatus::Passed,
                 yes_votes: Uint128::zero(),
                 no_votes: Uint128::zero(),
+                abstain_votes: Uint128::zero(),
                 end_height: 0u64,
                 title: "title".to_string(),
                 description: "description".to_string(),
@@ -1597,6 +1625,7 @@ fn withdraw_voting_tokens_remove_not_in_progress_poll_voter_info() {
                 link: None,
                 execute_data: None,
                 total_balance_at_end_poll: None,
+                voters_reward: Uint128::zero(),
             },
         )
         .unwrap();
@@ -1649,7 +1678,6 @@ fn withdraw_voting_tokens_remove_not_in_progress_poll_voter_info() {
         )
         .unwrap();
 
-    // withdraw voting token must remove not in-progress votes infos from the store
     let env = mock_env(TEST_VOTER, &[]);
     let msg = HandleMsg::WithdrawVotingTokens {
         amount: Some(Uint128::from(5u128)),
@@ -1665,12 +1693,6 @@ fn withdraw_voting_tokens_remove_not_in_progress_poll_voter_info() {
             vote: VoteOption::Yes,
             balance: Uint128(5u128),
         }
-    );
-    assert_eq!(
-        poll_voter_read(&deps.storage, 2u64)
-            .load(&voter_addr_raw.as_slice())
-            .is_err(),
-        true
     );
 
     let token_manager = bank_read(&deps.storage)
@@ -2019,6 +2041,7 @@ fn assert_create_poll_result(
             poll_count: 1,
             total_share: Uint128::zero(),
             total_deposit: Uint128(DEFAULT_PROPOSAL_DEPOSIT),
+            pending_voting_rewards: Uint128::zero(),
         }
     );
 }
@@ -2047,6 +2070,7 @@ fn assert_stake_tokens_result(
             poll_count,
             total_share: Uint128(total_share),
             total_deposit: Uint128(total_deposit),
+            pending_voting_rewards: Uint128::zero(),
         }
     );
 }
@@ -2085,6 +2109,7 @@ fn update_config() {
         effective_delay: None,
         expiration_period: None,
         proposal_deposit: None,
+        voter_weight: None,
     };
 
     let res = handle(&mut deps, env, msg).unwrap();
@@ -2110,6 +2135,7 @@ fn update_config() {
         effective_delay: Some(20000u64),
         expiration_period: Some(30000u64),
         proposal_deposit: Some(Uint128(123u128)),
+        voter_weight: Some(Decimal::percent(1)),
     };
 
     let res = handle(&mut deps, env, msg).unwrap();
@@ -2125,6 +2151,7 @@ fn update_config() {
     assert_eq!(20000u64, config.effective_delay);
     assert_eq!(30000u64, config.expiration_period);
     assert_eq!(123u128, config.proposal_deposit.u128());
+    assert_eq!(Decimal::percent(1), config.voter_weight);
 
     // Unauthorzied err
     let env = mock_env(TEST_CREATOR, &[]);
@@ -2136,6 +2163,7 @@ fn update_config() {
         effective_delay: None,
         expiration_period: None,
         proposal_deposit: None,
+        voter_weight: None,
     };
 
     let res = handle(&mut deps, env, msg);
@@ -2143,4 +2171,900 @@ fn update_config() {
         Err(StdError::Unauthorized { .. }) => {}
         _ => panic!("Must return unauthorized error"),
     }
+}
+
+#[test]
+fn distribute_voting_rewards() {
+    let mut deps = mock_dependencies(20, &[]);
+    let msg = InitMsg {
+        mirror_token: HumanAddr::from(VOTING_TOKEN),
+        quorum: Decimal::percent(DEFAULT_QUORUM),
+        threshold: Decimal::percent(DEFAULT_THRESHOLD),
+        voting_period: DEFAULT_VOTING_PERIOD,
+        effective_delay: DEFAULT_EFFECTIVE_DELAY,
+        expiration_period: DEFAULT_EXPIRATION_PERIOD,
+        proposal_deposit: Uint128(DEFAULT_PROPOSAL_DEPOSIT),
+        voter_weight: Decimal::percent(50), // distribute 50% rewards to voters
+    };
+
+    let env = mock_env(TEST_CREATOR, &[]);
+    let _res = init(&mut deps, env, msg).expect("contract successfully handles InitMsg");
+
+    let env = mock_env_height(VOTING_TOKEN, &coins(2, VOTING_TOKEN), 0, 10000);
+    let poll_end_height = env.block.height.clone() + DEFAULT_VOTING_PERIOD;
+    let msg = create_poll_msg("test".to_string(), "test".to_string(), None, None);
+    let handle_res = handle(&mut deps, env.clone(), msg.clone()).unwrap();
+
+    assert_create_poll_result(
+        1,
+        env.block.height + DEFAULT_VOTING_PERIOD,
+        TEST_CREATOR,
+        handle_res,
+        &mut deps,
+    );
+
+    let stake_amount = 100u128;
+
+    deps.querier.with_token_balances(&[(
+        &HumanAddr::from(VOTING_TOKEN),
+        &[(
+            &HumanAddr::from(MOCK_CONTRACT_ADDR),
+            &Uint128((stake_amount + DEFAULT_PROPOSAL_DEPOSIT) as u128),
+        )],
+    )]);
+
+    let msg = HandleMsg::Receive(Cw20ReceiveMsg {
+        sender: HumanAddr::from(TEST_VOTER),
+        amount: Uint128::from(stake_amount),
+        msg: Some(to_binary(&Cw20HookMsg::StakeVotingTokens {}).unwrap()),
+    });
+
+    let env = mock_env(VOTING_TOKEN.to_string(), &[]);
+    let _res = handle(&mut deps, env, msg).unwrap();
+
+    let msg = HandleMsg::CastVote {
+        poll_id: 1,
+        vote: VoteOption::Yes,
+        amount: Uint128::from(stake_amount),
+    };
+    let env = mock_env_height(TEST_VOTER, &[], 0, 10000);
+    let _res = handle(&mut deps, env, msg).unwrap();
+
+    let msg = HandleMsg::Receive(Cw20ReceiveMsg {
+        sender: HumanAddr::from(TEST_COLLECTOR),
+        amount: Uint128::from(100u128),
+        msg: Some(to_binary(&Cw20HookMsg::DepositReward {}).unwrap()),
+    });
+
+    let env = mock_env(VOTING_TOKEN.to_string(), &[]);
+    let _res = handle(&mut deps, env, msg).unwrap();
+
+    // FAIL - there is no finished polls, so amount to withdraw is 0
+    let msg = HandleMsg::WithdrawVotingRewards {};
+    let env = mock_env_height(TEST_VOTER, &[], 0, 10000);
+    let res = handle(&mut deps, env, msg).unwrap();
+    assert_eq!(
+        res.log,
+        vec![
+            log("action", "withdraw_voting_rewards"),
+            log("recipient", TEST_VOTER),
+            log("amount", 0),
+        ]
+    );
+
+    let env = mock_env_height(TEST_VOTER, &[], poll_end_height, 10000);
+    let msg = HandleMsg::EndPoll { poll_id: 1 };
+    let _res = handle(&mut deps, env.clone(), msg).unwrap();
+
+    // SUCCESS
+    let msg = HandleMsg::WithdrawVotingRewards {};
+    let env = mock_env_height(TEST_VOTER, &[], 0, 10000);
+    let res = handle(&mut deps, env.clone(), msg).unwrap();
+
+    // user can withdraw 50% of total staked (weight = 50% poll share = 100%)
+    assert_eq!(
+        res.log,
+        vec![
+            log("action", "withdraw_voting_rewards"),
+            log("recipient", TEST_VOTER),
+            log("amount", 50),
+        ]
+    );
+    assert_eq!(
+        res.messages,
+        vec![CosmosMsg::Wasm(WasmMsg::Execute {
+            contract_addr: HumanAddr::from(VOTING_TOKEN),
+            msg: to_binary(&Cw20HandleMsg::Transfer {
+                recipient: HumanAddr::from(TEST_VOTER),
+                amount: Uint128::from(50u128),
+            })
+            .unwrap(),
+            send: vec![],
+        })]
+    );
+
+    // voting info has been deleted
+    assert_eq!(
+        poll_voter_read(&deps.storage, 1u64)
+            .load(
+                &deps
+                    .api
+                    .canonical_address(&HumanAddr::from(TEST_VOTER))
+                    .unwrap()
+                    .as_slice()
+            )
+            .is_err(),
+        true
+    );
+}
+
+#[test]
+fn distribute_voting_rewards_with_multiple_active_polls_and_voters() {
+    let mut deps = mock_dependencies(20, &[]);
+    let msg = InitMsg {
+        mirror_token: HumanAddr::from(VOTING_TOKEN),
+        quorum: Decimal::percent(DEFAULT_QUORUM),
+        threshold: Decimal::percent(DEFAULT_THRESHOLD),
+        voting_period: DEFAULT_VOTING_PERIOD,
+        effective_delay: DEFAULT_EFFECTIVE_DELAY,
+        expiration_period: DEFAULT_EXPIRATION_PERIOD,
+        proposal_deposit: Uint128(DEFAULT_PROPOSAL_DEPOSIT),
+        voter_weight: Decimal::percent(50), // distribute 50% rewards to voters
+    };
+    let env = mock_env(TEST_CREATOR, &[]);
+    let _res = init(&mut deps, env, msg).expect("contract successfully handles InitMsg");
+
+    // create polls
+    let env = mock_env_height(VOTING_TOKEN, &coins(2, VOTING_TOKEN), 0, 10000);
+    let poll_end_height = env.block.height.clone() + DEFAULT_VOTING_PERIOD;
+    // poll 1
+    let msg = create_poll_msg("test".to_string(), "test".to_string(), None, None);
+    let _res = handle(&mut deps, env.clone(), msg.clone()).unwrap();
+    // poll 2
+    let msg = create_poll_msg("test2".to_string(), "test2".to_string(), None, None);
+    let _res = handle(&mut deps, env.clone(), msg.clone()).unwrap();
+
+    const ALICE: &str = "alice";
+    const ALICE_STAKE: u128 = 750_000_000u128;
+    const BOB: &str = "bob";
+    const BOB_STAKE: u128 = 250_000_000u128;
+    const CINDY: &str = "cindy";
+    const CINDY_STAKE: u128 = 250_000_000u128;
+
+    deps.querier.with_token_balances(&[(
+        &HumanAddr::from(VOTING_TOKEN),
+        &[(
+            &HumanAddr::from(MOCK_CONTRACT_ADDR),
+            &Uint128((ALICE_STAKE + DEFAULT_PROPOSAL_DEPOSIT * 2) as u128),
+        )],
+    )]);
+    // Alice stakes 750 MIR
+    let msg = HandleMsg::Receive(Cw20ReceiveMsg {
+        sender: HumanAddr::from(ALICE),
+        amount: Uint128::from(ALICE_STAKE),
+        msg: Some(to_binary(&Cw20HookMsg::StakeVotingTokens {}).unwrap()),
+    });
+    let env = mock_env(VOTING_TOKEN.to_string(), &[]);
+    let _res = handle(&mut deps, env.clone(), msg).unwrap();
+    deps.querier.with_token_balances(&[(
+        &HumanAddr::from(VOTING_TOKEN),
+        &[(
+            &HumanAddr::from(MOCK_CONTRACT_ADDR),
+            &Uint128((ALICE_STAKE + BOB_STAKE + DEFAULT_PROPOSAL_DEPOSIT * 2) as u128),
+        )],
+    )]);
+    // Bob stakes 250 MIR
+    let msg = HandleMsg::Receive(Cw20ReceiveMsg {
+        sender: HumanAddr::from(BOB),
+        amount: Uint128::from(BOB_STAKE),
+        msg: Some(to_binary(&Cw20HookMsg::StakeVotingTokens {}).unwrap()),
+    });
+    let _res = handle(&mut deps, env.clone(), msg).unwrap();
+    deps.querier.with_token_balances(&[(
+        &HumanAddr::from(VOTING_TOKEN),
+        &[(
+            &HumanAddr::from(MOCK_CONTRACT_ADDR),
+            &Uint128(
+                (ALICE_STAKE + BOB_STAKE + CINDY_STAKE + DEFAULT_PROPOSAL_DEPOSIT * 2) as u128,
+            ),
+        )],
+    )]);
+    // Cindy stakes 250 MIR
+    let msg = HandleMsg::Receive(Cw20ReceiveMsg {
+        sender: HumanAddr::from(CINDY),
+        amount: Uint128::from(CINDY_STAKE),
+        msg: Some(to_binary(&Cw20HookMsg::StakeVotingTokens {}).unwrap()),
+    });
+    let _res = handle(&mut deps, env.clone(), msg).unwrap();
+
+    // Alice votes on proposal 1
+    let msg = HandleMsg::CastVote {
+        poll_id: 1,
+        vote: VoteOption::Yes,
+        amount: Uint128::from(ALICE_STAKE),
+    };
+    let env = mock_env_height(ALICE, &[], 0, 10000);
+    let _res = handle(&mut deps, env, msg).unwrap();
+    // Bob votes on proposals 1 and 2
+    let msg = HandleMsg::CastVote {
+        poll_id: 1,
+        vote: VoteOption::Abstain,
+        amount: Uint128::from(BOB_STAKE),
+    };
+    let env = mock_env_height(BOB, &[], 0, 10000);
+    let _res = handle(&mut deps, env.clone(), msg).unwrap();
+    let msg = HandleMsg::CastVote {
+        poll_id: 2,
+        vote: VoteOption::No,
+        amount: Uint128::from(BOB_STAKE),
+    };
+    let _res = handle(&mut deps, env.clone(), msg).unwrap();
+    // Cindy votes on proposal 2
+    let msg = HandleMsg::CastVote {
+        poll_id: 2,
+        vote: VoteOption::Abstain,
+        amount: Uint128::from(CINDY_STAKE),
+    };
+    let env = mock_env_height(CINDY, &[], 0, 10000);
+    let _res = handle(&mut deps, env, msg).unwrap();
+
+    // Collector sends 2000 MIR with 50% voting weight
+    let msg = HandleMsg::Receive(Cw20ReceiveMsg {
+        sender: HumanAddr::from(TEST_COLLECTOR),
+        amount: Uint128::from(2000000000u128),
+        msg: Some(to_binary(&Cw20HookMsg::DepositReward {}).unwrap()),
+    });
+
+    let env = mock_env(VOTING_TOKEN.to_string(), &[]);
+    let _res = handle(&mut deps, env, msg).unwrap();
+
+    // End the polls
+    let env = mock_env_height(TEST_VOTER, &[], poll_end_height, 10000);
+    let msg = HandleMsg::EndPoll { poll_id: 1 };
+    let _res = handle(&mut deps, env.clone(), msg).unwrap();
+    let msg = HandleMsg::EndPoll { poll_id: 2 };
+    let _res = handle(&mut deps, env.clone(), msg).unwrap();
+
+    let msg = HandleMsg::WithdrawVotingRewards {};
+    // ALICE withdraws voting rewards
+    let env = mock_env_height(ALICE, &[], 0, 10000);
+    let res = handle(&mut deps, env, msg.clone()).unwrap();
+    assert_eq!(
+        res.log,
+        vec![
+            log("action", "withdraw_voting_rewards"),
+            log("recipient", ALICE),
+            log("amount", 375000000),
+        ]
+    );
+
+    // BOB withdraws voting rewards
+    let env = mock_env_height(BOB, &[], 0, 10000);
+    let res = handle(&mut deps, env.clone(), msg.clone()).unwrap();
+    assert_eq!(
+        res.log,
+        vec![
+            log("action", "withdraw_voting_rewards"),
+            log("recipient", BOB),
+            log("amount", 375000000), // 125 from poll 1 + 250 from poll 2
+        ]
+    );
+
+    // CINDY
+    let env = mock_env_height(CINDY, &[], 0, 10000);
+    let res = handle(&mut deps, env.clone(), msg.clone()).unwrap();
+    assert_eq!(
+        res.log,
+        vec![
+            log("action", "withdraw_voting_rewards"),
+            log("recipient", CINDY),
+            log("amount", 250000000),
+        ]
+    );
+}
+
+#[test]
+fn distribute_voting_rewards_only_to_polls_in_progress() {
+    let mut deps = mock_dependencies(20, &[]);
+    let msg = InitMsg {
+        mirror_token: HumanAddr::from(VOTING_TOKEN),
+        quorum: Decimal::percent(DEFAULT_QUORUM),
+        threshold: Decimal::percent(DEFAULT_THRESHOLD),
+        voting_period: DEFAULT_VOTING_PERIOD,
+        effective_delay: DEFAULT_EFFECTIVE_DELAY,
+        expiration_period: DEFAULT_EXPIRATION_PERIOD,
+        proposal_deposit: Uint128(DEFAULT_PROPOSAL_DEPOSIT),
+        voter_weight: Decimal::percent(50), // distribute 50% rewards to voters
+    };
+    let env = mock_env(TEST_CREATOR, &[]);
+    let _res = init(&mut deps, env, msg).expect("contract successfully handles InitMsg");
+
+    // make fake polls; one in progress & one in passed
+    poll_store(&mut deps.storage)
+        .save(
+            &1u64.to_be_bytes(),
+            &Poll {
+                id: 1u64,
+                creator: deps
+                    .api
+                    .canonical_address(&HumanAddr::from(TEST_CREATOR))
+                    .unwrap(),
+                status: PollStatus::InProgress,
+                yes_votes: Uint128::zero(),
+                no_votes: Uint128::zero(),
+                abstain_votes: Uint128::zero(),
+                end_height: 0u64,
+                title: "title".to_string(),
+                description: "description".to_string(),
+                deposit_amount: Uint128::zero(),
+                link: None,
+                execute_data: None,
+                total_balance_at_end_poll: None,
+                voters_reward: Uint128::zero(),
+            },
+        )
+        .unwrap();
+
+    poll_store(&mut deps.storage)
+        .save(
+            &2u64.to_be_bytes(),
+            &Poll {
+                id: 2u64,
+                creator: deps
+                    .api
+                    .canonical_address(&HumanAddr::from(TEST_CREATOR))
+                    .unwrap(),
+                status: PollStatus::Passed,
+                yes_votes: Uint128::zero(),
+                no_votes: Uint128::zero(),
+                abstain_votes: Uint128::zero(),
+                end_height: 0u64,
+                title: "title".to_string(),
+                description: "description".to_string(),
+                deposit_amount: Uint128::zero(),
+                link: None,
+                execute_data: None,
+                total_balance_at_end_poll: None,
+                voters_reward: Uint128::zero(),
+            },
+        )
+        .unwrap();
+
+    poll_indexer_store(&mut deps.storage, &PollStatus::InProgress)
+        .save(&1u64.to_be_bytes(), &true)
+        .unwrap();
+    poll_indexer_store(&mut deps.storage, &PollStatus::Passed)
+        .save(&2u64.to_be_bytes(), &true)
+        .unwrap();
+
+    // Collector sends 2000 MIR with 50% voting weight
+    let msg = HandleMsg::Receive(Cw20ReceiveMsg {
+        sender: HumanAddr::from(TEST_COLLECTOR),
+        amount: Uint128::from(2000000000u128),
+        msg: Some(to_binary(&Cw20HookMsg::DepositReward {}).unwrap()),
+    });
+
+    let env = mock_env(VOTING_TOKEN.to_string(), &[]);
+    let _res = handle(&mut deps, env, msg).unwrap();
+
+    let res = query(
+        &deps,
+        QueryMsg::Polls {
+            filter: None,
+            start_after: None,
+            limit: None,
+            order_by: Some(OrderBy::Asc),
+        },
+    )
+    .unwrap();
+    let response: PollsResponse = from_binary(&res).unwrap();
+    assert_eq!(
+        response.polls,
+        vec![
+            PollResponse {
+                id: 1u64,
+                creator: HumanAddr::from(TEST_CREATOR),
+                status: PollStatus::InProgress,
+                yes_votes: Uint128::zero(),
+                no_votes: Uint128::zero(),
+                abstain_votes: Uint128::zero(),
+                end_height: 0u64,
+                title: "title".to_string(),
+                description: "description".to_string(),
+                deposit_amount: Uint128::zero(),
+                link: None,
+                execute_data: None,
+                total_balance_at_end_poll: None,
+                voters_reward: Uint128::from(1000000000u128),
+            },
+            PollResponse {
+                id: 2u64,
+                creator: HumanAddr::from(TEST_CREATOR),
+                status: PollStatus::Passed,
+                yes_votes: Uint128::zero(),
+                no_votes: Uint128::zero(),
+                abstain_votes: Uint128::zero(),
+                end_height: 0u64,
+                title: "title".to_string(),
+                description: "description".to_string(),
+                deposit_amount: Uint128::zero(),
+                link: None,
+                execute_data: None,
+                total_balance_at_end_poll: None,
+                voters_reward: Uint128::zero(),
+            },
+        ]
+    );
+}
+
+#[test]
+fn test_staking_and_voting_rewards() {
+    let mut deps = mock_dependencies(20, &[]);
+    let msg = InitMsg {
+        mirror_token: HumanAddr::from(VOTING_TOKEN),
+        quorum: Decimal::percent(DEFAULT_QUORUM),
+        threshold: Decimal::percent(DEFAULT_THRESHOLD),
+        voting_period: DEFAULT_VOTING_PERIOD,
+        effective_delay: DEFAULT_EFFECTIVE_DELAY,
+        expiration_period: DEFAULT_EXPIRATION_PERIOD,
+        proposal_deposit: Uint128(DEFAULT_PROPOSAL_DEPOSIT),
+        voter_weight: Decimal::percent(50), // distribute 50% rewards to voters
+    };
+    let env = mock_env(TEST_CREATOR, &[]);
+    let _res = init(&mut deps, env, msg).expect("contract successfully handles InitMsg");
+
+    let env = mock_env_height(VOTING_TOKEN, &coins(2, VOTING_TOKEN), 0, 10000);
+    let poll_end_height = env.block.height.clone() + DEFAULT_VOTING_PERIOD;
+    // poll 1
+    let msg = create_poll_msg("test".to_string(), "test".to_string(), None, None);
+    let _res = handle(&mut deps, env.clone(), msg.clone()).unwrap();
+
+    const ALICE: &str = "alice";
+    const ALICE_STAKE: u128 = 750_000_000u128;
+    const BOB: &str = "bob";
+    const BOB_STAKE: u128 = 250_000_000u128;
+
+    deps.querier.with_token_balances(&[(
+        &HumanAddr::from(VOTING_TOKEN),
+        &[(
+            &HumanAddr::from(MOCK_CONTRACT_ADDR),
+            &Uint128((ALICE_STAKE + DEFAULT_PROPOSAL_DEPOSIT) as u128),
+        )],
+    )]);
+    // Alice stakes 750 MIR
+    let msg = HandleMsg::Receive(Cw20ReceiveMsg {
+        sender: HumanAddr::from(ALICE),
+        amount: Uint128::from(ALICE_STAKE),
+        msg: Some(to_binary(&Cw20HookMsg::StakeVotingTokens {}).unwrap()),
+    });
+    let env = mock_env(VOTING_TOKEN.to_string(), &[]);
+    let _res = handle(&mut deps, env.clone(), msg).unwrap();
+    deps.querier.with_token_balances(&[(
+        &HumanAddr::from(VOTING_TOKEN),
+        &[(
+            &HumanAddr::from(MOCK_CONTRACT_ADDR),
+            &Uint128((ALICE_STAKE + BOB_STAKE + DEFAULT_PROPOSAL_DEPOSIT) as u128),
+        )],
+    )]);
+    // Bob stakes 250 MIR
+    let msg = HandleMsg::Receive(Cw20ReceiveMsg {
+        sender: HumanAddr::from(BOB),
+        amount: Uint128::from(BOB_STAKE),
+        msg: Some(to_binary(&Cw20HookMsg::StakeVotingTokens {}).unwrap()),
+    });
+    let _res = handle(&mut deps, env.clone(), msg).unwrap();
+
+    // Alice votes
+    let msg = HandleMsg::CastVote {
+        poll_id: 1,
+        vote: VoteOption::Yes,
+        amount: Uint128::from(ALICE_STAKE),
+    };
+    let env = mock_env_height(ALICE, &[], 0, 10000);
+    let _res = handle(&mut deps, env, msg).unwrap();
+    // Bob votes
+    let msg = HandleMsg::CastVote {
+        poll_id: 1,
+        vote: VoteOption::Abstain,
+        amount: Uint128::from(BOB_STAKE),
+    };
+    let env = mock_env_height(BOB, &[], 0, 10000);
+    let _res = handle(&mut deps, env.clone(), msg).unwrap();
+
+    // Collector sends 2000 MIR with 50% voting weight
+    let msg = HandleMsg::Receive(Cw20ReceiveMsg {
+        sender: HumanAddr::from(TEST_COLLECTOR),
+        amount: Uint128::from(2_000_000_000u128),
+        msg: Some(to_binary(&Cw20HookMsg::DepositReward {}).unwrap()),
+    });
+
+    let env = mock_env(VOTING_TOKEN.to_string(), &[]);
+    let _res = handle(&mut deps, env, msg).unwrap();
+
+    // End the poll
+    let env = mock_env_height(TEST_VOTER, &[], poll_end_height, 10000);
+    let msg = HandleMsg::EndPoll { poll_id: 1 };
+    let _res = handle(&mut deps, env.clone(), msg).unwrap();
+
+    // deposit is returned to creator and collector deposit is added
+    deps.querier.with_token_balances(&[(
+        &HumanAddr::from(VOTING_TOKEN),
+        &[(
+            &HumanAddr::from(MOCK_CONTRACT_ADDR),
+            &Uint128((ALICE_STAKE + BOB_STAKE + 2_000_000_000) as u128),
+        )],
+    )]);
+
+    let res = query(&deps, QueryMsg::State {}).unwrap();
+    let response: StateResponse = from_binary(&res).unwrap();
+    assert_eq!(response.total_share, Uint128(1_000_000_000u128));
+    assert_eq!(response.total_deposit, Uint128::zero());
+    assert_eq!(response.pending_voting_rewards, Uint128(1_000_000_000u128));
+
+    let res = query(
+        &deps,
+        QueryMsg::Staker {
+            address: HumanAddr::from(ALICE),
+        },
+    )
+    .unwrap();
+    let response: StakerResponse = from_binary(&res).unwrap();
+    assert_eq!(
+        response,
+        StakerResponse {
+            balance: Uint128(ALICE_STAKE + 750_000_000u128),
+            share: Uint128(ALICE_STAKE),
+            locked_balance: vec![],
+            pending_voting_rewards: Uint128(750_000_000u128),
+        }
+    );
+    let res = query(
+        &deps,
+        QueryMsg::Staker {
+            address: HumanAddr::from(BOB),
+        },
+    )
+    .unwrap();
+    let response: StakerResponse = from_binary(&res).unwrap();
+    assert_eq!(
+        response,
+        StakerResponse {
+            balance: Uint128(BOB_STAKE + 250_000_000u128),
+            share: Uint128(BOB_STAKE),
+            locked_balance: vec![],
+            pending_voting_rewards: Uint128(250_000_000u128),
+        }
+    );
+
+    let msg = HandleMsg::WithdrawVotingRewards {};
+    // ALICE withdraws voting rewards
+    let env = mock_env_height(ALICE, &[], 0, 10000);
+    let res = handle(&mut deps, env, msg.clone()).unwrap();
+    assert_eq!(
+        res.log,
+        vec![
+            log("action", "withdraw_voting_rewards"),
+            log("recipient", ALICE),
+            log("amount", ALICE_STAKE),
+        ]
+    );
+
+    // BOB withdraws voting rewards
+    let env = mock_env_height(BOB, &[], 0, 10000);
+    let res = handle(&mut deps, env.clone(), msg.clone()).unwrap();
+    assert_eq!(
+        res.log,
+        vec![
+            log("action", "withdraw_voting_rewards"),
+            log("recipient", BOB),
+            log("amount", BOB_STAKE),
+        ]
+    );
+
+    deps.querier.with_token_balances(&[(
+        &HumanAddr::from(VOTING_TOKEN),
+        &[(
+            &HumanAddr::from(MOCK_CONTRACT_ADDR),
+            &Uint128((ALICE_STAKE + BOB_STAKE + 1_000_000_000) as u128),
+        )],
+    )]);
+
+    // withdraw remaining voting tokens
+    let msg = HandleMsg::WithdrawVotingTokens { amount: None };
+    let env = mock_env(ALICE.to_string(), &[]);
+    let res = handle(&mut deps, env, msg).unwrap();
+    assert_eq!(
+        res.log,
+        vec![
+            log("action", "withdraw"),
+            log("recipient", ALICE),
+            log("amount", "1500000000"),
+        ]
+    );
+    deps.querier.with_token_balances(&[(
+        &HumanAddr::from(VOTING_TOKEN),
+        &[(
+            &HumanAddr::from(MOCK_CONTRACT_ADDR),
+            &Uint128((BOB_STAKE + 250_000_000) as u128),
+        )],
+    )]);
+    // withdraw remaining voting tokens
+    let msg = HandleMsg::WithdrawVotingTokens { amount: None };
+    let env = mock_env(BOB.to_string(), &[]);
+    let res = handle(&mut deps, env, msg).unwrap();
+    assert_eq!(
+        res.log,
+        vec![
+            log("action", "withdraw"),
+            log("recipient", BOB),
+            log("amount", "500000000"),
+        ]
+    );
+}
+
+#[test]
+fn test_abstain_votes_theshold() {
+    let mut deps = mock_dependencies(20, &[]);
+    let msg = InitMsg {
+        mirror_token: HumanAddr::from(VOTING_TOKEN),
+        quorum: Decimal::percent(DEFAULT_QUORUM),
+        threshold: Decimal::percent(DEFAULT_THRESHOLD),
+        voting_period: DEFAULT_VOTING_PERIOD,
+        effective_delay: DEFAULT_EFFECTIVE_DELAY,
+        expiration_period: DEFAULT_EXPIRATION_PERIOD,
+        proposal_deposit: Uint128(DEFAULT_PROPOSAL_DEPOSIT),
+        voter_weight: Decimal::percent(50), // distribute 50% rewards to voters
+    };
+
+    let env = mock_env(TEST_CREATOR, &[]);
+    let _res = init(&mut deps, env, msg).expect("contract successfully handles InitMsg");
+
+    let env = mock_env_height(VOTING_TOKEN, &coins(2, VOTING_TOKEN), 0, 10000);
+    let poll_end_height = env.block.height.clone() + DEFAULT_VOTING_PERIOD;
+    let msg = create_poll_msg("test".to_string(), "test".to_string(), None, None);
+    let _res = handle(&mut deps, env.clone(), msg.clone()).unwrap();
+
+    const ALICE: &str = "alice";
+    const ALICE_STAKE: u128 = 750_000_000u128;
+    const BOB: &str = "bob";
+    const BOB_STAKE: u128 = 250_000_000u128;
+    const CINDY: &str = "cindy";
+    const CINDY_STAKE: u128 = 260_000_000u128;
+
+    deps.querier.with_token_balances(&[(
+        &HumanAddr::from(VOTING_TOKEN),
+        &[(
+            &HumanAddr::from(MOCK_CONTRACT_ADDR),
+            &Uint128((ALICE_STAKE + DEFAULT_PROPOSAL_DEPOSIT) as u128),
+        )],
+    )]);
+    // Alice stakes 750 MIR
+    let msg = HandleMsg::Receive(Cw20ReceiveMsg {
+        sender: HumanAddr::from(ALICE),
+        amount: Uint128::from(ALICE_STAKE),
+        msg: Some(to_binary(&Cw20HookMsg::StakeVotingTokens {}).unwrap()),
+    });
+    let env = mock_env(VOTING_TOKEN.to_string(), &[]);
+    let _res = handle(&mut deps, env.clone(), msg).unwrap();
+    deps.querier.with_token_balances(&[(
+        &HumanAddr::from(VOTING_TOKEN),
+        &[(
+            &HumanAddr::from(MOCK_CONTRACT_ADDR),
+            &Uint128((ALICE_STAKE + BOB_STAKE + DEFAULT_PROPOSAL_DEPOSIT) as u128),
+        )],
+    )]);
+    // Bob stakes 250 MIR
+    let msg = HandleMsg::Receive(Cw20ReceiveMsg {
+        sender: HumanAddr::from(BOB),
+        amount: Uint128::from(BOB_STAKE),
+        msg: Some(to_binary(&Cw20HookMsg::StakeVotingTokens {}).unwrap()),
+    });
+    let _res = handle(&mut deps, env.clone(), msg).unwrap();
+    deps.querier.with_token_balances(&[(
+        &HumanAddr::from(VOTING_TOKEN),
+        &[(
+            &HumanAddr::from(MOCK_CONTRACT_ADDR),
+            &Uint128((ALICE_STAKE + BOB_STAKE + CINDY_STAKE + DEFAULT_PROPOSAL_DEPOSIT) as u128),
+        )],
+    )]);
+    // Cindy stakes 260 MIR
+    let msg = HandleMsg::Receive(Cw20ReceiveMsg {
+        sender: HumanAddr::from(CINDY),
+        amount: Uint128::from(CINDY_STAKE),
+        msg: Some(to_binary(&Cw20HookMsg::StakeVotingTokens {}).unwrap()),
+    });
+    let _res = handle(&mut deps, env.clone(), msg).unwrap();
+
+    // Alice votes
+    let msg = HandleMsg::CastVote {
+        poll_id: 1,
+        vote: VoteOption::Abstain,
+        amount: Uint128::from(ALICE_STAKE),
+    };
+    let env = mock_env_height(ALICE, &[], 0, 10000);
+    let _res = handle(&mut deps, env, msg).unwrap();
+    // Bob votes
+    let msg = HandleMsg::CastVote {
+        poll_id: 1,
+        vote: VoteOption::No,
+        amount: Uint128::from(BOB_STAKE),
+    };
+    let env = mock_env_height(BOB, &[], 0, 10000);
+    let _res = handle(&mut deps, env.clone(), msg).unwrap();
+    // Cindy votes
+    let msg = HandleMsg::CastVote {
+        poll_id: 1,
+        vote: VoteOption::Yes,
+        amount: Uint128::from(CINDY_STAKE),
+    };
+    let env = mock_env_height(CINDY, &[], 0, 10000);
+    let _res = handle(&mut deps, env, msg).unwrap();
+
+    let msg = HandleMsg::EndPoll { poll_id: 1 };
+
+    let env = mock_env_height(TEST_VOTER, &[], poll_end_height, 10000);
+    let handle_res = handle(&mut deps, env.clone(), msg.clone()).unwrap();
+    // abstain votes should not affect threshold, so poll is passed
+    assert_eq!(
+        handle_res.log,
+        vec![
+            log("action", "end_poll"),
+            log("poll_id", "1"),
+            log("rejected_reason", ""),
+            log("passed", "true"),
+        ]
+    );
+}
+
+#[test]
+fn test_abstain_votes_quorum() {
+    let mut deps = mock_dependencies(20, &[]);
+    let msg = InitMsg {
+        mirror_token: HumanAddr::from(VOTING_TOKEN),
+        quorum: Decimal::percent(DEFAULT_QUORUM),
+        threshold: Decimal::percent(DEFAULT_THRESHOLD),
+        voting_period: DEFAULT_VOTING_PERIOD,
+        effective_delay: DEFAULT_EFFECTIVE_DELAY,
+        expiration_period: DEFAULT_EXPIRATION_PERIOD,
+        proposal_deposit: Uint128(DEFAULT_PROPOSAL_DEPOSIT),
+        voter_weight: Decimal::percent(50), // distribute 50% rewards to voters
+    };
+
+    let env = mock_env(TEST_CREATOR, &[]);
+    let _res = init(&mut deps, env, msg).expect("contract successfully handles InitMsg");
+
+    let env = mock_env_height(VOTING_TOKEN, &coins(2, VOTING_TOKEN), 0, 10000);
+    let poll_end_height = env.block.height.clone() + DEFAULT_VOTING_PERIOD;
+    let msg = create_poll_msg("test".to_string(), "test".to_string(), None, None);
+    let _res = handle(&mut deps, env.clone(), msg.clone()).unwrap();
+
+    const ALICE: &str = "alice";
+    const ALICE_STAKE: u128 = 750_000_000u128;
+    const BOB: &str = "bob";
+    const BOB_STAKE: u128 = 50_000_000u128;
+    const CINDY: &str = "cindy";
+    const CINDY_STAKE: u128 = 20_000_000u128;
+
+    deps.querier.with_token_balances(&[(
+        &HumanAddr::from(VOTING_TOKEN),
+        &[(
+            &HumanAddr::from(MOCK_CONTRACT_ADDR),
+            &Uint128((ALICE_STAKE + DEFAULT_PROPOSAL_DEPOSIT) as u128),
+        )],
+    )]);
+    // Alice stakes 750 MIR
+    let msg = HandleMsg::Receive(Cw20ReceiveMsg {
+        sender: HumanAddr::from(ALICE),
+        amount: Uint128::from(ALICE_STAKE),
+        msg: Some(to_binary(&Cw20HookMsg::StakeVotingTokens {}).unwrap()),
+    });
+    let env = mock_env(VOTING_TOKEN.to_string(), &[]);
+    let _res = handle(&mut deps, env.clone(), msg).unwrap();
+    deps.querier.with_token_balances(&[(
+        &HumanAddr::from(VOTING_TOKEN),
+        &[(
+            &HumanAddr::from(MOCK_CONTRACT_ADDR),
+            &Uint128((ALICE_STAKE + BOB_STAKE + DEFAULT_PROPOSAL_DEPOSIT) as u128),
+        )],
+    )]);
+    // Bob stakes 50 MIR
+    let msg = HandleMsg::Receive(Cw20ReceiveMsg {
+        sender: HumanAddr::from(BOB),
+        amount: Uint128::from(BOB_STAKE),
+        msg: Some(to_binary(&Cw20HookMsg::StakeVotingTokens {}).unwrap()),
+    });
+    let _res = handle(&mut deps, env.clone(), msg).unwrap();
+    deps.querier.with_token_balances(&[(
+        &HumanAddr::from(VOTING_TOKEN),
+        &[(
+            &HumanAddr::from(MOCK_CONTRACT_ADDR),
+            &Uint128((ALICE_STAKE + BOB_STAKE + CINDY_STAKE + DEFAULT_PROPOSAL_DEPOSIT) as u128),
+        )],
+    )]);
+    // Cindy stakes 50 MIR
+    let msg = HandleMsg::Receive(Cw20ReceiveMsg {
+        sender: HumanAddr::from(CINDY),
+        amount: Uint128::from(CINDY_STAKE),
+        msg: Some(to_binary(&Cw20HookMsg::StakeVotingTokens {}).unwrap()),
+    });
+    let _res = handle(&mut deps, env.clone(), msg).unwrap();
+
+    // Alice votes
+    let msg = HandleMsg::CastVote {
+        poll_id: 1,
+        vote: VoteOption::Abstain,
+        amount: Uint128::from(ALICE_STAKE),
+    };
+    let env = mock_env_height(ALICE, &[], 0, 10000);
+    let _res = handle(&mut deps, env, msg).unwrap();
+    // Bob votes
+    let msg = HandleMsg::CastVote {
+        poll_id: 1,
+        vote: VoteOption::Yes,
+        amount: Uint128::from(BOB_STAKE),
+    };
+    let env = mock_env_height(BOB, &[], 0, 10000);
+    let _res = handle(&mut deps, env.clone(), msg).unwrap();
+    // Cindy votes
+    let msg = HandleMsg::CastVote {
+        poll_id: 1,
+        vote: VoteOption::Yes,
+        amount: Uint128::from(CINDY_STAKE),
+    };
+    let env = mock_env_height(CINDY, &[], 0, 10000);
+    let _res = handle(&mut deps, env, msg).unwrap();
+
+    let msg = HandleMsg::EndPoll { poll_id: 1 };
+
+    let env = mock_env_height(TEST_VOTER, &[], poll_end_height, 10000);
+    let handle_res = handle(&mut deps, env.clone(), msg.clone()).unwrap();
+    // abstain votes make the poll surpass quorum
+    assert_eq!(
+        handle_res.log,
+        vec![
+            log("action", "end_poll"),
+            log("poll_id", "1"),
+            log("rejected_reason", ""),
+            log("passed", "true"),
+        ]
+    );
+
+    let env = mock_env_height(VOTING_TOKEN, &coins(2, VOTING_TOKEN), 0, 10000);
+    let poll_end_height = env.block.height.clone() + DEFAULT_VOTING_PERIOD;
+    let msg = create_poll_msg("test".to_string(), "test".to_string(), None, None);
+    let _res = handle(&mut deps, env.clone(), msg.clone()).unwrap();
+
+    // Alice doesn't vote
+
+    // Bob votes
+    let msg = HandleMsg::CastVote {
+        poll_id: 2,
+        vote: VoteOption::Yes,
+        amount: Uint128::from(BOB_STAKE),
+    };
+    let env = mock_env_height(BOB, &[], 0, 10000);
+    let _res = handle(&mut deps, env.clone(), msg).unwrap();
+    // Cindy votes
+    let msg = HandleMsg::CastVote {
+        poll_id: 2,
+        vote: VoteOption::Yes,
+        amount: Uint128::from(CINDY_STAKE),
+    };
+    let env = mock_env_height(CINDY, &[], 0, 10000);
+    let _res = handle(&mut deps, env, msg).unwrap();
+
+    let msg = HandleMsg::EndPoll { poll_id: 2 };
+
+    let env = mock_env_height(TEST_VOTER, &[], poll_end_height, 10000);
+    let handle_res = handle(&mut deps, env.clone(), msg.clone()).unwrap();
+    // without abstain votes, quroum is not reached
+    assert_eq!(
+        handle_res.log,
+        vec![
+            log("action", "end_poll"),
+            log("poll_id", "2"),
+            log("rejected_reason", "Quorum not reached"),
+            log("passed", "false"),
+        ]
+    );
 }

--- a/contracts/mirror_gov/tests/integration.rs
+++ b/contracts/mirror_gov/tests/integration.rs
@@ -59,6 +59,7 @@ const DEFAULT_VOTING_PERIOD: u64 = 10000u64;
 const DEFAULT_EFFECTIVE_DELAY: u64 = 10000u64;
 const DEFAULT_EXPIRATION_PERIOD: u64 = 20000u64;
 const DEFAULT_PROPOSAL_DEPOSIT: u128 = 10000000000u128;
+const DEFAULT_VOTER_WEIGHT: u64 = 50u64;
 
 fn init_msg() -> InitMsg {
     InitMsg {
@@ -69,6 +70,7 @@ fn init_msg() -> InitMsg {
         effective_delay: DEFAULT_EFFECTIVE_DELAY,
         expiration_period: DEFAULT_EXPIRATION_PERIOD,
         proposal_deposit: Uint128(DEFAULT_PROPOSAL_DEPOSIT),
+        voter_weight: Decimal::percent(DEFAULT_VOTER_WEIGHT),
     }
 }
 
@@ -106,6 +108,7 @@ fn proper_initialization() {
                 effective_delay: DEFAULT_EFFECTIVE_DELAY,
                 expiration_period: DEFAULT_EXPIRATION_PERIOD,
                 proposal_deposit: Uint128(DEFAULT_PROPOSAL_DEPOSIT),
+                voter_weight: Decimal::percent(DEFAULT_VOTER_WEIGHT),
             }
         );
         Ok(())
@@ -134,6 +137,7 @@ fn update_config() {
         effective_delay: None,
         expiration_period: None,
         proposal_deposit: None,
+        voter_weight: None,
     };
 
     let res: HandleResponse = handle(&mut deps, env, msg).unwrap();
@@ -158,6 +162,7 @@ fn update_config() {
         effective_delay: Some(20000u64),
         expiration_period: Some(30000u64),
         proposal_deposit: Some(Uint128(123u128)),
+        voter_weight: None,
     };
 
     let res: HandleResponse = handle(&mut deps, env, msg).unwrap();
@@ -182,6 +187,7 @@ fn update_config() {
         effective_delay: None,
         expiration_period: None,
         proposal_deposit: None,
+        voter_weight: None,
     };
 
     let res: HandleResult = handle(&mut deps, env, msg);

--- a/packages/mirror_protocol/src/gov.rs
+++ b/packages/mirror_protocol/src/gov.rs
@@ -170,9 +170,11 @@ pub struct VotersResponse {
     pub voters: Vec<VotersResponseItem>,
 }
 
-/// We currently take no arguments for migrations
+/// Migrates the contract state, currently taking a state version argument
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-pub struct MigrateMsg {}
+pub struct MigrateMsg {
+    pub version: u64, // current contract migration state version
+}
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct VoterInfo {


### PR DESCRIPTION
### Overview:

**Voting rewards (gov):**

- Collector calls `DepositReward` hook on gov contract when distributing rewards
- A portion of the distributed rewards (based on `voter_weight`) is given to voters of polls in progress
- Users can claim the rewards given for voting with `WithdrawVotingRewards` 

**Abstain Votes:**

- Users can vote with `Abstain`
- Abstain votes affect quorum, but not the threshold

**Revoke asset auth:**

- Now, `RevokeAsset` can be called by the feeder or owner, so that it is possible to revoke it with a governance poll