### PR TITLE
[Feature] Improvements to collaterals

### DIFF
--- a/contracts/mirror_collateral_oracle/schema/collateral_info_response.json
+++ b/contracts/mirror_collateral_oracle/schema/collateral_info_response.json
@@ -5,6 +5,7 @@
   "required": [
     "asset",
     "collateral_premium",
+    "is_revoked",
     "query_request"
   ],
   "properties": {
@@ -13,6 +14,9 @@
     },
     "collateral_premium": {
       "$ref": "#/definitions/Decimal"
+    },
+    "is_revoked": {
+      "type": "boolean"
     },
     "query_request": {
       "$ref": "#/definitions/WasmQuery"
@@ -24,7 +28,7 @@
       "type": "string"
     },
     "Decimal": {
-      "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0 The greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
+      "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
       "type": "string"
     },
     "HumanAddr": {

--- a/contracts/mirror_collateral_oracle/schema/collateral_infos_response.json
+++ b/contracts/mirror_collateral_oracle/schema/collateral_infos_response.json
@@ -23,6 +23,7 @@
       "required": [
         "asset",
         "collateral_premium",
+        "is_revoked",
         "query_request"
       ],
       "properties": {
@@ -32,13 +33,16 @@
         "collateral_premium": {
           "$ref": "#/definitions/Decimal"
         },
+        "is_revoked": {
+          "type": "boolean"
+        },
         "query_request": {
           "$ref": "#/definitions/WasmQuery"
         }
       }
     },
     "Decimal": {
-      "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0 The greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
+      "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
       "type": "string"
     },
     "HumanAddr": {

--- a/contracts/mirror_collateral_oracle/schema/collateral_price_response.json
+++ b/contracts/mirror_collateral_oracle/schema/collateral_price_response.json
@@ -5,6 +5,7 @@
   "required": [
     "asset",
     "collateral_premium",
+    "is_revoked",
     "rate"
   ],
   "properties": {
@@ -14,13 +15,16 @@
     "collateral_premium": {
       "$ref": "#/definitions/Decimal"
     },
+    "is_revoked": {
+      "type": "boolean"
+    },
     "rate": {
       "$ref": "#/definitions/Decimal"
     }
   },
   "definitions": {
     "Decimal": {
-      "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0 The greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
+      "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
       "type": "string"
     }
   }

--- a/contracts/mirror_collateral_oracle/schema/config_response.json
+++ b/contracts/mirror_collateral_oracle/schema/config_response.json
@@ -4,11 +4,19 @@
   "type": "object",
   "required": [
     "base_denom",
+    "factory_contract",
+    "mint_contract",
     "owner"
   ],
   "properties": {
     "base_denom": {
       "type": "string"
+    },
+    "factory_contract": {
+      "$ref": "#/definitions/HumanAddr"
+    },
+    "mint_contract": {
+      "$ref": "#/definitions/HumanAddr"
     },
     "owner": {
       "$ref": "#/definitions/HumanAddr"

--- a/contracts/mirror_collateral_oracle/schema/handle_msg.json
+++ b/contracts/mirror_collateral_oracle/schema/handle_msg.json
@@ -17,6 +17,26 @@
                 "null"
               ]
             },
+            "factory_contract": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/HumanAddr"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "mint_contract": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/HumanAddr"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
             "owner": {
               "anyOf": [
                 {
@@ -61,10 +81,10 @@
     {
       "type": "object",
       "required": [
-        "update_collateral_asset"
+        "revoke_collateral_asset"
       ],
       "properties": {
-        "update_collateral_asset": {
+        "revoke_collateral_asset": {
           "type": "object",
           "required": [
             "asset"
@@ -72,26 +92,52 @@
           "properties": {
             "asset": {
               "$ref": "#/definitions/AssetInfo"
-            },
-            "collateral_premium": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/Decimal"
-                },
-                {
-                  "type": "null"
-                }
-              ]
+            }
+          }
+        }
+      }
+    },
+    {
+      "type": "object",
+      "required": [
+        "update_collateral_query"
+      ],
+      "properties": {
+        "update_collateral_query": {
+          "type": "object",
+          "required": [
+            "asset",
+            "query_request"
+          ],
+          "properties": {
+            "asset": {
+              "$ref": "#/definitions/AssetInfo"
             },
             "query_request": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/Binary"
-                },
-                {
-                  "type": "null"
-                }
-              ]
+              "$ref": "#/definitions/Binary"
+            }
+          }
+        }
+      }
+    },
+    {
+      "type": "object",
+      "required": [
+        "update_collateral_premium"
+      ],
+      "properties": {
+        "update_collateral_premium": {
+          "type": "object",
+          "required": [
+            "asset",
+            "collateral_premium"
+          ],
+          "properties": {
+            "asset": {
+              "$ref": "#/definitions/AssetInfo"
+            },
+            "collateral_premium": {
+              "$ref": "#/definitions/Decimal"
             }
           }
         }
@@ -146,7 +192,7 @@
       "type": "string"
     },
     "Decimal": {
-      "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0 The greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
+      "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
       "type": "string"
     },
     "HumanAddr": {

--- a/contracts/mirror_collateral_oracle/schema/init_msg.json
+++ b/contracts/mirror_collateral_oracle/schema/init_msg.json
@@ -4,11 +4,19 @@
   "type": "object",
   "required": [
     "base_denom",
+    "factory_contract",
+    "mint_contract",
     "owner"
   ],
   "properties": {
     "base_denom": {
       "type": "string"
+    },
+    "factory_contract": {
+      "$ref": "#/definitions/HumanAddr"
+    },
+    "mint_contract": {
+      "$ref": "#/definitions/HumanAddr"
     },
     "owner": {
       "$ref": "#/definitions/HumanAddr"

--- a/contracts/mirror_collateral_oracle/src/contract.rs
+++ b/contracts/mirror_collateral_oracle/src/contract.rs
@@ -117,12 +117,7 @@ pub fn register_collateral<S: Storage, A: Api, Q: Querier>(
         return Err(StdError::unauthorized());
     }
 
-    let collateral_id: String = match asset {
-        AssetInfo::NativeToken { denom } => denom,
-        AssetInfo::Token { contract_addr } => contract_addr.to_string(),
-    };
-
-    if read_collateral_info(&deps.storage, &collateral_id).is_ok() {
+    if read_collateral_info(&deps.storage, &asset.to_string()).is_ok() {
         return Err(StdError::generic_err("Collateral was already registered"));
     }
 
@@ -136,7 +131,7 @@ pub fn register_collateral<S: Storage, A: Api, Q: Querier>(
     store_collateral_info(
         &mut deps.storage,
         &CollateralAssetInfo {
-            asset: collateral_id,
+            asset: asset.to_string(),
             collateral_premium,
             query_request,
             is_revoked: false,
@@ -158,13 +153,8 @@ pub fn revoke_collateral<S: Storage, A: Api, Q: Querier>(
         return Err(StdError::unauthorized());
     }
 
-    let collateral_id: String = match asset {
-        AssetInfo::NativeToken { denom } => denom,
-        AssetInfo::Token { contract_addr } => contract_addr.to_string(),
-    };
-
-    let mut collateral_info =
-        if let Ok(collateral) = read_collateral_info(&deps.storage, &collateral_id) {
+    let mut collateral_info: CollateralAssetInfo =
+        if let Ok(collateral) = read_collateral_info(&deps.storage, &asset.to_string()) {
             collateral
         } else {
             return Err(StdError::generic_err("Collateral not found"));
@@ -190,13 +180,8 @@ pub fn update_collateral_query<S: Storage, A: Api, Q: Querier>(
         return Err(StdError::unauthorized());
     }
 
-    let collateral_id: String = match asset {
-        AssetInfo::NativeToken { denom } => denom,
-        AssetInfo::Token { contract_addr } => contract_addr.to_string(),
-    };
-
-    let mut collateral_info =
-        if let Ok(collateral) = read_collateral_info(&deps.storage, &collateral_id) {
+    let mut collateral_info: CollateralAssetInfo =
+        if let Ok(collateral) = read_collateral_info(&deps.storage, &asset.to_string()) {
             collateral
         } else {
             return Err(StdError::generic_err("Collateral not found"));
@@ -228,13 +213,8 @@ pub fn update_collateral_premium<S: Storage, A: Api, Q: Querier>(
         return Err(StdError::unauthorized());
     }
 
-    let collateral_id: String = match asset {
-        AssetInfo::NativeToken { denom } => denom,
-        AssetInfo::Token { contract_addr } => contract_addr.to_string(),
-    };
-
-    let mut collateral_info =
-        if let Ok(collateral) = read_collateral_info(&deps.storage, &collateral_id) {
+    let mut collateral_info: CollateralAssetInfo =
+        if let Ok(collateral) = read_collateral_info(&deps.storage, &asset.to_string()) {
             collateral
         } else {
             return Err(StdError::generic_err("Collateral not found"));

--- a/contracts/mirror_collateral_oracle/src/contract.rs
+++ b/contracts/mirror_collateral_oracle/src/contract.rs
@@ -4,9 +4,9 @@ use crate::state::{
     CollateralAssetInfo, Config,
 };
 use cosmwasm_std::{
-    from_binary, to_binary, Api, Binary, Decimal, Env, Extern, HandleResponse, HandleResult,
-    HumanAddr, InitResponse, MigrateResponse, MigrateResult, Querier, StdError, StdResult, Storage,
-    WasmQuery,
+    from_binary, to_binary, Api, Binary, CanonicalAddr, Decimal, Env, Extern, HandleResponse,
+    HandleResult, HumanAddr, InitResponse, MigrateResponse, MigrateResult, Querier, StdError,
+    StdResult, Storage, WasmQuery,
 };
 
 use mirror_protocol::collateral_oracle::{
@@ -25,6 +25,8 @@ pub fn init<S: Storage, A: Api, Q: Querier>(
         &mut deps.storage,
         &Config {
             owner: deps.api.canonical_address(&msg.owner)?,
+            mint_contract: deps.api.canonical_address(&msg.mint_contract)?,
+            factory_contract: deps.api.canonical_address(&msg.factory_contract)?,
             base_denom: msg.base_denom,
         },
     )?;
@@ -38,19 +40,33 @@ pub fn handle<S: Storage, A: Api, Q: Querier>(
     msg: HandleMsg,
 ) -> HandleResult {
     match msg {
-        HandleMsg::UpdateConfig { owner, base_denom } => {
-            update_config(deps, env, owner, base_denom)
-        }
+        HandleMsg::UpdateConfig {
+            owner,
+            mint_contract,
+            factory_contract,
+            base_denom,
+        } => update_config(
+            deps,
+            env,
+            owner,
+            mint_contract,
+            factory_contract,
+            base_denom,
+        ),
         HandleMsg::RegisterCollateralAsset {
             asset,
             query_request,
             collateral_premium,
         } => register_collateral(deps, env, asset, query_request, collateral_premium),
-        HandleMsg::UpdateCollateralAsset {
+        HandleMsg::RevokeCollateralAsset { asset } => revoke_collateral(deps, env, asset),
+        HandleMsg::UpdateCollateralQuery {
             asset,
             query_request,
+        } => update_collateral_query(deps, env, asset, query_request),
+        HandleMsg::UpdateCollateralPremium {
+            asset,
             collateral_premium,
-        } => update_collateral(deps, env, asset, query_request, collateral_premium),
+        } => update_collateral_premium(deps, env, asset, collateral_premium),
     }
 }
 
@@ -58,6 +74,8 @@ pub fn update_config<S: Storage, A: Api, Q: Querier>(
     deps: &mut Extern<S, A, Q>,
     env: Env,
     owner: Option<HumanAddr>,
+    mint_contract: Option<HumanAddr>,
+    factory_contract: Option<HumanAddr>,
     base_denom: Option<String>,
 ) -> HandleResult {
     let mut config: Config = read_config(&deps.storage)?;
@@ -67,6 +85,14 @@ pub fn update_config<S: Storage, A: Api, Q: Querier>(
 
     if let Some(owner) = owner {
         config.owner = deps.api.canonical_address(&owner)?;
+    }
+
+    if let Some(mint_contract) = mint_contract {
+        config.mint_contract = deps.api.canonical_address(&mint_contract)?;
+    }
+
+    if let Some(factory_contract) = factory_contract {
+        config.factory_contract = deps.api.canonical_address(&factory_contract)?;
     }
 
     if let Some(base_denom) = base_denom {
@@ -85,8 +111,9 @@ pub fn register_collateral<S: Storage, A: Api, Q: Querier>(
     collateral_premium: Decimal,
 ) -> HandleResult {
     let config: Config = read_config(&deps.storage)?;
-    // only contract onwner can register a new collateral
-    if config.owner != deps.api.canonical_address(&env.message.sender)? {
+    let sender_address_raw: CanonicalAddr = deps.api.canonical_address(&env.message.sender)?;
+    // only contract onwner and mint contract can register a new collateral
+    if config.owner != sender_address_raw && config.mint_contract != sender_address_raw {
         return Err(StdError::unauthorized());
     }
 
@@ -112,22 +139,22 @@ pub fn register_collateral<S: Storage, A: Api, Q: Querier>(
             asset: collateral_id,
             collateral_premium,
             query_request,
+            is_revoked: false,
         },
     )?;
 
     Ok(HandleResponse::default())
 }
 
-pub fn update_collateral<S: Storage, A: Api, Q: Querier>(
+pub fn revoke_collateral<S: Storage, A: Api, Q: Querier>(
     deps: &mut Extern<S, A, Q>,
     env: Env,
     asset: AssetInfo,
-    query_request: Option<Binary>,
-    collateral_premium: Option<Decimal>,
 ) -> HandleResult {
     let config: Config = read_config(&deps.storage)?;
-    // only contract onwner can update collaterals
-    if config.owner != deps.api.canonical_address(&env.message.sender)? {
+    let sender_address_raw: CanonicalAddr = deps.api.canonical_address(&env.message.sender)?;
+    // only owner and mint contract can revoke a collateral assets
+    if config.owner != sender_address_raw && config.mint_contract != sender_address_raw {
         return Err(StdError::unauthorized());
     }
 
@@ -143,20 +170,77 @@ pub fn update_collateral<S: Storage, A: Api, Q: Querier>(
             return Err(StdError::generic_err("Collateral not found"));
         };
 
-    if let Some(query_request) = query_request {
-        // test the query request
-        if query_price(&deps, query_request.clone(), config.base_denom).is_err() {
-            return Err(StdError::generic_err(
-                "The query request provided is not valid",
-            ));
-        }
-        collateral_info.query_request = query_request;
+    collateral_info.is_revoked = true;
+
+    store_collateral_info(&mut deps.storage, &collateral_info)?;
+
+    Ok(HandleResponse::default())
+}
+
+pub fn update_collateral_query<S: Storage, A: Api, Q: Querier>(
+    deps: &mut Extern<S, A, Q>,
+    env: Env,
+    asset: AssetInfo,
+    query_request: Binary,
+) -> HandleResult {
+    let config: Config = read_config(&deps.storage)?;
+    let sender_address_raw: CanonicalAddr = deps.api.canonical_address(&env.message.sender)?;
+    // only contract onwner can update collateral query
+    if config.owner != sender_address_raw {
+        return Err(StdError::unauthorized());
     }
 
-    if let Some(collateral_premium) = collateral_premium {
-        collateral_info.collateral_premium = collateral_premium;
+    let collateral_id: String = match asset {
+        AssetInfo::NativeToken { denom } => denom,
+        AssetInfo::Token { contract_addr } => contract_addr.to_string(),
+    };
+
+    let mut collateral_info =
+        if let Ok(collateral) = read_collateral_info(&deps.storage, &collateral_id) {
+            collateral
+        } else {
+            return Err(StdError::generic_err("Collateral not found"));
+        };
+
+    // test the query request
+    if query_price(&deps, query_request.clone(), config.base_denom).is_err() {
+        return Err(StdError::generic_err(
+            "The query request provided is not valid",
+        ));
+    }
+    collateral_info.query_request = query_request;
+
+    store_collateral_info(&mut deps.storage, &collateral_info)?;
+
+    Ok(HandleResponse::default())
+}
+
+pub fn update_collateral_premium<S: Storage, A: Api, Q: Querier>(
+    deps: &mut Extern<S, A, Q>,
+    env: Env,
+    asset: AssetInfo,
+    collateral_premium: Decimal,
+) -> HandleResult {
+    let config: Config = read_config(&deps.storage)?;
+    let sender_address_raw: CanonicalAddr = deps.api.canonical_address(&env.message.sender)?;
+    // only factory contract can update collateral premium
+    if config.factory_contract != sender_address_raw {
+        return Err(StdError::unauthorized());
     }
 
+    let collateral_id: String = match asset {
+        AssetInfo::NativeToken { denom } => denom,
+        AssetInfo::Token { contract_addr } => contract_addr.to_string(),
+    };
+
+    let mut collateral_info =
+        if let Ok(collateral) = read_collateral_info(&deps.storage, &collateral_id) {
+            collateral
+        } else {
+            return Err(StdError::generic_err("Collateral not found"));
+        };
+
+    collateral_info.collateral_premium = collateral_premium;
     store_collateral_info(&mut deps.storage, &collateral_info)?;
 
     Ok(HandleResponse::default())
@@ -180,6 +264,8 @@ pub fn query_config<S: Storage, A: Api, Q: Querier>(
     let config = read_config(&deps.storage)?;
     let resp = ConfigResponse {
         owner: deps.api.human_address(&config.owner)?,
+        mint_contract: deps.api.human_address(&config.mint_contract)?,
+        factory_contract: deps.api.human_address(&config.factory_contract)?,
         base_denom: config.base_denom,
     };
 
@@ -205,6 +291,7 @@ pub fn query_collateral_price<S: Storage, A: Api, Q: Querier>(
         asset: collateral.asset,
         rate: price,
         collateral_premium: collateral.collateral_premium,
+        is_revoked: collateral.is_revoked,
     })
 }
 
@@ -225,6 +312,7 @@ pub fn query_collateral_info<S: Storage, A: Api, Q: Querier>(
         asset: collateral.asset,
         query_request: wasm_query,
         collateral_premium: collateral.collateral_premium,
+        is_revoked: collateral.is_revoked,
     })
 }
 

--- a/contracts/mirror_collateral_oracle/src/mock_querier.rs
+++ b/contracts/mirror_collateral_oracle/src/mock_querier.rs
@@ -1,6 +1,6 @@
 use cosmwasm_std::testing::{MockApi, MockQuerier, MockStorage, MOCK_CONTRACT_ADDR};
 use cosmwasm_std::{
-    from_binary, from_slice, to_binary, Api, Coin, Decimal, Empty, Extern, HumanAddr, Querier,
+    from_binary, from_slice, to_binary, Coin, Decimal, Empty, Extern, HumanAddr, Querier,
     QuerierResult, QueryRequest, SystemError, Uint128, WasmQuery,
 };
 use schemars::JsonSchema;
@@ -19,11 +19,8 @@ pub fn mock_dependencies(
     contract_balance: &[Coin],
 ) -> Extern<MockStorage, MockApi, WasmMockQuerier> {
     let contract_addr = HumanAddr::from(MOCK_CONTRACT_ADDR);
-    let custom_querier: WasmMockQuerier = WasmMockQuerier::new(
-        MockQuerier::new(&[(&contract_addr, contract_balance)]),
-        MockApi::new(canonical_length),
-        canonical_length,
-    );
+    let custom_querier: WasmMockQuerier =
+        WasmMockQuerier::new(MockQuerier::new(&[(&contract_addr, contract_balance)]));
 
     Extern {
         storage: MockStorage::default(),
@@ -36,7 +33,6 @@ pub struct WasmMockQuerier {
     base: MockQuerier<Empty>,
     oracle_price_querier: OraclePriceQuerier,
     terraswap_pools_querier: TerraswapPoolsQuerier,
-    canonical_length: usize,
 }
 
 #[derive(Clone, Default)]
@@ -171,12 +167,11 @@ impl WasmMockQuerier {
 }
 
 impl WasmMockQuerier {
-    pub fn new<A: Api>(base: MockQuerier<Empty>, _api: A, canonical_length: usize) -> Self {
+    pub fn new(base: MockQuerier<Empty>) -> Self {
         WasmMockQuerier {
             base,
             oracle_price_querier: OraclePriceQuerier::default(),
             terraswap_pools_querier: TerraswapPoolsQuerier::default(),
-            canonical_length,
         }
     }
 

--- a/contracts/mirror_collateral_oracle/src/state.rs
+++ b/contracts/mirror_collateral_oracle/src/state.rs
@@ -14,6 +14,8 @@ static KEY_CONFIG: &[u8] = b"config";
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct Config {
     pub owner: CanonicalAddr,
+    pub mint_contract: CanonicalAddr,
+    pub factory_contract: CanonicalAddr,
     pub base_denom: String,
 }
 
@@ -30,6 +32,7 @@ pub struct CollateralAssetInfo {
     pub asset: String,
     pub query_request: Binary,
     pub collateral_premium: Decimal,
+    pub is_revoked: bool,
 }
 
 pub fn store_collateral_info<S: Storage>(
@@ -63,6 +66,7 @@ pub fn read_collateral_infos<S: Storage>(storage: &S) -> StdResult<Vec<Collatera
                 asset: v.asset,
                 query_request: wasm_query,
                 collateral_premium: v.collateral_premium,
+                is_revoked: v.is_revoked,
             })
         })
         .collect()

--- a/contracts/mirror_collateral_oracle/tests/integration.rs
+++ b/contracts/mirror_collateral_oracle/tests/integration.rs
@@ -28,7 +28,7 @@ use mirror_protocol::collateral_oracle::{ConfigResponse, HandleMsg, InitMsg, Que
 
 // This line will test the output of cargo wasm
 static WASM: &[u8] =
-    include_bytes!("../../../target/wasm32-unknown-unknown/release/mirror_collaterals.wasm");
+    include_bytes!("../../../target/wasm32-unknown-unknown/release/mirror_collateral_oracle.wasm");
 // You can uncomment this line instead to test productionified build from rust-optimizer
 // static WASM: &[u8] = include_bytes!("../contract.wasm");
 
@@ -51,6 +51,9 @@ fn proper_initialization() {
 
     let msg = InitMsg {
         owner: HumanAddr::from("owner0000"),
+        mint_contract: HumanAddr("mint0000".to_string()),
+        factory_contract: HumanAddr("factory0000".to_string()),
+        base_denom: "uusd".to_string(),
     };
 
     let env = mock_env("addr0000", &[]);
@@ -69,7 +72,10 @@ fn proper_initialization() {
 fn update_owner() {
     let mut deps = mock_instance(WASM, &[]);
     let msg = InitMsg {
-        owner: HumanAddr("owner0000".to_string()),
+        owner: HumanAddr::from("owner0000"),
+        mint_contract: HumanAddr("mint0000".to_string()),
+        factory_contract: HumanAddr("factory0000".to_string()),
+        base_denom: "uusd".to_string(),
     };
 
     let env = mock_env("addr0000", &[]);
@@ -80,6 +86,9 @@ fn update_owner() {
     let env = mock_env("owner0000", &[]);
     let msg = HandleMsg::UpdateConfig {
         owner: Some(HumanAddr("owner0001".to_string())),
+        mint_contract: Some(HumanAddr("mint0000".to_string())),
+        factory_contract: Some(HumanAddr("factory0000".to_string())),
+        base_denom: Some("uusd".to_string()),
     };
 
     let res: HandleResponse = handle(&mut deps, env, msg).unwrap();
@@ -89,10 +98,18 @@ fn update_owner() {
     let query_result = query(&mut deps, QueryMsg::Config {}).unwrap();
     let value: ConfigResponse = from_binary(&query_result).unwrap();
     assert_eq!("owner0001", value.owner.as_str());
+    assert_eq!("mint0000", value.mint_contract.as_str());
+    assert_eq!("factory0000", value.factory_contract.as_str());
+    assert_eq!("uusd", value.base_denom.as_str());
 
     // Unauthorzied err
     let env = mock_env("addr0000", &[]);
-    let msg = HandleMsg::UpdateConfig { owner: None };
+    let msg = HandleMsg::UpdateConfig {
+        owner: None,
+        mint_contract: None,
+        factory_contract: None,
+        base_denom: None,
+    };
 
     let res: HandleResult = handle(&mut deps, env, msg);
     match res.unwrap_err() {

--- a/contracts/mirror_mint/src/asserts.rs
+++ b/contracts/mirror_mint/src/asserts.rs
@@ -42,6 +42,18 @@ pub fn assert_migrated_asset(asset_config: &AssetConfig) -> StdResult<()> {
     Ok(())
 }
 
+pub fn assert_revoked_collateral(
+    load_collateral_res: (Decimal, Decimal, bool),
+) -> StdResult<(Decimal, Decimal)> {
+    if load_collateral_res.2 {
+        return Err(StdError::generic_err(
+            "The collateral asset provided is no longer valid",
+        ));
+    }
+
+    Ok((load_collateral_res.0, load_collateral_res.1))
+}
+
 pub fn assert_auction_discount(auction_discount: Decimal) -> StdResult<()> {
     if auction_discount > Decimal::one() {
         Err(StdError::generic_err(

--- a/contracts/mirror_mint/src/contract.rs
+++ b/contracts/mirror_mint/src/contract.rs
@@ -1,7 +1,7 @@
 use cosmwasm_std::{
-    from_binary, log, to_binary, Api, Binary, Decimal, Env, Extern, HandleResponse, HandleResult,
-    HumanAddr, InitResponse, MigrateResponse, MigrateResult, Querier, StdError, StdResult, Storage,
-    Uint128,
+    from_binary, log, to_binary, Api, Binary, CosmosMsg, Decimal, Env, Extern, HandleResponse,
+    HandleResult, HumanAddr, InitResponse, MigrateResponse, MigrateResult, Querier, StdError,
+    StdResult, Storage, Uint128, WasmMsg, WasmQuery,
 };
 
 use crate::{
@@ -18,9 +18,11 @@ use crate::{
 };
 
 use cw20::Cw20ReceiveMsg;
+use mirror_protocol::collateral_oracle::HandleMsg as CollateralOracleHandleMsg;
 use mirror_protocol::mint::{
     AssetConfigResponse, ConfigResponse, Cw20HookMsg, HandleMsg, InitMsg, MigrateMsg, QueryMsg,
 };
+use mirror_protocol::oracle::QueryMsg as OracleQueryMsg;
 use terraswap::asset::{Asset, AssetInfo};
 
 pub fn init<S: Storage, A: Api, Q: Querier>(
@@ -317,8 +319,25 @@ pub fn register_asset<S: Storage, A: Api, Q: Querier>(
         },
     )?;
 
+    // register the new asset as collateral in collateral oracle
     Ok(HandleResponse {
-        messages: vec![],
+        messages: vec![CosmosMsg::Wasm(WasmMsg::Execute {
+            contract_addr: deps.api.human_address(&config.collateral_oracle)?,
+            send: vec![],
+            msg: to_binary(&CollateralOracleHandleMsg::RegisterCollateralAsset {
+                asset: AssetInfo::Token {
+                    contract_addr: asset_token.clone(),
+                },
+                collateral_premium: Decimal::zero(), // default collateral premium for new mAssets
+                query_request: to_binary(&WasmQuery::Smart {
+                    contract_addr: deps.api.human_address(&config.oracle)?,
+                    msg: to_binary(&OracleQueryMsg::Price {
+                        base_asset: config.base_denom,
+                        quote_asset: asset_token.to_string(),
+                    })?,
+                })?,
+            })?,
+        })],
         log: vec![log("action", "register"), log("asset_token", asset_token)],
         data: None,
     })
@@ -350,8 +369,17 @@ pub fn register_migration<S: Storage, A: Api, Q: Querier>(
         },
     )?;
 
+    // flag asset as revoked in the collateral oracle
     Ok(HandleResponse {
-        messages: vec![],
+        messages: vec![CosmosMsg::Wasm(WasmMsg::Execute {
+            contract_addr: deps.api.human_address(&config.collateral_oracle)?,
+            send: vec![],
+            msg: to_binary(&CollateralOracleHandleMsg::RevokeCollateralAsset {
+                asset: AssetInfo::Token {
+                    contract_addr: asset_token.clone(),
+                },
+            })?,
+        })],
         log: vec![
             log("action", "migrate_asset"),
             log("asset_token", asset_token.as_str()),

--- a/contracts/mirror_mint/src/migrated_asset_test.rs
+++ b/contracts/mirror_mint/src/migrated_asset_test.rs
@@ -8,6 +8,7 @@ mod tests {
         StdError, Uint128, WasmMsg,
     };
     use cw20::{Cw20HandleMsg, Cw20ReceiveMsg};
+    use mirror_protocol::collateral_oracle::HandleMsg::RevokeCollateralAsset;
     use mirror_protocol::mint::{
         AssetConfigResponse, Cw20HookMsg, HandleMsg, InitMsg, PositionResponse, PositionsResponse,
         QueryMsg,
@@ -103,6 +104,19 @@ mod tests {
                 log("end_price", "0.5"),
             ]
         );
+        assert_eq!(
+            res.messages,
+            vec![CosmosMsg::Wasm(WasmMsg::Execute {
+                contract_addr: HumanAddr::from("collateraloracle0000"),
+                send: vec![],
+                msg: to_binary(&RevokeCollateralAsset {
+                    asset: AssetInfo::Token {
+                        contract_addr: HumanAddr::from("asset0000"),
+                    },
+                })
+                .unwrap(),
+            })]
+        );
 
         let res = query(
             &deps,
@@ -143,6 +157,7 @@ mod tests {
             &"asset0000".to_string(),
             &Decimal::percent(100),
             &Decimal::zero(),
+            &false,
         )]);
 
         let base_denom = "uusd".to_string();
@@ -251,27 +266,33 @@ mod tests {
         let res = handle(&mut deps, env, msg).unwrap_err();
         match res {
             StdError::GenericErr { msg, .. } => {
-                assert_eq!(msg, "Operation is not allowed for the deprecated asset")
+                assert_eq!(msg, "The collateral asset provided is no longer valid")
             }
             _ => panic!("DO NOT ENTER HERE"),
         }
 
         // cannot open a deprecated asset position
-        let msg = HandleMsg::Receive(Cw20ReceiveMsg {
-            msg: Some(
-                to_binary(&Cw20HookMsg::OpenPosition {
-                    asset_info: AssetInfo::Token {
-                        contract_addr: HumanAddr::from("asset0000"),
-                    },
-                    collateral_ratio: Decimal::percent(150),
-                    short_params: None,
-                })
-                .unwrap(),
-            ),
-            sender: HumanAddr::from("addr0001"),
-            amount: Uint128(1000000u128),
-        });
-        let env = mock_env_with_block_time("asset0000", &[], 1000);
+        let msg = HandleMsg::OpenPosition {
+            collateral: Asset {
+                info: AssetInfo::NativeToken {
+                    denom: "uusd".to_string(),
+                },
+                amount: Uint128(100u128),
+            },
+            asset_info: AssetInfo::Token {
+                contract_addr: HumanAddr::from("asset0000"),
+            },
+            collateral_ratio: Decimal::percent(150),
+            short_params: None,
+        };
+        let env = mock_env_with_block_time(
+            "addr0000",
+            &[Coin {
+                amount: Uint128(100u128),
+                denom: "uusd".to_string(),
+            }],
+            1000,
+        );
         let res = handle(&mut deps, env, msg).unwrap_err();
         match res {
             StdError::GenericErr { msg, .. } => {
@@ -305,7 +326,7 @@ mod tests {
             _ => panic!("DO NOT ENTER HERE"),
         }
 
-        // cannot do deposit more collateral to the deprecated asset position
+        // cannot deposit more collateral to the deprecated collateral position
         let msg = HandleMsg::Receive(Cw20ReceiveMsg {
             msg: Some(
                 to_binary(&Cw20HookMsg::Deposit {
@@ -320,7 +341,7 @@ mod tests {
         let res = handle(&mut deps, env, msg).unwrap_err();
         match res {
             StdError::GenericErr { msg, .. } => {
-                assert_eq!(msg, "Operation is not allowed for the deprecated asset")
+                assert_eq!(msg, "The collateral asset provided is no longer valid")
             }
             _ => panic!("DO NOT ENTER HERE"),
         }
@@ -345,7 +366,7 @@ mod tests {
             _ => panic!("DO NOT ENTER HERE"),
         }
 
-        // cannot mint more the asset with deprecated position
+        // cannot mint more asset with deprecated collateral
         let msg = HandleMsg::Mint {
             position_idx: Uint128(2u128),
             asset: Asset {
@@ -360,7 +381,7 @@ mod tests {
         let res = handle(&mut deps, env, msg).unwrap_err();
         match res {
             StdError::GenericErr { msg, .. } => {
-                assert_eq!(msg, "Operation is not allowed for the deprecated asset")
+                assert_eq!(msg, "The collateral asset provided is no longer valid")
             }
             _ => panic!("DO NOT ENTER HERE"),
         }
@@ -517,6 +538,7 @@ mod tests {
             &"asset0000".to_string(),
             &Decimal::percent(100),
             &Decimal::zero(),
+            &false,
         )]);
 
         let base_denom = "uusd".to_string();
@@ -716,5 +738,185 @@ mod tests {
         .unwrap();
         let positions: PositionsResponse = from_binary(&res).unwrap();
         assert_eq!(positions, PositionsResponse { positions: vec![] });
+    }
+
+    #[test]
+    fn revoked_collateral() {
+        let mut deps = mock_dependencies(20, &[]);
+        deps.querier.with_token_balances(&[(
+            &HumanAddr::from("asset000"),
+            &[(
+                &HumanAddr::from(MOCK_CONTRACT_ADDR),
+                &Uint128::from(1000000u128),
+            )],
+        )]);
+        deps.querier.with_oracle_price(&[
+            (&"uusd".to_string(), &Decimal::one()),
+            (&"asset0000".to_string(), &Decimal::percent(100)),
+        ]);
+        deps.querier.with_collateral_infos(&[(
+            &"uluna".to_string(),
+            &Decimal::percent(10),
+            &Decimal::percent(50),
+            &false,
+        )]);
+
+        let base_denom = "uusd".to_string();
+
+        let msg = InitMsg {
+            owner: HumanAddr::from("owner0000"),
+            oracle: HumanAddr::from("oracle0000"),
+            collector: HumanAddr::from("collector0000"),
+            collateral_oracle: HumanAddr::from("collateraloracle0000"),
+            staking: HumanAddr::from("staking0000"),
+            terraswap_factory: HumanAddr::from("terraswap_factory"),
+            base_denom: base_denom.clone(),
+            token_code_id: TOKEN_CODE_ID,
+            protocol_fee_rate: Decimal::percent(1),
+        };
+
+        let env = mock_env("addr0000", &[]);
+        let _res = init(&mut deps, env, msg).unwrap();
+
+        let msg = HandleMsg::RegisterAsset {
+            asset_token: HumanAddr::from("asset0000"),
+            auction_discount: Decimal::percent(20),
+            min_collateral_ratio: Decimal::percent(150),
+            mint_end: None,
+            min_collateral_ratio_after_migration: None,
+        };
+        let env = mock_env("owner0000", &[]);
+        let _res = handle(&mut deps, env, msg).unwrap();
+
+        // Open uluna:asset0000 position
+        let msg = HandleMsg::OpenPosition {
+            collateral: Asset {
+                info: AssetInfo::NativeToken {
+                    denom: "uluna".to_string(),
+                },
+                amount: Uint128(1000u128),
+            },
+            asset_info: AssetInfo::Token {
+                contract_addr: HumanAddr::from("asset0000"),
+            },
+            collateral_ratio: Decimal::percent(200),
+            short_params: None,
+        };
+        let env = mock_env_with_block_time(
+            "addr0000",
+            &[Coin {
+                amount: Uint128(1000u128),
+                denom: "uluna".to_string(),
+            }],
+            1000,
+        );
+        let _res = handle(&mut deps, env, msg.clone()).unwrap();
+
+        // collateral is revoked
+        deps.querier.with_collateral_infos(&[(
+            &"uluna".to_string(),
+            &Decimal::percent(100),
+            &Decimal::percent(50),
+            &true,
+        )]);
+
+        // open position fails
+        let env = mock_env_with_block_time(
+            "addr0000",
+            &[Coin {
+                amount: Uint128(1000u128),
+                denom: "uluna".to_string(),
+            }],
+            1000,
+        );
+        let res = handle(&mut deps, env, msg.clone()).unwrap_err();
+        assert_eq!(
+            res,
+            StdError::generic_err("The collateral asset provided is no longer valid")
+        );
+
+        // minting to previously open position fails
+        let msg = HandleMsg::Mint {
+            position_idx: Uint128(1u128),
+            asset: Asset {
+                info: AssetInfo::Token {
+                    contract_addr: HumanAddr::from("asset0000"),
+                },
+                amount: Uint128(1u128),
+            },
+            short_params: None,
+        };
+        let env = mock_env("addr0000", &[]);
+        let res = handle(&mut deps, env, msg.clone()).unwrap_err();
+        assert_eq!(
+            res,
+            StdError::generic_err("The collateral asset provided is no longer valid")
+        );
+
+        // deposit fails
+        let msg = HandleMsg::Deposit {
+            position_idx: Uint128(1u128),
+            collateral: Asset {
+                info: AssetInfo::NativeToken {
+                    denom: "uluna".to_string(),
+                },
+                amount: Uint128(2u128),
+            },
+        };
+        let env = mock_env_with_block_time(
+            "addr0000",
+            &[Coin {
+                amount: Uint128(2u128),
+                denom: "uluna".to_string(),
+            }],
+            1000,
+        );
+        let res = handle(&mut deps, env, msg.clone()).unwrap_err();
+        assert_eq!(
+            res,
+            StdError::generic_err("The collateral asset provided is no longer valid")
+        );
+
+        // burn against revoked collateral is enabled
+        // fail attempt, only owner can burn
+        let msg = HandleMsg::Receive(Cw20ReceiveMsg {
+            sender: HumanAddr::from("addr0001"),
+            amount: Uint128::from(10u128),
+            msg: Some(
+                to_binary(&Cw20HookMsg::Burn {
+                    position_idx: Uint128(1u128),
+                })
+                .unwrap(),
+            ),
+        });
+        let env = mock_env("asset0000", &[]);
+        let res = handle(&mut deps, env, msg).unwrap_err();
+        assert_eq!(res, StdError::unauthorized());
+        // sucessful attempt
+        let msg = HandleMsg::Receive(Cw20ReceiveMsg {
+            sender: HumanAddr::from("addr0000"),
+            amount: Uint128::from(10u128),
+            msg: Some(
+                to_binary(&Cw20HookMsg::Burn {
+                    position_idx: Uint128(1u128),
+                })
+                .unwrap(),
+            ),
+        });
+        let env = mock_env("asset0000", &[]);
+        let _res = handle(&mut deps, env, msg).unwrap();
+
+        // owner can withdraw revoked collateral
+        let msg = HandleMsg::Withdraw {
+            position_idx: Uint128(1u128),
+            collateral: Asset {
+                info: AssetInfo::NativeToken {
+                    denom: "uluna".to_string(),
+                },
+                amount: Uint128(2u128),
+            },
+        };
+        let env = mock_env_with_block_time("addr0000", &[], 1000);
+        let _res = handle(&mut deps, env, msg.clone()).unwrap();
     }
 }

--- a/contracts/mirror_mint/src/mock_querier.rs
+++ b/contracts/mirror_mint/src/mock_querier.rs
@@ -125,11 +125,11 @@ pub(crate) fn oracle_price_to_map(
 #[derive(Clone, Default)]
 pub struct CollateralOracleQuerier {
     // this lets us iterate over all pairs that match the first string
-    collateral_infos: HashMap<String, (Decimal, Decimal)>,
+    collateral_infos: HashMap<String, (Decimal, Decimal, bool)>,
 }
 
 impl CollateralOracleQuerier {
-    pub fn new(collateral_infos: &[(&String, &Decimal, &Decimal)]) -> Self {
+    pub fn new(collateral_infos: &[(&String, &Decimal, &Decimal, &bool)]) -> Self {
         CollateralOracleQuerier {
             collateral_infos: collateral_infos_to_map(collateral_infos),
         }
@@ -137,13 +137,13 @@ impl CollateralOracleQuerier {
 }
 
 pub(crate) fn collateral_infos_to_map(
-    collateral_infos: &[(&String, &Decimal, &Decimal)],
-) -> HashMap<String, (Decimal, Decimal)> {
-    let mut collateral_infos_map: HashMap<String, (Decimal, Decimal)> = HashMap::new();
-    for (collateral, collateral_price, collateral_premium) in collateral_infos.iter() {
+    collateral_infos: &[(&String, &Decimal, &Decimal, &bool)],
+) -> HashMap<String, (Decimal, Decimal, bool)> {
+    let mut collateral_infos_map: HashMap<String, (Decimal, Decimal, bool)> = HashMap::new();
+    for (collateral, collateral_price, collateral_premium, is_revoked) in collateral_infos.iter() {
         collateral_infos_map.insert(
             (*collateral).clone(),
-            (**collateral_price, **collateral_premium),
+            (**collateral_price, **collateral_premium, **is_revoked),
         );
     }
 
@@ -267,6 +267,7 @@ impl WasmMockQuerier {
                             asset,
                             rate: collateral_info.0,
                             collateral_premium: collateral_info.1,
+                            is_revoked: collateral_info.2,
                         })),
                         None => Err(SystemError::InvalidRequest {
                             error: "Collateral info does not exist".to_string(),
@@ -378,7 +379,10 @@ impl WasmMockQuerier {
     }
 
     // configure the collateral oracle mock querier
-    pub fn with_collateral_infos(&mut self, collateral_infos: &[(&String, &Decimal, &Decimal)]) {
+    pub fn with_collateral_infos(
+        &mut self,
+        collateral_infos: &[(&String, &Decimal, &Decimal, &bool)],
+    ) {
         self.collateral_oracle_querier = CollateralOracleQuerier::new(collateral_infos);
     }
 

--- a/contracts/mirror_mint/src/positions.rs
+++ b/contracts/mirror_mint/src/positions.rs
@@ -6,7 +6,7 @@ use cosmwasm_std::{
 use crate::{
     asserts::{
         assert_asset, assert_burn_period, assert_collateral, assert_migrated_asset,
-        assert_mint_period,
+        assert_mint_period, assert_revoked_collateral,
     },
     math::{decimal_division, decimal_subtraction, reverse_decimal},
     querier::{load_asset_price, load_collateral_info},
@@ -39,31 +39,19 @@ pub fn open_position<S: Storage, A: Api, Q: Querier>(
     collateral_ratio: Decimal,
     short_params: Option<ShortParams>,
 ) -> StdResult<HandleResponse> {
+    let config: Config = read_config(&deps.storage)?;
     if collateral.amount.is_zero() {
         return Err(StdError::generic_err("Wrong collateral"));
     }
-    
-    // assert collateral migrated
-    let collateral_info_raw: AssetInfoRaw = collateral.info.to_raw(&deps)?;
-    match collateral_info_raw.clone() {
-        AssetInfoRaw::Token { contract_addr } => {
-            assert_migrated_asset(&read_asset_config(&deps.storage, &contract_addr)?)?;
-        }
-        _ => {}
-    };
 
-    // query collateral info from collateral oracle
-    let config: Config = read_config(&deps.storage)?;
+    // assert the collateral is listed and has not been migrated/revoked
+    let collateral_info_raw: AssetInfoRaw = collateral.info.to_raw(&deps)?;
     let collateral_oracle: HumanAddr = deps.api.human_address(&config.collateral_oracle)?;
-    let (collateral_price, collateral_premium) = if let Ok(response) =
-        load_collateral_info(deps, &collateral_oracle, &collateral_info_raw)
-    {
-        response
-    } else {
-        return Err(StdError::generic_err(
-            "The collateral asset provided is not valid",
-        ));
-    };
+    let (collateral_price, collateral_premium) = assert_revoked_collateral(load_collateral_info(
+        &deps,
+        &collateral_oracle,
+        &collateral_info_raw,
+    )?)?;
 
     // assert asset migrated
     let asset_info_raw: AssetInfoRaw = asset_info.to_raw(&deps)?;
@@ -210,6 +198,7 @@ pub fn deposit<S: Storage, A: Api, Q: Querier>(
     position_idx: Uint128,
     collateral: Asset,
 ) -> HandleResult {
+    let config: Config = read_config(&deps.storage)?;
     let mut position: Position = read_position(&deps.storage, position_idx)?;
     let position_owner = deps.api.human_address(&position.owner)?;
     if sender != position_owner {
@@ -221,13 +210,13 @@ pub fn deposit<S: Storage, A: Api, Q: Querier>(
     // also Check the collateral amount is non-zero
     assert_collateral(deps, &position, &collateral)?;
 
-    // assert collateral migrated
-    match position.collateral.info.clone() {
-        AssetInfoRaw::Token { contract_addr } => {
-            assert_migrated_asset(&read_asset_config(&deps.storage, &contract_addr)?)?;
-        }
-        _ => {}
-    };
+    // assert the collateral is listed and has not been migrated/revoked
+    let collateral_oracle: HumanAddr = deps.api.human_address(&config.collateral_oracle)?;
+    assert_revoked_collateral(load_collateral_info(
+        &deps,
+        &collateral_oracle,
+        &position.collateral.info,
+    )?)?;
 
     // assert asset migrated
     match position.asset.info.clone() {
@@ -258,6 +247,7 @@ pub fn withdraw<S: Storage, A: Api, Q: Querier>(
     position_idx: Uint128,
     collateral: Asset,
 ) -> HandleResult {
+    let config: Config = read_config(&deps.storage)?;
     let mut position: Position = read_position(&deps.storage, position_idx)?;
     let position_owner = deps.api.human_address(&position.owner)?;
     if env.message.sender != position_owner {
@@ -275,7 +265,6 @@ pub fn withdraw<S: Storage, A: Api, Q: Querier>(
         ));
     }
 
-    let config: Config = read_config(&deps.storage)?;
     let asset_token_raw = match position.asset.info.clone() {
         AssetInfoRaw::Token { contract_addr } => contract_addr,
         _ => panic!("DO NOT ENTER HERE"),
@@ -286,8 +275,9 @@ pub fn withdraw<S: Storage, A: Api, Q: Querier>(
     let asset_price: Decimal =
         load_asset_price(&deps, &oracle, &position.asset.info, Some(env.block.time))?;
 
+    // Fetch collateral info from collateral oracle
     let collateral_oracle: HumanAddr = deps.api.human_address(&config.collateral_oracle)?;
-    let (collateral_price, collateral_premium) =
+    let (collateral_price, collateral_premium, _collateral_is_revoked) =
         load_collateral_info(&deps, &collateral_oracle, &position.collateral.info)?;
 
     // Compute new collateral amount
@@ -358,6 +348,7 @@ pub fn mint<S: Storage, A: Api, Q: Querier>(
     asset: Asset,
     short_params: Option<ShortParams>,
 ) -> HandleResult {
+    let config: Config = read_config(&deps.storage)?;
     let mint_amount = asset.amount;
     let sender = env.message.sender.clone();
 
@@ -369,15 +360,6 @@ pub fn mint<S: Storage, A: Api, Q: Querier>(
 
     assert_asset(&deps, &position, &asset)?;
 
-    // assert the collateral migrated
-    match position.collateral.info.clone() {
-        AssetInfoRaw::Token { contract_addr } => {
-            assert_migrated_asset(&read_asset_config(&deps.storage, &contract_addr)?)?;
-        }
-        _ => {}
-    };
-
-    let config: Config = read_config(&deps.storage)?;
     let asset_token_raw = match position.asset.info.clone() {
         AssetInfoRaw::Token { contract_addr } => contract_addr,
         _ => panic!("DO NOT ENTER HERE"),
@@ -387,16 +369,20 @@ pub fn mint<S: Storage, A: Api, Q: Querier>(
     let asset_config: AssetConfig = read_asset_config(&deps.storage, &asset_token_raw)?;
     assert_migrated_asset(&asset_config)?;
 
+    // assert the collateral is listed and has not been migrated/revoked
+    let collateral_oracle: HumanAddr = deps.api.human_address(&config.collateral_oracle)?;
+    let (collateral_price, collateral_premium) = assert_revoked_collateral(load_collateral_info(
+        &deps,
+        &collateral_oracle,
+        &position.collateral.info,
+    )?)?;
+
     // for assets with limited minting period (preIPO assets), assert minting phase
     assert_mint_period(&env, &asset_config)?;
 
     let oracle: HumanAddr = deps.api.human_address(&config.oracle)?;
     let asset_price: Decimal =
         load_asset_price(&deps, &oracle, &position.asset.info, Some(env.block.time))?;
-
-    let collateral_oracle: HumanAddr = deps.api.human_address(&config.collateral_oracle)?;
-    let (collateral_price, collateral_premium) =
-        load_collateral_info(&deps, &collateral_oracle, &position.collateral.info)?;
 
     // Compute new asset amount
     let asset_amount: Uint128 = mint_amount + position.asset.amount;
@@ -548,8 +534,9 @@ pub fn burn<S: Storage, A: Api, Q: Querier>(
         let asset_price: Decimal =
             load_asset_price(&deps, &oracle, &position.asset.info, Some(env.block.time))?;
 
+        // fetch collateral info from collateral oracle
         let collateral_oracle: HumanAddr = deps.api.human_address(&config.collateral_oracle)?;
-        let (collateral_price, _collateral_premium) =
+        let (collateral_price, _collateral_premium, _collateral_is_revoked) =
             load_collateral_info(&deps, &collateral_oracle, &position.collateral.info)?;
 
         let collateral_price_in_asset = decimal_division(asset_price, collateral_price);
@@ -645,11 +632,11 @@ pub fn auction<S: Storage, A: Api, Q: Querier>(
     position_idx: Uint128,
     asset: Asset,
 ) -> StdResult<HandleResponse> {
+    let config: Config = read_config(&deps.storage)?;
     let mut position: Position = read_position(&deps.storage, position_idx)?;
     let position_owner = deps.api.human_address(&position.owner)?;
     assert_asset(&deps, &position, &asset)?;
 
-    let config: Config = read_config(&deps.storage)?;
     let asset_token_raw = match position.asset.info.clone() {
         AssetInfoRaw::Token { contract_addr } => contract_addr,
         _ => panic!("DO NOT ENTER HERE"),
@@ -671,8 +658,9 @@ pub fn auction<S: Storage, A: Api, Q: Querier>(
     let asset_price: Decimal =
         load_asset_price(&deps, &oracle, &position.asset.info, Some(env.block.time))?;
 
+    // fetch collateral info from collateral oracle
     let collateral_oracle: HumanAddr = deps.api.human_address(&config.collateral_oracle)?;
-    let (collateral_price, _collateral_premium) =
+    let (collateral_price, _collateral_premium, _collateral_is_revoked) =
         load_collateral_info(&deps, &collateral_oracle, &position.collateral.info)?;
 
     let collateral_price_in_asset: Decimal = decimal_division(asset_price, collateral_price);

--- a/contracts/mirror_mint/src/positions_test.rs
+++ b/contracts/mirror_mint/src/positions_test.rs
@@ -41,6 +41,7 @@ mod tests {
             &"asset0001".to_string(),
             &Decimal::percent(50),
             &Decimal::zero(),
+            &false,
         )]);
 
         let base_denom = "uusd".to_string();
@@ -410,6 +411,7 @@ mod tests {
             &"asset0001".to_string(),
             &Decimal::percent(50),
             &Decimal::zero(),
+            &false,
         )]);
 
         let base_denom = "uusd".to_string();
@@ -620,6 +622,7 @@ mod tests {
             &"asset0001".to_string(),
             &Decimal::from_ratio(50u128, 1u128),
             &Decimal::zero(),
+            &false,
         )]);
 
         let base_denom = "uusd".to_string();
@@ -866,6 +869,7 @@ mod tests {
             &"asset0001".to_string(),
             &Decimal::from_ratio(50u128, 1u128),
             &Decimal::zero(),
+            &false,
         )]);
 
         let base_denom = "uusd".to_string();
@@ -1136,6 +1140,7 @@ mod tests {
             &"asset0001".to_string(),
             &Decimal::from_ratio(50u128, 1u128),
             &Decimal::zero(),
+            &false,
         )]);
 
         let base_denom = "uusd".to_string();
@@ -1329,11 +1334,13 @@ mod tests {
                 &"asset0000".to_string(),
                 &Decimal::from_ratio(100u128, 1u128),
                 &Decimal::zero(),
+                &false,
             ),
             (
                 &"asset0001".to_string(),
                 &Decimal::from_ratio(50u128, 1u128),
                 &Decimal::zero(),
+                &false,
             ),
         ]);
 
@@ -1485,11 +1492,13 @@ mod tests {
                 &"asset0000".to_string(),
                 &Decimal::from_ratio(116u128, 1u128),
                 &Decimal::zero(),
+                &false,
             ),
             (
                 &"asset0001".to_string(),
                 &Decimal::from_ratio(50u128, 1u128),
                 &Decimal::zero(),
+                &false,
             ),
         ]);
 
@@ -1616,11 +1625,13 @@ mod tests {
                 &"asset0000".to_string(),
                 &Decimal::percent(200),
                 &Decimal::zero(),
+                &false,
             ),
             (
                 &"asset0001".to_string(),
                 &Decimal::percent(50),
                 &Decimal::zero(),
+                &false,
             ),
         ]);
 

--- a/packages/mirror_protocol/src/collateral_oracle.rs
+++ b/packages/mirror_protocol/src/collateral_oracle.rs
@@ -7,6 +7,8 @@ use terraswap::asset::AssetInfo;
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct InitMsg {
     pub owner: HumanAddr,
+    pub mint_contract: HumanAddr,
+    pub factory_contract: HumanAddr,
     pub base_denom: String,
 }
 
@@ -15,6 +17,8 @@ pub struct InitMsg {
 pub enum HandleMsg {
     UpdateConfig {
         owner: Option<HumanAddr>,
+        mint_contract: Option<HumanAddr>,
+        factory_contract: Option<HumanAddr>,
         base_denom: Option<String>,
     },
     RegisterCollateralAsset {
@@ -22,10 +26,16 @@ pub enum HandleMsg {
         query_request: Binary,
         collateral_premium: Decimal,
     },
-    UpdateCollateralAsset {
+    RevokeCollateralAsset {
         asset: AssetInfo,
-        query_request: Option<Binary>,    
-        collateral_premium: Option<Decimal>,
+    },
+    UpdateCollateralQuery {
+        asset: AssetInfo,
+        query_request: Binary,
+    },
+    UpdateCollateralPremium {
+        asset: AssetInfo,
+        collateral_premium: Decimal,
     }
 }
 
@@ -45,6 +55,8 @@ pub enum QueryMsg {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct ConfigResponse {
     pub owner: HumanAddr,
+    pub mint_contract: HumanAddr,
+    pub factory_contract: HumanAddr,
     pub base_denom: String,
 }
 
@@ -53,6 +65,7 @@ pub struct CollateralPriceResponse {
     pub asset: String,
     pub rate: Decimal,
     pub collateral_premium: Decimal,
+    pub is_revoked: bool,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
@@ -60,6 +73,7 @@ pub struct CollateralInfoResponse {
     pub asset: String,
     pub collateral_premium: Decimal,
     pub query_request: WasmQuery,
+    pub is_revoked: bool,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]


### PR DESCRIPTION
### Overview

- Added the possibility to revoke collaterals from collateral oracle
- Mint contract will register new mAssets as collaterals and will revoke the collateral when the mAsset is migrated
- Changed the permission structure of collateral oracle to the following:
  - RegisterCollateral can be called by owner or mint contract
  - RevokeCollateral can be called by owner or mint contract
  - Only owner can update the collateral asset query
  - Factory can update collateral premium (so that it can be altered through gov poll)

#### About revoking:
There are 2 situation when revoking a collateral:

1. _mAsset collateral:_ If the collateral asset is an mAsset, when the mAsset is delisted/migrated, an end_price is registered to mint contract. When mint is fetching the price of a collateral, it will first check if this end_price is registered, if thats the case, it will treat the collateral as revoked. 
2. _non-mAsset collateral:_ If the collateral is not an mAsset. The collateral oracle owner needs to actively flag the collateral as revoked. “RevokeCollateral” handler.

Notice that in case 1, mint contract will know that a collateral is revoked even if it is not registered in the collateral oracle. Anyways, for consistency, mint will automatically update the `is_revoked` on the collateral oracle when migration is executed.

If a collateral asset is flagged as revoked, mint contract will disable minting, opening new positions or depositing more collateral. (On the positions that have the revoked assets as collateral)
All other operations are enabled and behave normally.
