### PR TITLE
feat: snapshot poll + fix: subtract pending rewards from token balance

### DIFF
--- a/contracts/mirror_gov/schema/config_response.json
+++ b/contracts/mirror_gov/schema/config_response.json
@@ -9,6 +9,7 @@
     "owner",
     "proposal_deposit",
     "quorum",
+    "snapshot_period",
     "threshold",
     "voter_weight",
     "voting_period"
@@ -36,6 +37,11 @@
     "quorum": {
       "$ref": "#/definitions/Decimal"
     },
+    "snapshot_period": {
+      "type": "integer",
+      "format": "uint64",
+      "minimum": 0.0
+    },
     "threshold": {
       "$ref": "#/definitions/Decimal"
     },
@@ -50,7 +56,7 @@
   },
   "definitions": {
     "Decimal": {
-      "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0 The greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
+      "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
       "type": "string"
     },
     "HumanAddr": {

--- a/contracts/mirror_gov/schema/handle_msg.json
+++ b/contracts/mirror_gov/schema/handle_msg.json
@@ -68,6 +68,14 @@
                 }
               ]
             },
+            "snapshot_period": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint64",
+              "minimum": 0.0
+            },
             "threshold": {
               "anyOf": [
                 {
@@ -212,6 +220,27 @@
       ],
       "properties": {
         "expire_poll": {
+          "type": "object",
+          "required": [
+            "poll_id"
+          ],
+          "properties": {
+            "poll_id": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            }
+          }
+        }
+      }
+    },
+    {
+      "type": "object",
+      "required": [
+        "snapshot_poll"
+      ],
+      "properties": {
+        "snapshot_poll": {
           "type": "object",
           "required": [
             "poll_id"

--- a/contracts/mirror_gov/schema/init_msg.json
+++ b/contracts/mirror_gov/schema/init_msg.json
@@ -8,6 +8,7 @@
     "mirror_token",
     "proposal_deposit",
     "quorum",
+    "snapshot_period",
     "threshold",
     "voter_weight",
     "voting_period"
@@ -32,6 +33,11 @@
     "quorum": {
       "$ref": "#/definitions/Decimal"
     },
+    "snapshot_period": {
+      "type": "integer",
+      "format": "uint64",
+      "minimum": 0.0
+    },
     "threshold": {
       "$ref": "#/definitions/Decimal"
     },
@@ -46,7 +52,7 @@
   },
   "definitions": {
     "Decimal": {
-      "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0 The greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
+      "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
       "type": "string"
     },
     "HumanAddr": {

--- a/contracts/mirror_gov/schema/migrate_msg.json
+++ b/contracts/mirror_gov/schema/migrate_msg.json
@@ -4,13 +4,29 @@
   "description": "Migrates the contract state, currently taking a state version argument",
   "type": "object",
   "required": [
-    "version"
+    "snapshot_period",
+    "version",
+    "voter_weight"
   ],
   "properties": {
+    "snapshot_period": {
+      "type": "integer",
+      "format": "uint64",
+      "minimum": 0.0
+    },
     "version": {
       "type": "integer",
       "format": "uint64",
       "minimum": 0.0
+    },
+    "voter_weight": {
+      "$ref": "#/definitions/Decimal"
+    }
+  },
+  "definitions": {
+    "Decimal": {
+      "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
+      "type": "string"
     }
   }
 }

--- a/contracts/mirror_gov/schema/poll_response.json
+++ b/contracts/mirror_gov/schema/poll_response.json
@@ -57,6 +57,16 @@
     "no_votes": {
       "$ref": "#/definitions/Uint128"
     },
+    "staked_amount": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/Uint128"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "status": {
       "$ref": "#/definitions/PollStatus"
     },

--- a/contracts/mirror_gov/src/staking.rs
+++ b/contracts/mirror_gov/src/staking.rs
@@ -29,11 +29,12 @@ pub fn stake_voting_tokens<S: Storage, A: Api, Q: Querier>(
     let mut state: State = state_store(&mut deps.storage).load()?;
 
     // balance already increased, so subtract deposit amount
+    let total_locked_balance = state.total_deposit + state.pending_voting_rewards;
     let total_balance = (load_token_balance(
         &deps,
         &deps.api.human_address(&config.mirror_token)?,
         &state.contract_addr,
-    )? - (state.total_deposit + amount))?;
+    )? - (total_locked_balance + amount))?;
 
     let share = if total_balance.is_zero() || state.total_share.is_zero() {
         amount

--- a/contracts/mirror_gov/src/state.rs
+++ b/contracts/mirror_gov/src/state.rs
@@ -28,6 +28,7 @@ pub struct Config {
     pub expiration_period: u64,
     pub proposal_deposit: Uint128,
     pub voter_weight: Decimal,
+    pub snapshot_period: u64,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
@@ -63,6 +64,7 @@ pub struct Poll {
     /// Total balance at the end poll
     pub total_balance_at_end_poll: Option<Uint128>,
     pub voters_reward: Uint128,
+    pub staked_amount: Option<Uint128>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/contracts/mirror_gov/tests/integration.rs
+++ b/contracts/mirror_gov/tests/integration.rs
@@ -60,6 +60,7 @@ const DEFAULT_EFFECTIVE_DELAY: u64 = 10000u64;
 const DEFAULT_EXPIRATION_PERIOD: u64 = 20000u64;
 const DEFAULT_PROPOSAL_DEPOSIT: u128 = 10000000000u128;
 const DEFAULT_VOTER_WEIGHT: u64 = 50u64;
+const DEFAULT_SNAPSHOT_PERIOD: u64 = 100u64;
 
 fn init_msg() -> InitMsg {
     InitMsg {
@@ -71,6 +72,7 @@ fn init_msg() -> InitMsg {
         expiration_period: DEFAULT_EXPIRATION_PERIOD,
         proposal_deposit: Uint128(DEFAULT_PROPOSAL_DEPOSIT),
         voter_weight: Decimal::percent(DEFAULT_VOTER_WEIGHT),
+        snapshot_period: DEFAULT_SNAPSHOT_PERIOD,
     }
 }
 
@@ -109,6 +111,7 @@ fn proper_initialization() {
                 expiration_period: DEFAULT_EXPIRATION_PERIOD,
                 proposal_deposit: Uint128(DEFAULT_PROPOSAL_DEPOSIT),
                 voter_weight: Decimal::percent(DEFAULT_VOTER_WEIGHT),
+                snapshot_period: DEFAULT_SNAPSHOT_PERIOD,
             }
         );
         Ok(())
@@ -138,6 +141,7 @@ fn update_config() {
         expiration_period: None,
         proposal_deposit: None,
         voter_weight: None,
+        snapshot_period: None,
     };
 
     let res: HandleResponse = handle(&mut deps, env, msg).unwrap();
@@ -162,7 +166,8 @@ fn update_config() {
         effective_delay: Some(20000u64),
         expiration_period: Some(30000u64),
         proposal_deposit: Some(Uint128(123u128)),
-        voter_weight: None,
+        voter_weight: Some(Decimal::percent(30u64)),
+        snapshot_period: Some(110u64),
     };
 
     let res: HandleResponse = handle(&mut deps, env, msg).unwrap();
@@ -176,6 +181,8 @@ fn update_config() {
     assert_eq!(Decimal::percent(75), config.threshold);
     assert_eq!(20000u64, config.voting_period);
     assert_eq!(123u128, config.proposal_deposit.u128());
+    assert_eq!(Decimal::percent(30u64), config.voter_weight);
+    assert_eq!(110u64, config.snapshot_period);
 
     // Unauthorized err
     let env = mock_env(TEST_CREATOR, &[]);
@@ -188,6 +195,7 @@ fn update_config() {
         expiration_period: None,
         proposal_deposit: None,
         voter_weight: None,
+        snapshot_period: None,
     };
 
     let res: HandleResult = handle(&mut deps, env, msg);

--- a/packages/mirror_protocol/src/gov.rs
+++ b/packages/mirror_protocol/src/gov.rs
@@ -16,6 +16,7 @@ pub struct InitMsg {
     pub expiration_period: u64,
     pub proposal_deposit: Uint128,
     pub voter_weight: Decimal,
+    pub snapshot_period: u64,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
@@ -31,6 +32,7 @@ pub enum HandleMsg {
         expiration_period: Option<u64>,
         proposal_deposit: Option<Uint128>,
         voter_weight: Option<Decimal>,
+        snapshot_period: Option<u64>,
     },
     CastVote {
         poll_id: u64,
@@ -48,6 +50,9 @@ pub enum HandleMsg {
         poll_id: u64,
     },
     ExpirePoll {
+        poll_id: u64,
+    },
+    SnapshotPoll {
         poll_id: u64,
     },
 }
@@ -112,6 +117,7 @@ pub struct ConfigResponse {
     pub expiration_period: u64,
     pub proposal_deposit: Uint128,
     pub voter_weight: Decimal,
+    pub snapshot_period: u64,
 }
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema)]
@@ -138,6 +144,7 @@ pub struct PollResponse {
     pub abstain_votes: Uint128, // balance
     pub total_balance_at_end_poll: Option<Uint128>,
     pub voters_reward: Uint128,
+    pub staked_amount: Option<Uint128>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema)]
@@ -174,6 +181,8 @@ pub struct VotersResponse {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct MigrateMsg {
     pub version: u64, // current contract migration state version
+    pub voter_weight: Decimal,
+    pub snapshot_period: u64,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]


### PR DESCRIPTION
### Overview

Added `SnapshotPoll` operation, same as in Anchor Protocol:
https://docs.anchorprotocol.com/smart-contracts/anchor-token/gov#snapshotpoll

Fixed an issue from #24. Pending voting rewards were not being subtracted from share calculation and quorum calculation.