### PR TITLE
feat: stake voting rewards + fix: return error when voting rewards is 0

### DIFF
--- a/contracts/mirror_gov/schema/handle_msg.json
+++ b/contracts/mirror_gov/schema/handle_msg.json
@@ -174,6 +174,17 @@
     {
       "type": "object",
       "required": [
+        "stake_voting_rewards"
+      ],
+      "properties": {
+        "stake_voting_rewards": {
+          "type": "object"
+        }
+      }
+    },
+    {
+      "type": "object",
+      "required": [
         "end_poll"
       ],
       "properties": {

--- a/contracts/mirror_gov/src/contract.rs
+++ b/contracts/mirror_gov/src/contract.rs
@@ -1,7 +1,7 @@
 use crate::querier::load_token_balance;
 use crate::staking::{
-    deposit_reward, query_staker, stake_voting_tokens, withdraw_voting_rewards,
-    withdraw_voting_tokens,
+    deposit_reward, query_staker, stake_voting_rewards, stake_voting_tokens,
+    withdraw_voting_rewards, withdraw_voting_tokens,
 };
 use crate::state::{
     bank_read, bank_store, config_read, config_store, poll_indexer_store, poll_read, poll_store,
@@ -96,6 +96,7 @@ pub fn handle<S: Storage, A: Api, Q: Querier>(
         ),
         HandleMsg::WithdrawVotingTokens { amount } => withdraw_voting_tokens(deps, env, amount),
         HandleMsg::WithdrawVotingRewards {} => withdraw_voting_rewards(deps, env),
+        HandleMsg::StakeVotingRewards {} => stake_voting_rewards(deps, env),
         HandleMsg::CastVote {
             poll_id,
             vote,

--- a/contracts/mirror_gov/src/tests.rs
+++ b/contracts/mirror_gov/src/tests.rs
@@ -2402,18 +2402,11 @@ fn distribute_voting_rewards() {
     let env = mock_env(VOTING_TOKEN.to_string(), &[]);
     let _res = handle(&mut deps, env, msg).unwrap();
 
-    // FAIL - there is no finished polls, so amount to withdraw is 0
+    // FAIL - there is no finished polls, amount to withdraw is 0, returning error
     let msg = HandleMsg::WithdrawVotingRewards {};
     let env = mock_env_height(TEST_VOTER, &[], 0, 10000);
-    let res = handle(&mut deps, env, msg).unwrap();
-    assert_eq!(
-        res.log,
-        vec![
-            log("action", "withdraw_voting_rewards"),
-            log("recipient", TEST_VOTER),
-            log("amount", 0),
-        ]
-    );
+    let res = handle(&mut deps, env, msg).unwrap_err();
+    assert_eq!(res, StdError::generic_err("Nothing to withdraw"));
 
     let env = mock_env_height(TEST_VOTER, &[], poll_end_height, 10000);
     let msg = HandleMsg::EndPoll { poll_id: 1 };
@@ -2458,6 +2451,155 @@ fn distribute_voting_rewards() {
             )
             .is_err(),
         true
+    );
+}
+
+#[test]
+fn stake_voting_rewards() {
+    let mut deps = mock_dependencies(20, &[]);
+    let msg = InitMsg {
+        mirror_token: HumanAddr::from(VOTING_TOKEN),
+        quorum: Decimal::percent(DEFAULT_QUORUM),
+        threshold: Decimal::percent(DEFAULT_THRESHOLD),
+        voting_period: DEFAULT_VOTING_PERIOD,
+        effective_delay: DEFAULT_EFFECTIVE_DELAY,
+        expiration_period: DEFAULT_EXPIRATION_PERIOD,
+        proposal_deposit: Uint128(DEFAULT_PROPOSAL_DEPOSIT),
+        voter_weight: Decimal::percent(50), // distribute 50% rewards to voters
+        snapshot_period: DEFAULT_SNAPSHOT_PERIOD,
+    };
+
+    let env = mock_env(TEST_CREATOR, &[]);
+    let _res = init(&mut deps, env, msg).expect("contract successfully handles InitMsg");
+
+    let env = mock_env_height(VOTING_TOKEN, &coins(2, VOTING_TOKEN), 0, 10000);
+    let poll_end_height = env.block.height.clone() + DEFAULT_VOTING_PERIOD;
+    let msg = create_poll_msg("test".to_string(), "test".to_string(), None, None);
+    let handle_res = handle(&mut deps, env.clone(), msg.clone()).unwrap();
+
+    assert_create_poll_result(
+        1,
+        env.block.height + DEFAULT_VOTING_PERIOD,
+        TEST_CREATOR,
+        handle_res,
+        &mut deps,
+    );
+
+    let stake_amount = 100u128;
+
+    deps.querier.with_token_balances(&[(
+        &HumanAddr::from(VOTING_TOKEN),
+        &[(
+            &HumanAddr::from(MOCK_CONTRACT_ADDR),
+            &Uint128((stake_amount + DEFAULT_PROPOSAL_DEPOSIT) as u128),
+        )],
+    )]);
+
+    let msg = HandleMsg::Receive(Cw20ReceiveMsg {
+        sender: HumanAddr::from(TEST_VOTER),
+        amount: Uint128::from(stake_amount),
+        msg: Some(to_binary(&Cw20HookMsg::StakeVotingTokens {}).unwrap()),
+    });
+
+    let env = mock_env(VOTING_TOKEN.to_string(), &[]);
+    let _res = handle(&mut deps, env, msg).unwrap();
+
+    let msg = HandleMsg::CastVote {
+        poll_id: 1,
+        vote: VoteOption::Yes,
+        amount: Uint128::from(stake_amount),
+    };
+    let env = mock_env_height(TEST_VOTER, &[], 0, 10000);
+    let _res = handle(&mut deps, env, msg).unwrap();
+
+    deps.querier.with_token_balances(&[(
+        &HumanAddr::from(VOTING_TOKEN),
+        &[(
+            &HumanAddr::from(MOCK_CONTRACT_ADDR),
+            &Uint128((stake_amount + DEFAULT_PROPOSAL_DEPOSIT + 100u128) as u128),
+        )],
+    )]);
+
+    let msg = HandleMsg::Receive(Cw20ReceiveMsg {
+        sender: HumanAddr::from(TEST_COLLECTOR),
+        amount: Uint128::from(100u128),
+        msg: Some(to_binary(&Cw20HookMsg::DepositReward {}).unwrap()),
+    });
+
+    let env = mock_env(VOTING_TOKEN.to_string(), &[]);
+    let _res = handle(&mut deps, env, msg).unwrap();
+
+    // FAIL - there is no finished polls, amount to withdraw is 0, returning error
+    let msg = HandleMsg::StakeVotingRewards {};
+    let env = mock_env_height(TEST_VOTER, &[], 0, 10000);
+    let res = handle(&mut deps, env, msg).unwrap_err();
+    assert_eq!(res, StdError::generic_err("Nothing to withdraw"));
+
+    let env = mock_env_height(TEST_VOTER, &[], poll_end_height, 10000);
+    let msg = HandleMsg::EndPoll { poll_id: 1 };
+    let _res = handle(&mut deps, env.clone(), msg).unwrap();
+
+    deps.querier.with_token_balances(&[(
+        &HumanAddr::from(VOTING_TOKEN),
+        &[(
+            &HumanAddr::from(MOCK_CONTRACT_ADDR),
+            &Uint128((stake_amount + 100u128) as u128),
+        )],
+    )]);
+
+    // SUCCESS
+    let msg = HandleMsg::StakeVotingRewards {};
+    let env = mock_env_height(TEST_VOTER, &[], 0, 10000);
+    let res = handle(&mut deps, env.clone(), msg).unwrap();
+
+    // user can stake 50% of the deposited reward (weight = 50% poll share = 100%)
+    assert_eq!(
+        res.log,
+        vec![
+            log("action", "stake_voting_rewards"),
+            log("staker", TEST_VOTER),
+            log("share", 33),
+            log("amount", 50),
+        ]
+    );
+    assert_eq!(res.messages, vec![]);
+
+    // FAIL - already withdrawn
+    let msg = HandleMsg::StakeVotingRewards {};
+    let env = mock_env_height(TEST_VOTER, &[], 0, 10000);
+    let res = handle(&mut deps, env, msg).unwrap_err();
+    assert_eq!(res, StdError::generic_err("Nothing to withdraw"));
+
+    // voting info has been deleted
+    assert_eq!(
+        poll_voter_read(&deps.storage, 1u64)
+            .load(
+                &deps
+                    .api
+                    .canonical_address(&HumanAddr::from(TEST_VOTER))
+                    .unwrap()
+                    .as_slice()
+            )
+            .is_err(),
+        true
+    );
+
+    let res = query(
+        &deps,
+        QueryMsg::Staker {
+            address: HumanAddr::from(TEST_VOTER),
+        },
+    )
+    .unwrap();
+    let response: StakerResponse = from_binary(&res).unwrap();
+    assert_eq!(
+        response,
+        StakerResponse {
+            balance: Uint128(stake_amount + 100u128),
+            share: Uint128(stake_amount + 33u128),
+            locked_balance: vec![],
+            pending_voting_rewards: Uint128(0u128),
+        }
     );
 }
 

--- a/packages/mirror_protocol/src/gov.rs
+++ b/packages/mirror_protocol/src/gov.rs
@@ -43,6 +43,7 @@ pub enum HandleMsg {
         amount: Option<Uint128>,
     },
     WithdrawVotingRewards {},
+    StakeVotingRewards {},
     EndPoll {
         poll_id: u64,
     },


### PR DESCRIPTION
### Overview:

The following changes only affect **gov contract**.

- [FEATURE] Re-stake withdrawn voting rewards: new operation to be able to re-stake the claimed rewards. This has the same functionality as `WithdrawVotingRewards`, but instead of sending the rewards back to the user, it adds them to the staking pool, increasing the user staking share

- [FIX] Return error when voting reward amount is 0: When user does not have any pending voting rewards, return error to prevent having a send msg with amount = 0.