### PR TITLE
Add optional intermediate_denom parameter to terraswap price source

### DIFF
--- a/contracts/mirror_collateral_oracle/schema/handle_msg.json
+++ b/contracts/mirror_collateral_oracle/schema/handle_msg.json
@@ -269,6 +269,12 @@
                 "terraswap_query"
               ],
               "properties": {
+                "intermediate_denom": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
                 "terraswap_query": {
                   "$ref": "#/definitions/Binary"
                 }

--- a/contracts/mirror_collateral_oracle/src/math.rs
+++ b/contracts/mirror_collateral_oracle/src/math.rs
@@ -6,3 +6,7 @@ const DECIMAL_FRACTIONAL: Uint128 = Uint128(1_000_000_000u128);
 pub fn decimal_division(a: Decimal, b: Decimal) -> Decimal {
     Decimal::from_ratio(DECIMAL_FRACTIONAL * a, b * DECIMAL_FRACTIONAL)
 }
+
+pub fn decimal_multiplication(a: Decimal, b: Decimal) -> Decimal {
+    Decimal::from_ratio(a * DECIMAL_FRACTIONAL * b, DECIMAL_FRACTIONAL)
+}

--- a/packages/mirror_protocol/src/collateral_oracle.rs
+++ b/packages/mirror_protocol/src/collateral_oracle.rs
@@ -102,6 +102,7 @@ pub enum SourceType {
     },
     Terraswap {
         terraswap_query: Binary,
+        intermediate_denom: Option<String>,
     },
     AnchorMarket {
         anchor_market_query: Binary,


### PR DESCRIPTION
### Overview

To be able to cover cases where there is no direct terraswap pair with UST, we add an additional `intermedaite_denom` parameter to the Terraswap collateral price source.

`rate = (query_rate / intermadiate_denom) * (intermediate_denom / quote_denom)`

This would be useful to add collaterals such as bLuna, since there is only a pair with Luna.

**Example**
```
intermediate_denom = luna

terraswap_price = bLuna / luna
native_price = luna / ust
final_price = terraswap_price * native_price
```