### PR TITLE
[Feature] change short_reward_weight to be computed from the function

### DIFF
--- a/contracts/mirror_staking/schema/config_response.json
+++ b/contracts/mirror_staking/schema/config_response.json
@@ -9,9 +9,6 @@
     "oracle_contract",
     "owner",
     "premium_min_update_interval",
-    "premium_short_reward_weight",
-    "premium_tolerance",
-    "short_reward_weight",
     "terraswap_factory"
   ],
   "properties": {
@@ -35,24 +32,11 @@
       "format": "uint64",
       "minimum": 0.0
     },
-    "premium_short_reward_weight": {
-      "$ref": "#/definitions/Decimal"
-    },
-    "premium_tolerance": {
-      "$ref": "#/definitions/Decimal"
-    },
-    "short_reward_weight": {
-      "$ref": "#/definitions/Decimal"
-    },
     "terraswap_factory": {
       "$ref": "#/definitions/HumanAddr"
     }
   },
   "definitions": {
-    "Decimal": {
-      "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0 The greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
-      "type": "string"
-    },
     "HumanAddr": {
       "type": "string"
     }

--- a/contracts/mirror_staking/schema/handle_msg.json
+++ b/contracts/mirror_staking/schema/handle_msg.json
@@ -40,36 +40,6 @@
               ],
               "format": "uint64",
               "minimum": 0.0
-            },
-            "premium_short_reward_weight": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/Decimal"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            },
-            "premium_tolerance": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/Decimal"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            },
-            "short_reward_weight": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/Decimal"
-                },
-                {
-                  "type": "null"
-                }
-              ]
             }
           }
         }
@@ -255,10 +225,6 @@
           "$ref": "#/definitions/HumanAddr"
         }
       }
-    },
-    "Decimal": {
-      "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0 The greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
-      "type": "string"
     },
     "HumanAddr": {
       "type": "string"

--- a/contracts/mirror_staking/schema/init_msg.json
+++ b/contracts/mirror_staking/schema/init_msg.json
@@ -9,9 +9,6 @@
     "oracle_contract",
     "owner",
     "premium_min_update_interval",
-    "premium_short_reward_weight",
-    "premium_tolerance",
-    "short_reward_weight",
     "terraswap_factory"
   ],
   "properties": {
@@ -35,24 +32,11 @@
       "format": "uint64",
       "minimum": 0.0
     },
-    "premium_short_reward_weight": {
-      "$ref": "#/definitions/Decimal"
-    },
-    "premium_tolerance": {
-      "$ref": "#/definitions/Decimal"
-    },
-    "short_reward_weight": {
-      "$ref": "#/definitions/Decimal"
-    },
     "terraswap_factory": {
       "$ref": "#/definitions/HumanAddr"
     }
   },
   "definitions": {
-    "Decimal": {
-      "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0 The greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
-      "type": "string"
-    },
     "HumanAddr": {
       "type": "string"
     }

--- a/contracts/mirror_staking/schema/migrate_msg.json
+++ b/contracts/mirror_staking/schema/migrate_msg.json
@@ -8,9 +8,6 @@
     "mint_contract",
     "oracle_contract",
     "premium_min_update_interval",
-    "premium_short_reward_weight",
-    "premium_tolerance",
-    "short_reward_weight",
     "terraswap_factory"
   ],
   "properties": {
@@ -28,24 +25,11 @@
       "format": "uint64",
       "minimum": 0.0
     },
-    "premium_short_reward_weight": {
-      "$ref": "#/definitions/Decimal"
-    },
-    "premium_tolerance": {
-      "$ref": "#/definitions/Decimal"
-    },
-    "short_reward_weight": {
-      "$ref": "#/definitions/Decimal"
-    },
     "terraswap_factory": {
       "$ref": "#/definitions/HumanAddr"
     }
   },
   "definitions": {
-    "Decimal": {
-      "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0 The greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
-      "type": "string"
-    },
     "HumanAddr": {
       "type": "string"
     }

--- a/contracts/mirror_staking/src/contract.rs
+++ b/contracts/mirror_staking/src/contract.rs
@@ -29,9 +29,6 @@ pub fn init<S: Storage, A: Api, Q: Querier>(
             oracle_contract: deps.api.canonical_address(&msg.oracle_contract)?,
             terraswap_factory: deps.api.canonical_address(&msg.terraswap_factory)?,
             base_denom: msg.base_denom,
-            premium_tolerance: msg.premium_tolerance,
-            short_reward_weight: msg.short_reward_weight,
-            premium_short_reward_weight: msg.premium_short_reward_weight,
             premium_min_update_interval: msg.premium_min_update_interval,
         },
     )?;
@@ -48,19 +45,8 @@ pub fn handle<S: Storage, A: Api, Q: Querier>(
         HandleMsg::Receive(msg) => receive_cw20(deps, env, msg),
         HandleMsg::UpdateConfig {
             owner,
-            premium_tolerance,
-            short_reward_weight,
-            premium_short_reward_weight,
             premium_min_update_interval,
-        } => update_config(
-            deps,
-            env,
-            owner,
-            premium_tolerance,
-            short_reward_weight,
-            premium_short_reward_weight,
-            premium_min_update_interval,
-        ),
+        } => update_config(deps, env, owner, premium_min_update_interval),
         HandleMsg::RegisterAsset {
             asset_token,
             staking_token,
@@ -131,9 +117,6 @@ pub fn update_config<S: Storage, A: Api, Q: Querier>(
     deps: &mut Extern<S, A, Q>,
     env: Env,
     owner: Option<HumanAddr>,
-    premium_tolerance: Option<Decimal>,
-    short_reward_weight: Option<Decimal>,
-    premium_short_reward_weight: Option<Decimal>,
     premium_min_update_interval: Option<u64>,
 ) -> StdResult<HandleResponse> {
     let mut config: Config = read_config(&deps.storage)?;
@@ -144,18 +127,6 @@ pub fn update_config<S: Storage, A: Api, Q: Querier>(
 
     if let Some(owner) = owner {
         config.owner = deps.api.canonical_address(&owner)?;
-    }
-
-    if let Some(premium_tolerance) = premium_tolerance {
-        config.premium_tolerance = premium_tolerance;
-    }
-
-    if let Some(short_reward_weight) = short_reward_weight {
-        config.short_reward_weight = short_reward_weight;
-    }
-
-    if let Some(premium_short_reward_weight) = premium_short_reward_weight {
-        config.premium_short_reward_weight = premium_short_reward_weight;
     }
 
     if let Some(premium_min_update_interval) = premium_min_update_interval {
@@ -238,9 +209,6 @@ pub fn query_config<S: Storage, A: Api, Q: Querier>(
         oracle_contract: deps.api.human_address(&state.oracle_contract)?,
         terraswap_factory: deps.api.human_address(&state.terraswap_factory)?,
         base_denom: state.base_denom,
-        premium_tolerance: state.premium_tolerance,
-        short_reward_weight: state.short_reward_weight,
-        premium_short_reward_weight: state.premium_short_reward_weight,
         premium_min_update_interval: state.premium_min_update_interval,
     };
 
@@ -278,9 +246,6 @@ pub fn migrate<S: Storage, A: Api, Q: Querier>(
         deps.api.canonical_address(&msg.oracle_contract)?,
         deps.api.canonical_address(&msg.terraswap_factory)?,
         msg.base_denom,
-        msg.premium_tolerance,
-        msg.short_reward_weight,
-        msg.premium_short_reward_weight,
         msg.premium_min_update_interval,
     )?;
 

--- a/contracts/mirror_staking/src/contract_test.rs
+++ b/contracts/mirror_staking/src/contract_test.rs
@@ -20,9 +20,6 @@ mod tests {
             oracle_contract: HumanAddr::from("oracle"),
             terraswap_factory: HumanAddr::from("terraswap_factory"),
             base_denom: "uusd".to_string(),
-            premium_tolerance: Decimal::percent(2),
-            short_reward_weight: Decimal::percent(20),
-            premium_short_reward_weight: Decimal::percent(40),
             premium_min_update_interval: 3600,
         };
 
@@ -42,9 +39,6 @@ mod tests {
                 oracle_contract: HumanAddr::from("oracle"),
                 terraswap_factory: HumanAddr::from("terraswap_factory"),
                 base_denom: "uusd".to_string(),
-                premium_tolerance: Decimal::percent(2),
-                short_reward_weight: Decimal::percent(20),
-                premium_short_reward_weight: Decimal::percent(40),
                 premium_min_update_interval: 3600,
             },
             config
@@ -62,9 +56,6 @@ mod tests {
             oracle_contract: HumanAddr::from("oracle"),
             terraswap_factory: HumanAddr::from("terraswap_factory"),
             base_denom: "uusd".to_string(),
-            premium_tolerance: Decimal::percent(2),
-            short_reward_weight: Decimal::percent(20),
-            premium_short_reward_weight: Decimal::percent(40),
             premium_min_update_interval: 3600,
         };
 
@@ -75,9 +66,6 @@ mod tests {
         let env = mock_env("owner", &[]);
         let msg = HandleMsg::UpdateConfig {
             owner: Some(HumanAddr("owner2".to_string())),
-            premium_tolerance: Some(Decimal::percent(5)),
-            short_reward_weight: Some(Decimal::percent(30)),
-            premium_short_reward_weight: Some(Decimal::percent(60)),
             premium_min_update_interval: Some(7200),
         };
 
@@ -95,9 +83,6 @@ mod tests {
                 oracle_contract: HumanAddr::from("oracle"),
                 terraswap_factory: HumanAddr::from("terraswap_factory"),
                 base_denom: "uusd".to_string(),
-                premium_tolerance: Decimal::percent(5),
-                short_reward_weight: Decimal::percent(30),
-                premium_short_reward_weight: Decimal::percent(60),
                 premium_min_update_interval: 7200,
             },
             config
@@ -107,9 +92,6 @@ mod tests {
         let env = mock_env("owner", &[]);
         let msg = HandleMsg::UpdateConfig {
             owner: None,
-            premium_tolerance: Some(Decimal::percent(5)),
-            short_reward_weight: Some(Decimal::percent(30)),
-            premium_short_reward_weight: Some(Decimal::percent(60)),
             premium_min_update_interval: Some(7200),
         };
 
@@ -131,9 +113,6 @@ mod tests {
             oracle_contract: HumanAddr::from("oracle"),
             terraswap_factory: HumanAddr::from("terraswap_factory"),
             base_denom: "uusd".to_string(),
-            premium_tolerance: Decimal::percent(2),
-            short_reward_weight: Decimal::percent(20),
-            premium_short_reward_weight: Decimal::percent(40),
             premium_min_update_interval: 3600,
         };
 

--- a/contracts/mirror_staking/src/lib.rs
+++ b/contracts/mirror_staking/src/lib.rs
@@ -11,6 +11,7 @@ mod contract_test;
 mod migration_test;
 mod reward_test;
 mod staking_test;
+mod math_test;
 
 #[cfg(target_arch = "wasm32")]
 cosmwasm_std::create_entry_points_with_migration!(contract);

--- a/contracts/mirror_staking/src/math.rs
+++ b/contracts/mirror_staking/src/math.rs
@@ -13,3 +13,138 @@ pub fn decimal_subtraction(a: Decimal, b: Decimal) -> Decimal {
         DECIMAL_FRACTIONAL,
     )
 }
+
+pub fn decimal_multiplication(a: Decimal, b: Decimal) -> Decimal {
+    Decimal::from_ratio(a * DECIMAL_FRACTIONAL * b, DECIMAL_FRACTIONAL)
+}
+
+pub fn reverse_decimal(decimal: Decimal) -> Decimal {
+    Decimal::from_ratio(DECIMAL_FRACTIONAL, decimal * DECIMAL_FRACTIONAL)
+}
+
+// p == premium * 100
+pub fn erf_plus_one(p: Decimal) -> Decimal {
+    if p >= Decimal::from_ratio(10u128, 1u128) {
+        return Decimal::from_ratio(2u128, 1u128);
+    }
+
+    if p <= Decimal::from_ratio(9u128, 10u128) {
+        return Decimal::zero();
+    }
+
+    let e6 = 1000000u128;
+    let e10 = 10000000000u128;
+    let a1 = Decimal::from_ratio(705230784u128, e10);
+    let a2 = Decimal::from_ratio(422820123u128, e10);
+    let a3 = Decimal::from_ratio(92705272u128, e10);
+    let a4 = Decimal::from_ratio(1520143u128, e10);
+    let a5 = Decimal::from_ratio(2765672u128, e10);
+    let a6 = Decimal::from_ratio(430638u128, e10);
+
+    let one = Decimal::one();
+    let two = one + one;
+    let three = two + one;
+    let sqrt_two = Decimal::from_ratio(14142135624u128, e10);
+    let (sign_x, x) = if p > three {
+        (
+            Sign::Positive,
+            decimal_division(decimal_subtraction(p, three), sqrt_two),
+        )
+    } else {
+        (
+            Sign::Negative,
+            decimal_division(decimal_subtraction(three, p), sqrt_two),
+        )
+    };
+
+    // ((((((a6 * x) + a5) * x + a4 ) * x + a3) * x + a2) * x + a1) * x + 1
+    let sign = sign_x.clone();
+    let num = decimal_multiplication(a6, x);
+    let (sign, num) = sum_and_multiply_x(sign, Sign::Positive, sign_x.clone(), num, a5, x);
+    let (sign, num) = sum_and_multiply_x(sign, Sign::Positive, sign_x.clone(), num, a4, x);
+    let (sign, num) = sum_and_multiply_x(sign, Sign::Positive, sign_x.clone(), num, a3, x);
+    let (sign, num) = sum_and_multiply_x(sign, Sign::Positive, sign_x.clone(), num, a2, x);
+    let (sign, num) = sum_and_multiply_x(sign, Sign::Positive, sign_x, num, a1, x);
+    let num = if sign == Sign::Positive {
+        num + one
+    } else if num > one {
+        decimal_subtraction(num, one)
+    } else {
+        decimal_subtraction(one, num)
+    };
+
+    // ignore sign
+    let num2 = decimal_multiplication(num, num);
+    let num4 = decimal_multiplication(num2, num2);
+    let num8 = decimal_multiplication(num4, num4);
+    let num16 = decimal_multiplication(num8, num8);
+    let reverse_num16 = reverse_decimal(num16);
+    if reverse_num16 > two {
+        return Decimal::zero();
+    }
+
+    let erf_plus_one = decimal_subtraction(two, reverse_num16);
+
+    // maximum error: 3 * 10^-7
+    // so only use 6 decimal digits
+    Decimal::from_ratio(erf_plus_one * e6.into(), e6)
+}
+
+// (1 + erf(premium * 100)) / 5
+pub fn short_reward_weight(premium_rate: Decimal) -> Decimal {
+    if premium_rate >= Decimal::percent(10) {
+        return Decimal::percent(40);
+    }
+
+    // if premium_rate < 0.9%; just return zero
+    if premium_rate <= Decimal::permille(9) {
+        return Decimal::zero();
+    }
+
+    return decimal_division(
+        erf_plus_one(decimal_multiplication(
+            premium_rate,
+            Decimal::from_ratio(100u128, 1u128),
+        )),
+        Decimal::from_ratio(5u128, 1u128),
+    );
+}
+
+#[derive(PartialEq, Clone)]
+enum Sign {
+    Positive,
+    Negative,
+}
+
+// return (sign, result)
+fn sum_and_multiply_x(
+    sign_1: Sign,
+    sign_2: Sign,
+    sign_x: Sign,
+    num1: Decimal,
+    num2: Decimal,
+    x: Decimal,
+) -> (Sign, Decimal) {
+    if sign_1 == sign_2 {
+        let val = decimal_multiplication(num1 + num2, x);
+        if sign_1 == sign_x {
+            (Sign::Positive, val)
+        } else {
+            (Sign::Negative, val)
+        }
+    } else if num1 > num2 {
+        let val = decimal_multiplication(decimal_subtraction(num1, num2), x);
+        if sign_1 == sign_x {
+            (Sign::Positive, val)
+        } else {
+            (Sign::Negative, val)
+        }
+    } else {
+        let val = decimal_multiplication(decimal_subtraction(num2, num1), x);
+        if sign_2 == sign_x {
+            (Sign::Positive, val)
+        } else {
+            (Sign::Negative, val)
+        }
+    }
+}

--- a/contracts/mirror_staking/src/math.rs
+++ b/contracts/mirror_staking/src/math.rs
@@ -71,31 +71,25 @@ fn erf_plus_one(sign_x: Sign, x: Decimal) -> Decimal {
 
 // (1 + erf(premium * 100)) / 5
 pub fn short_reward_weight(premium_rate: Decimal) -> Decimal {
-    if premium_rate > Decimal::percent(10) {
+    if premium_rate > Decimal::percent(7) {
         return Decimal::percent(40);
-    }
-
-    // if premium_rate < 1%; just return zero
-    if premium_rate < Decimal::percent(1) {
-        return Decimal::zero();
     }
 
     let one = Decimal::one();
     let two = one + one;
-    let three = two + one;
     let e10 = 10000000000u128;
     let sqrt_two = Decimal::from_ratio(14142135624u128, e10);
 
     let p = decimal_multiplication(premium_rate, Decimal::from_ratio(100u128, 1u128));
-    let (sign_x, x) = if p > three {
+    let (sign_x, x) = if p > two {
         (
             Sign::Positive,
-            decimal_division(decimal_subtraction(p, three), sqrt_two),
+            decimal_division(decimal_subtraction(p, two), sqrt_two),
         )
     } else {
         (
             Sign::Negative,
-            decimal_division(decimal_subtraction(three, p), sqrt_two),
+            decimal_division(decimal_subtraction(two, p), sqrt_two),
         )
     };
 

--- a/contracts/mirror_staking/src/math_test.rs
+++ b/contracts/mirror_staking/src/math_test.rs
@@ -1,27 +1,30 @@
 #[cfg(test)]
 mod tests {
-    use crate::math::{short_reward_weight};
+    use crate::math::short_reward_weight;
     use cosmwasm_std::Decimal;
 
     #[test]
     fn short_reward_weight_test() {
         let e6 = 1000000u128;
         let e7 = 10000000u128;
-        assert_eq!(short_reward_weight(Decimal::zero()), Decimal::zero());
         assert_eq!(
-            short_reward_weight(Decimal::percent(1)),
-            Decimal::from_ratio(002618u128, e6),
+            short_reward_weight(Decimal::zero()),
+            Decimal::from_ratio(002618u128, e6)
         );
         assert_eq!(
-            short_reward_weight(Decimal::percent(3)),
+            short_reward_weight(Decimal::percent(1)),
+            Decimal::from_ratio(0634168u128, e7),
+        );
+        assert_eq!(
+            short_reward_weight(Decimal::percent(2)),
             Decimal::percent(20)
         );
         assert_eq!(
-            short_reward_weight(Decimal::percent(5)),
+            short_reward_weight(Decimal::percent(4)),
             Decimal::from_ratio(3908998u128, e7)
         );
         assert_eq!(
-            short_reward_weight(Decimal::percent(10)),
+            short_reward_weight(Decimal::percent(8)),
             Decimal::percent(40)
         );
         assert_eq!(

--- a/contracts/mirror_staking/src/math_test.rs
+++ b/contracts/mirror_staking/src/math_test.rs
@@ -1,0 +1,58 @@
+#[cfg(test)]
+mod tests {
+    use crate::math::{erf_plus_one, short_reward_weight};
+    use cosmwasm_std::Decimal;
+
+    #[test]
+    fn erf_plus_one_test() {
+        let e6 = 1000000u128;
+        assert_eq!(erf_plus_one(Decimal::zero()), Decimal::zero());
+        assert_eq!(
+            erf_plus_one(Decimal::one()),
+            Decimal::from_ratio(013090u128, e6)
+        );
+        assert_eq!(
+            erf_plus_one(Decimal::from_ratio(3u128, 1u128)),
+            Decimal::from_ratio(1000000u128, e6)
+        );
+        assert_eq!(
+            erf_plus_one(Decimal::from_ratio(5u128, 1u128)),
+            Decimal::from_ratio(1954499u128, e6)
+        );
+        assert_eq!(
+            erf_plus_one(Decimal::from_ratio(10u128, 1u128)),
+            Decimal::from_ratio(2000000u128, e6)
+        );
+        assert_eq!(
+            erf_plus_one(Decimal::from_ratio(14u128, 1u128)),
+            Decimal::from_ratio(2000000u128, e6)
+        );
+    }
+
+    #[test]
+    fn short_reward_weight_test() {
+        let e6 = 1000000u128;
+        let e7 = 10000000u128;
+        assert_eq!(short_reward_weight(Decimal::zero()), Decimal::zero());
+        assert_eq!(
+            short_reward_weight(Decimal::percent(1)),
+            Decimal::from_ratio(002618u128, e6),
+        );
+        assert_eq!(
+            short_reward_weight(Decimal::percent(3)),
+            Decimal::percent(20)
+        );
+        assert_eq!(
+            short_reward_weight(Decimal::percent(5)),
+            Decimal::from_ratio(3908998u128, e7)
+        );
+        assert_eq!(
+            short_reward_weight(Decimal::percent(10)),
+            Decimal::percent(40)
+        );
+        assert_eq!(
+            short_reward_weight(Decimal::percent(15)),
+            Decimal::percent(40)
+        );
+    }
+}

--- a/contracts/mirror_staking/src/math_test.rs
+++ b/contracts/mirror_staking/src/math_test.rs
@@ -1,33 +1,7 @@
 #[cfg(test)]
 mod tests {
-    use crate::math::{erf_plus_one, short_reward_weight};
+    use crate::math::{short_reward_weight};
     use cosmwasm_std::Decimal;
-
-    #[test]
-    fn erf_plus_one_test() {
-        let e6 = 1000000u128;
-        assert_eq!(erf_plus_one(Decimal::zero()), Decimal::zero());
-        assert_eq!(
-            erf_plus_one(Decimal::one()),
-            Decimal::from_ratio(013090u128, e6)
-        );
-        assert_eq!(
-            erf_plus_one(Decimal::from_ratio(3u128, 1u128)),
-            Decimal::from_ratio(1000000u128, e6)
-        );
-        assert_eq!(
-            erf_plus_one(Decimal::from_ratio(5u128, 1u128)),
-            Decimal::from_ratio(1954499u128, e6)
-        );
-        assert_eq!(
-            erf_plus_one(Decimal::from_ratio(10u128, 1u128)),
-            Decimal::from_ratio(2000000u128, e6)
-        );
-        assert_eq!(
-            erf_plus_one(Decimal::from_ratio(14u128, 1u128)),
-            Decimal::from_ratio(2000000u128, e6)
-        );
-    }
 
     #[test]
     fn short_reward_weight_test() {

--- a/contracts/mirror_staking/src/migration.rs
+++ b/contracts/mirror_staking/src/migration.rs
@@ -44,9 +44,6 @@ pub fn migrate_config<S: Storage>(
     oracle_contract: CanonicalAddr,
     terraswap_factory: CanonicalAddr,
     base_denom: String,
-    premium_tolerance: Decimal,
-    short_reward_weight: Decimal,
-    premium_short_reward_weight: Decimal,
     premium_min_update_interval: u64,
 ) -> StdResult<()> {
     let legacy_config = read_legacy_config(storage)?;
@@ -60,9 +57,6 @@ pub fn migrate_config<S: Storage>(
             oracle_contract,
             terraswap_factory,
             base_denom,
-            premium_tolerance,
-            short_reward_weight,
-            premium_short_reward_weight,
             premium_min_update_interval,
         },
     )

--- a/contracts/mirror_staking/src/migration_test.rs
+++ b/contracts/mirror_staking/src/migration_test.rs
@@ -52,9 +52,6 @@ mod tests {
                 .canonical_address(&HumanAddr::from("terraswap_factory"))
                 .unwrap(),
             "uusd".to_string(),
-            Decimal::percent(5),
-            Decimal::percent(20),
-            Decimal::percent(40),
             7200,
         )
         .unwrap();
@@ -82,9 +79,6 @@ mod tests {
                     .canonical_address(&HumanAddr::from("terraswap_factory"))
                     .unwrap(),
                 base_denom: "uusd".to_string(),
-                premium_tolerance: Decimal::percent(5),
-                short_reward_weight: Decimal::percent(20),
-                premium_short_reward_weight: Decimal::percent(40),
                 premium_min_update_interval: 7200,
             },
             read_config(&deps.storage).unwrap()

--- a/contracts/mirror_staking/src/reward_test.rs
+++ b/contracts/mirror_staking/src/reward_test.rs
@@ -56,7 +56,7 @@ mod tests {
             &mut deps.storage,
             &token_raw,
             &PoolInfo {
-                premium_rate: Decimal::percent(3),
+                premium_rate: Decimal::percent(2),
                 ..pool_info
             },
         )
@@ -199,7 +199,7 @@ mod tests {
             &mut deps.storage,
             &token_raw,
             &PoolInfo {
-                premium_rate: Decimal::percent(3),
+                premium_rate: Decimal::percent(2),
                 ..pool_info
             },
         )
@@ -319,7 +319,7 @@ mod tests {
             &mut deps.storage,
             &token_raw,
             &PoolInfo {
-                premium_rate: Decimal::percent(3),
+                premium_rate: Decimal::percent(2),
                 ..pool_info
             },
         )
@@ -477,7 +477,7 @@ mod tests {
             &mut deps.storage,
             &token_raw,
             &PoolInfo {
-                premium_rate: Decimal::percent(3),
+                premium_rate: Decimal::percent(2),
                 ..pool_info
             },
         )
@@ -575,7 +575,7 @@ mod tests {
             &mut deps.storage,
             &token_raw,
             &PoolInfo {
-                premium_rate: Decimal::percent(3),
+                premium_rate: Decimal::percent(2),
                 ..pool_info
             },
         )
@@ -591,7 +591,7 @@ mod tests {
             &mut deps.storage,
             &token_raw,
             &PoolInfo {
-                premium_rate: Decimal::percent(3),
+                premium_rate: Decimal::percent(2),
                 ..pool_info
             },
         )

--- a/contracts/mirror_staking/src/reward_test.rs
+++ b/contracts/mirror_staking/src/reward_test.rs
@@ -32,9 +32,6 @@ mod tests {
             oracle_contract: HumanAddr::from("oracle"),
             terraswap_factory: HumanAddr::from("terraswap_factory"),
             base_denom: "uusd".to_string(),
-            premium_tolerance: Decimal::percent(2),
-            short_reward_weight: Decimal::percent(20),
-            premium_short_reward_weight: Decimal::percent(40),
             premium_min_update_interval: 3600,
         };
 
@@ -48,6 +45,22 @@ mod tests {
 
         let env = mock_env("owner", &[]);
         let _res = handle(&mut deps, env, msg.clone()).unwrap();
+
+        // store 3% premium rate
+        let token_raw = deps
+            .api
+            .canonical_address(&HumanAddr::from("asset"))
+            .unwrap();
+        let pool_info = read_pool_info(&deps.storage, &token_raw).unwrap();
+        store_pool_info(
+            &mut deps.storage,
+            &token_raw,
+            &PoolInfo {
+                premium_rate: Decimal::percent(3),
+                ..pool_info
+            },
+        )
+        .unwrap();
 
         // bond 100 tokens
         let msg = HandleMsg::Receive(Cw20ReceiveMsg {
@@ -162,9 +175,6 @@ mod tests {
             oracle_contract: HumanAddr::from("oracle"),
             terraswap_factory: HumanAddr::from("terraswap_factory"),
             base_denom: "uusd".to_string(),
-            premium_tolerance: Decimal::percent(2),
-            short_reward_weight: Decimal::percent(20),
-            premium_short_reward_weight: Decimal::percent(40),
             premium_min_update_interval: 3600,
         };
 
@@ -178,6 +188,22 @@ mod tests {
 
         let env = mock_env("owner", &[]);
         let _res = handle(&mut deps, env, msg.clone()).unwrap();
+
+        // store 3% premium rate
+        let token_raw = deps
+            .api
+            .canonical_address(&HumanAddr::from("asset"))
+            .unwrap();
+        let pool_info = read_pool_info(&deps.storage, &token_raw).unwrap();
+        store_pool_info(
+            &mut deps.storage,
+            &token_raw,
+            &PoolInfo {
+                premium_rate: Decimal::percent(3),
+                ..pool_info
+            },
+        )
+        .unwrap();
 
         // factory deposit 100 reward tokens
         // premium is 0, so rewards distributed 80:20
@@ -269,9 +295,6 @@ mod tests {
             oracle_contract: HumanAddr::from("oracle"),
             terraswap_factory: HumanAddr::from("terraswap_factory"),
             base_denom: "uusd".to_string(),
-            premium_tolerance: Decimal::percent(2),
-            short_reward_weight: Decimal::percent(20),
-            premium_short_reward_weight: Decimal::percent(40),
             premium_min_update_interval: 3600,
         };
 
@@ -285,6 +308,22 @@ mod tests {
 
         let env = mock_env("owner", &[]);
         let _res = handle(&mut deps, env, msg.clone()).unwrap();
+
+        // store 3% premium rate
+        let token_raw = deps
+            .api
+            .canonical_address(&HumanAddr::from("asset"))
+            .unwrap();
+        let pool_info = read_pool_info(&deps.storage, &token_raw).unwrap();
+        store_pool_info(
+            &mut deps.storage,
+            &token_raw,
+            &PoolInfo {
+                premium_rate: Decimal::percent(3),
+                ..pool_info
+            },
+        )
+        .unwrap();
 
         // bond 100 tokens
         let msg = HandleMsg::Receive(Cw20ReceiveMsg {
@@ -414,9 +453,6 @@ mod tests {
             oracle_contract: HumanAddr::from("oracle"),
             terraswap_factory: HumanAddr::from("terraswap_factory"),
             base_denom: "uusd".to_string(),
-            premium_tolerance: Decimal::percent(2),
-            short_reward_weight: Decimal::percent(20),
-            premium_short_reward_weight: Decimal::percent(40),
             premium_min_update_interval: 3600,
         };
 
@@ -430,6 +466,22 @@ mod tests {
 
         let env = mock_env("owner", &[]);
         let _res = handle(&mut deps, env, msg.clone()).unwrap();
+
+        // store 3% premium rate
+        let token_raw = deps
+            .api
+            .canonical_address(&HumanAddr::from("asset"))
+            .unwrap();
+        let pool_info = read_pool_info(&deps.storage, &token_raw).unwrap();
+        store_pool_info(
+            &mut deps.storage,
+            &token_raw,
+            &PoolInfo {
+                premium_rate: Decimal::percent(3),
+                ..pool_info
+            },
+        )
+        .unwrap();
 
         // bond 100 tokens
         let msg = HandleMsg::Receive(Cw20ReceiveMsg {
@@ -491,9 +543,6 @@ mod tests {
             oracle_contract: HumanAddr::from("oracle"),
             terraswap_factory: HumanAddr::from("terraswap_factory"),
             base_denom: "uusd".to_string(),
-            premium_tolerance: Decimal::percent(2),
-            short_reward_weight: Decimal::percent(20),
-            premium_short_reward_weight: Decimal::percent(40),
             premium_min_update_interval: 3600,
         };
 
@@ -515,6 +564,38 @@ mod tests {
 
         let env = mock_env("owner", &[]);
         let _res = handle(&mut deps, env, msg.clone()).unwrap();
+
+        // store 3% premium rate
+        let token_raw = deps
+            .api
+            .canonical_address(&HumanAddr::from("asset"))
+            .unwrap();
+        let pool_info = read_pool_info(&deps.storage, &token_raw).unwrap();
+        store_pool_info(
+            &mut deps.storage,
+            &token_raw,
+            &PoolInfo {
+                premium_rate: Decimal::percent(3),
+                ..pool_info
+            },
+        )
+        .unwrap();
+
+        // store 3% premium rate for asset2
+        let token_raw = deps
+            .api
+            .canonical_address(&HumanAddr::from("asset2"))
+            .unwrap();
+        let pool_info = read_pool_info(&deps.storage, &token_raw).unwrap();
+        store_pool_info(
+            &mut deps.storage,
+            &token_raw,
+            &PoolInfo {
+                premium_rate: Decimal::percent(3),
+                ..pool_info
+            },
+        )
+        .unwrap();
 
         // bond 100 tokens
         let msg = HandleMsg::Receive(Cw20ReceiveMsg {
@@ -693,9 +774,6 @@ mod tests {
             oracle_contract: HumanAddr::from("oracle"),
             terraswap_factory: HumanAddr::from("terraswap_factory"),
             base_denom: "uusd".to_string(),
-            premium_tolerance: Decimal::percent(2),
-            short_reward_weight: Decimal::percent(20),
-            premium_short_reward_weight: Decimal::percent(40),
             premium_min_update_interval: 3600,
         };
 

--- a/contracts/mirror_staking/src/staking_test.rs
+++ b/contracts/mirror_staking/src/staking_test.rs
@@ -22,9 +22,6 @@ mod tests {
             oracle_contract: HumanAddr::from("oracle"),
             terraswap_factory: HumanAddr::from("terraswap_factory"),
             base_denom: "uusd".to_string(),
-            premium_tolerance: Decimal::percent(2),
-            short_reward_weight: Decimal::percent(20),
-            premium_short_reward_weight: Decimal::percent(40),
             premium_min_update_interval: 3600,
         };
 
@@ -168,9 +165,6 @@ mod tests {
             oracle_contract: HumanAddr::from("oracle"),
             terraswap_factory: HumanAddr::from("terraswap_factory"),
             base_denom: "uusd".to_string(),
-            premium_tolerance: Decimal::percent(2),
-            short_reward_weight: Decimal::percent(20),
-            premium_short_reward_weight: Decimal::percent(40),
             premium_min_update_interval: 3600,
         };
 
@@ -289,9 +283,6 @@ mod tests {
             oracle_contract: HumanAddr::from("oracle"),
             terraswap_factory: HumanAddr::from("terraswap_factory"),
             base_denom: "uusd".to_string(),
-            premium_tolerance: Decimal::percent(2),
-            short_reward_weight: Decimal::percent(20),
-            premium_short_reward_weight: Decimal::percent(40),
             premium_min_update_interval: 3600,
         };
 
@@ -390,9 +381,6 @@ mod tests {
             oracle_contract: HumanAddr::from("oracle"),
             terraswap_factory: HumanAddr::from("terraswap_factory"),
             base_denom: "uusd".to_string(),
-            premium_tolerance: Decimal::percent(2),
-            short_reward_weight: Decimal::percent(20),
-            premium_short_reward_weight: Decimal::percent(40),
             premium_min_update_interval: 3600,
         };
 

--- a/contracts/mirror_staking/src/state.rs
+++ b/contracts/mirror_staking/src/state.rs
@@ -18,9 +18,6 @@ pub struct Config {
     pub oracle_contract: CanonicalAddr,
     pub terraswap_factory: CanonicalAddr,
     pub base_denom: String,
-    pub premium_tolerance: Decimal,
-    pub short_reward_weight: Decimal,
-    pub premium_short_reward_weight: Decimal,
     pub premium_min_update_interval: u64,
 }
 

--- a/packages/mirror_protocol/src/staking.rs
+++ b/packages/mirror_protocol/src/staking.rs
@@ -12,9 +12,6 @@ pub struct InitMsg {
     pub oracle_contract: HumanAddr,
     pub terraswap_factory: HumanAddr,
     pub base_denom: String,
-    pub premium_tolerance: Decimal,
-    pub short_reward_weight: Decimal,
-    pub premium_short_reward_weight: Decimal,
     pub premium_min_update_interval: u64,
 }
 
@@ -28,9 +25,6 @@ pub enum HandleMsg {
     ////////////////////////
     UpdateConfig {
         owner: Option<HumanAddr>,
-        premium_tolerance: Option<Decimal>,
-        short_reward_weight: Option<Decimal>,
-        premium_short_reward_weight: Option<Decimal>,
         premium_min_update_interval: Option<u64>,
     },
     RegisterAsset {
@@ -87,9 +81,6 @@ pub struct MigrateMsg {
     pub oracle_contract: HumanAddr,
     pub terraswap_factory: HumanAddr,
     pub base_denom: String,
-    pub premium_tolerance: Decimal,
-    pub short_reward_weight: Decimal,
-    pub premium_short_reward_weight: Decimal,
     pub premium_min_update_interval: u64,
 }
 
@@ -115,9 +106,6 @@ pub struct ConfigResponse {
     pub oracle_contract: HumanAddr,
     pub terraswap_factory: HumanAddr,
     pub base_denom: String,
-    pub premium_tolerance: Decimal,
-    pub short_reward_weight: Decimal,
-    pub premium_short_reward_weight: Decimal,
     pub premium_min_update_interval: u64,
 }
 


### PR DESCRIPTION
### Change notes

Remove following params from the staking contract
 * short_reward_weight
 * premium_short_reward_weight
 * premium_tolerance

Now we compute the short_reward_weight from the following equation:
```
# To prevent overflow or resource waste
# following checks are added
if premium_rate > 7%: return 40%

let p = premium_rate * 100;
let x = (p -2) / sqrt(2);
let short_reward_weight = (1 + erf(x)) / 5;
```