### PR TITLE
[Feature] New mechanism for preIPO assets

### DIFF
--- a/contracts/mirror_factory/schema/handle_msg.json
+++ b/contracts/mirror_factory/schema/handle_msg.json
@@ -358,6 +358,17 @@
           "format": "uint64",
           "minimum": 0.0
         },
+        "pre_ipo_price": {
+          "description": "For pre-IPO assets, fixed price during minting period",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Decimal"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "weight": {
           "description": "Distribution weight (default is 30, which is 1/10 of MIR distribution weight)",
           "type": [

--- a/contracts/mirror_factory/schema/handle_msg.json
+++ b/contracts/mirror_factory/schema/handle_msg.json
@@ -338,8 +338,8 @@
             }
           ]
         },
-        "min_collateral_ratio_after_migration": {
-          "description": "For pre-IPO assets, collateral ratio for the asset after migration",
+        "min_collateral_ratio_after_ipo": {
+          "description": "For pre-IPO assets, collateral ratio for the asset after ipo",
           "anyOf": [
             {
               "$ref": "#/definitions/Decimal"

--- a/contracts/mirror_factory/src/mock_querier.rs
+++ b/contracts/mirror_factory/src/mock_querier.rs
@@ -102,10 +102,7 @@ pub(crate) fn configs_to_map(
 ) -> HashMap<HumanAddr, (Decimal, Decimal)> {
     let mut configs_map: HashMap<HumanAddr, (Decimal, Decimal)> = HashMap::new();
     for (contract_addr, touple) in configs.iter() {
-        configs_map.insert(
-            HumanAddr::from(contract_addr),
-            (touple.0, touple.1),
-        );
+        configs_map.insert(HumanAddr::from(contract_addr), (touple.0, touple.1));
     }
     configs_map
 }
@@ -252,10 +249,7 @@ impl WasmMockQuerier {
         self.oracle_querier = OracleQuerier::new(feeders);
     }
 
-    pub fn with_mint_configs(
-        &mut self,
-        configs: &[(&HumanAddr, &(Decimal, Decimal))],
-    ) {
+    pub fn with_mint_configs(&mut self, configs: &[(&HumanAddr, &(Decimal, Decimal))]) {
         self.mint_querier = MintQuerier::new(configs);
     }
 }

--- a/contracts/mirror_factory/src/mock_querier.rs
+++ b/contracts/mirror_factory/src/mock_querier.rs
@@ -86,11 +86,11 @@ pub(crate) fn address_pair_to_map(
 
 #[derive(Clone, Default)]
 pub struct MintQuerier {
-    configs: HashMap<HumanAddr, (Decimal, Decimal, Option<Decimal>)>,
+    configs: HashMap<HumanAddr, (Decimal, Decimal)>,
 }
 
 impl MintQuerier {
-    pub fn new(configs: &[(&HumanAddr, &(Decimal, Decimal, Option<Decimal>))]) -> Self {
+    pub fn new(configs: &[(&HumanAddr, &(Decimal, Decimal))]) -> Self {
         MintQuerier {
             configs: configs_to_map(configs),
         }
@@ -98,13 +98,13 @@ impl MintQuerier {
 }
 
 pub(crate) fn configs_to_map(
-    configs: &[(&HumanAddr, &(Decimal, Decimal, Option<Decimal>))],
-) -> HashMap<HumanAddr, (Decimal, Decimal, Option<Decimal>)> {
-    let mut configs_map: HashMap<HumanAddr, (Decimal, Decimal, Option<Decimal>)> = HashMap::new();
+    configs: &[(&HumanAddr, &(Decimal, Decimal))],
+) -> HashMap<HumanAddr, (Decimal, Decimal)> {
+    let mut configs_map: HashMap<HumanAddr, (Decimal, Decimal)> = HashMap::new();
     for (contract_addr, touple) in configs.iter() {
         configs_map.insert(
             HumanAddr::from(contract_addr),
-            (touple.0, touple.1, touple.2),
+            (touple.0, touple.1),
         );
     }
     configs_map
@@ -220,7 +220,6 @@ impl WasmMockQuerier {
                             token: api.canonical_address(&asset_token).unwrap(),
                             auction_discount: config.0,
                             min_collateral_ratio: config.1,
-                            min_collateral_ratio_after_migration: config.2,
                         })
                         .unwrap(),
                     ))
@@ -255,7 +254,7 @@ impl WasmMockQuerier {
 
     pub fn with_mint_configs(
         &mut self,
-        configs: &[(&HumanAddr, &(Decimal, Decimal, Option<Decimal>))],
+        configs: &[(&HumanAddr, &(Decimal, Decimal))],
     ) {
         self.mint_querier = MintQuerier::new(configs);
     }

--- a/contracts/mirror_factory/src/querier.rs
+++ b/contracts/mirror_factory/src/querier.rs
@@ -42,14 +42,13 @@ pub struct MintAssetConfig {
     pub token: CanonicalAddr,
     pub auction_discount: Decimal,
     pub min_collateral_ratio: Decimal,
-    pub min_collateral_ratio_after_migration: Option<Decimal>,
 }
 
 pub fn load_mint_asset_config<S: Storage, A: Api, Q: Querier>(
     deps: &Extern<S, A, Q>,
     contract_addr: &HumanAddr,
     asset_token: &CanonicalAddr,
-) -> StdResult<(Decimal, Decimal, Option<Decimal>)> {
+) -> StdResult<(Decimal, Decimal)> {
     let res: StdResult<Binary> = deps.querier.query(&QueryRequest::Wasm(WasmQuery::Raw {
         contract_addr: HumanAddr::from(contract_addr),
         key: Binary::from(concat(
@@ -80,7 +79,6 @@ pub fn load_mint_asset_config<S: Storage, A: Api, Q: Querier>(
     Ok((
         asset_config.auction_discount,
         asset_config.min_collateral_ratio,
-        asset_config.min_collateral_ratio_after_migration,
     ))
 }
 

--- a/contracts/mirror_factory/src/testing.rs
+++ b/contracts/mirror_factory/src/testing.rs
@@ -289,6 +289,7 @@ fn test_whitelist() {
             weight: Some(100u32),
             mint_period: None,
             min_collateral_ratio_after_ipo: None,
+            pre_ipo_price: None,
         },
     };
     let env = mock_env("owner0000", &[]);
@@ -340,6 +341,7 @@ fn test_whitelist() {
             weight: Some(100u32),
             mint_period: None,
             min_collateral_ratio_after_ipo: None,
+            pre_ipo_price: None,
         }
     );
 
@@ -404,6 +406,7 @@ fn test_token_creation_hook() {
             weight: Some(100u32),
             mint_period: None,
             min_collateral_ratio_after_ipo: None,
+            pre_ipo_price: None,
         },
     };
     let env = mock_env("owner0000", &[]);
@@ -459,6 +462,13 @@ fn test_token_creation_hook() {
                 })
                 .unwrap(),
             })
+        ]
+    );
+    assert_eq!(
+        res.log,
+        vec![
+            log("asset_token_addr", "asset0000"),
+            log("is_pre_ipo", false),
         ]
     );
 
@@ -533,6 +543,7 @@ fn test_token_creation_hook_without_weight() {
             weight: None,
             mint_period: None,
             min_collateral_ratio_after_ipo: None,
+            pre_ipo_price: None,
         },
     };
     let env = mock_env("owner0000", &[]);
@@ -651,6 +662,7 @@ fn test_terraswap_creation_hook() {
             weight: Some(100u32),
             mint_period: None,
             min_collateral_ratio_after_ipo: None,
+            pre_ipo_price: None,
         },
     };
     let env = mock_env("owner0000", &[]);
@@ -723,6 +735,7 @@ fn test_distribute() {
             weight: Some(100u32),
             mint_period: None,
             min_collateral_ratio_after_ipo: None,
+            pre_ipo_price: None,
         },
     };
     let env = mock_env("owner0000", &[]);
@@ -751,6 +764,7 @@ fn test_distribute() {
             weight: Some(100u32),
             mint_period: None,
             min_collateral_ratio_after_ipo: None,
+            pre_ipo_price: None,
         },
     };
     let env = mock_env("owner0000", &[]);
@@ -845,6 +859,7 @@ fn whitelist_token(
             weight: Some(weight),
             mint_period: None,
             min_collateral_ratio_after_ipo: None,
+            pre_ipo_price: None,
         },
     };
     let env = mock_env("owner0000", &[]);
@@ -1021,6 +1036,7 @@ fn test_revocation() {
             weight: Some(100u32),
             mint_period: None,
             min_collateral_ratio_after_ipo: None,
+            pre_ipo_price: None,
         },
     };
     let env = mock_env("owner0000", &[]);
@@ -1049,6 +1065,7 @@ fn test_revocation() {
             weight: Some(100u32),
             mint_period: None,
             min_collateral_ratio_after_ipo: None,
+            pre_ipo_price: None,
         },
     };
     let env = mock_env("owner0000", &[]);
@@ -1164,6 +1181,7 @@ fn test_migration() {
             weight: Some(100u32),
             mint_period: None,
             min_collateral_ratio_after_ipo: None,
+            pre_ipo_price: None,
         },
     };
     let env = mock_env("owner0000", &[]);
@@ -1281,6 +1299,7 @@ fn test_whitelist_pre_ipo_asset() {
             weight: Some(100u32),
             mint_period: Some(10000u64),
             min_collateral_ratio_after_ipo: Some(Decimal::percent(150)),
+            pre_ipo_price: Some(Decimal::percent(1)),
         },
     };
     let env = mock_env("owner0000", &[]);
@@ -1323,6 +1342,7 @@ fn test_whitelist_pre_ipo_asset() {
             weight: Some(100u32),
             mint_period: Some(10000u64),
             min_collateral_ratio_after_ipo: Some(Decimal::percent(150)),
+            pre_ipo_price: Some(Decimal::percent(1)),
         }
     );
 
@@ -1344,8 +1364,9 @@ fn test_whitelist_pre_ipo_asset() {
                     auction_discount: Decimal::percent(5),
                     min_collateral_ratio: Decimal::percent(1000),
                     ipo_params: Some(IPOParams {
-                        mint_end: env.block.height + 10000u64,
+                        mint_end: env.block.time + 10000u64,
                         min_collateral_ratio_after_ipo: Decimal::percent(150),
+                        pre_ipo_price: Decimal::percent(1),
                     }),
                 })
                 .unwrap(),
@@ -1381,6 +1402,17 @@ fn test_whitelist_pre_ipo_asset() {
                 })
                 .unwrap(),
             })
+        ]
+    );
+
+    assert_eq!(
+        res.log,
+        vec![
+            log("asset_token_addr", "asset0000"),
+            log("is_pre_ipo", true),
+            log("mint_end", env.block.time + 10000u64),
+            log("min_collateral_ratio_after_ipo", "1.5"),
+            log("pre_ipo_price", "0.01"),
         ]
     );
 }

--- a/contracts/mirror_factory/src/testing.rs
+++ b/contracts/mirror_factory/src/testing.rs
@@ -13,7 +13,7 @@ use cw20::{Cw20HandleMsg, MinterResponse};
 use mirror_protocol::factory::{
     ConfigResponse, DistributionInfoResponse, HandleMsg, InitMsg, Params, QueryMsg,
 };
-use mirror_protocol::mint::HandleMsg as MintHandleMsg;
+use mirror_protocol::mint::{HandleMsg as MintHandleMsg, IPOParams};
 use mirror_protocol::oracle::HandleMsg as OracleHandleMsg;
 use mirror_protocol::staking::Cw20HookMsg as StakingCw20HookMsg;
 use mirror_protocol::staking::HandleMsg as StakingHandleMsg;
@@ -288,7 +288,7 @@ fn test_whitelist() {
             min_collateral_ratio: Decimal::percent(150),
             weight: Some(100u32),
             mint_period: None,
-            min_collateral_ratio_after_migration: None,
+            min_collateral_ratio_after_ipo: None,
         },
     };
     let env = mock_env("owner0000", &[]);
@@ -339,7 +339,7 @@ fn test_whitelist() {
             min_collateral_ratio: Decimal::percent(150),
             weight: Some(100u32),
             mint_period: None,
-            min_collateral_ratio_after_migration: None,
+            min_collateral_ratio_after_ipo: None,
         }
     );
 
@@ -403,7 +403,7 @@ fn test_token_creation_hook() {
             min_collateral_ratio: Decimal::percent(150),
             weight: Some(100u32),
             mint_period: None,
-            min_collateral_ratio_after_migration: None,
+            min_collateral_ratio_after_ipo: None,
         },
     };
     let env = mock_env("owner0000", &[]);
@@ -424,8 +424,7 @@ fn test_token_creation_hook() {
                     asset_token: HumanAddr::from("asset0000"),
                     auction_discount: Decimal::percent(5),
                     min_collateral_ratio: Decimal::percent(150),
-                    mint_end: None,
-                    min_collateral_ratio_after_migration: None,
+                    ipo_params: None,
                 })
                 .unwrap(),
             }),
@@ -533,7 +532,7 @@ fn test_token_creation_hook_without_weight() {
             min_collateral_ratio: Decimal::percent(150),
             weight: None,
             mint_period: None,
-            min_collateral_ratio_after_migration: None,
+            min_collateral_ratio_after_ipo: None,
         },
     };
     let env = mock_env("owner0000", &[]);
@@ -554,8 +553,7 @@ fn test_token_creation_hook_without_weight() {
                     asset_token: HumanAddr::from("asset0000"),
                     auction_discount: Decimal::percent(5),
                     min_collateral_ratio: Decimal::percent(150),
-                    mint_end: None,
-                    min_collateral_ratio_after_migration: None,
+                    ipo_params: None,
                 })
                 .unwrap(),
             }),
@@ -652,7 +650,7 @@ fn test_terraswap_creation_hook() {
             min_collateral_ratio: Decimal::percent(150),
             weight: Some(100u32),
             mint_period: None,
-            min_collateral_ratio_after_migration: None,
+            min_collateral_ratio_after_ipo: None,
         },
     };
     let env = mock_env("owner0000", &[]);
@@ -724,7 +722,7 @@ fn test_distribute() {
             min_collateral_ratio: Decimal::percent(150),
             weight: Some(100u32),
             mint_period: None,
-            min_collateral_ratio_after_migration: None,
+            min_collateral_ratio_after_ipo: None,
         },
     };
     let env = mock_env("owner0000", &[]);
@@ -752,7 +750,7 @@ fn test_distribute() {
             min_collateral_ratio: Decimal::percent(150),
             weight: Some(100u32),
             mint_period: None,
-            min_collateral_ratio_after_migration: None,
+            min_collateral_ratio_after_ipo: None,
         },
     };
     let env = mock_env("owner0000", &[]);
@@ -846,7 +844,7 @@ fn whitelist_token(
             min_collateral_ratio: Decimal::percent(150),
             weight: Some(weight),
             mint_period: None,
-            min_collateral_ratio_after_migration: None,
+            min_collateral_ratio_after_ipo: None,
         },
     };
     let env = mock_env("owner0000", &[]);
@@ -1022,7 +1020,7 @@ fn test_revocation() {
             min_collateral_ratio: Decimal::percent(150),
             weight: Some(100u32),
             mint_period: None,
-            min_collateral_ratio_after_migration: None,
+            min_collateral_ratio_after_ipo: None,
         },
     };
     let env = mock_env("owner0000", &[]);
@@ -1050,7 +1048,7 @@ fn test_revocation() {
             min_collateral_ratio: Decimal::percent(150),
             weight: Some(100u32),
             mint_period: None,
-            min_collateral_ratio_after_migration: None,
+            min_collateral_ratio_after_ipo: None,
         },
     };
     let env = mock_env("owner0000", &[]);
@@ -1165,7 +1163,7 @@ fn test_migration() {
             min_collateral_ratio: Decimal::percent(150),
             weight: Some(100u32),
             mint_period: None,
-            min_collateral_ratio_after_migration: None,
+            min_collateral_ratio_after_ipo: None,
         },
     };
     let env = mock_env("owner0000", &[]);
@@ -1186,7 +1184,7 @@ fn test_migration() {
     // register queriers
     deps.querier.with_mint_configs(&[(
         &HumanAddr::from("asset0000"),
-        &(Decimal::percent(1), Decimal::percent(1), None),
+        &(Decimal::percent(1), Decimal::percent(1)),
     )]);
     deps.querier.with_oracle_feeders(&[(
         &HumanAddr::from("asset0000"),
@@ -1282,7 +1280,7 @@ fn test_whitelist_pre_ipo_asset() {
             min_collateral_ratio: Decimal::percent(1000),
             weight: Some(100u32),
             mint_period: Some(10000u64),
-            min_collateral_ratio_after_migration: Some(Decimal::percent(150)),
+            min_collateral_ratio_after_ipo: Some(Decimal::percent(150)),
         },
     };
     let env = mock_env("owner0000", &[]);
@@ -1324,7 +1322,7 @@ fn test_whitelist_pre_ipo_asset() {
             min_collateral_ratio: Decimal::percent(1000),
             weight: Some(100u32),
             mint_period: Some(10000u64),
-            min_collateral_ratio_after_migration: Some(Decimal::percent(150)),
+            min_collateral_ratio_after_ipo: Some(Decimal::percent(150)),
         }
     );
 
@@ -1345,8 +1343,10 @@ fn test_whitelist_pre_ipo_asset() {
                     asset_token: HumanAddr::from("asset0000"),
                     auction_discount: Decimal::percent(5),
                     min_collateral_ratio: Decimal::percent(1000),
-                    mint_end: Some(env.block.height + 10000u64),
-                    min_collateral_ratio_after_migration: Some(Decimal::percent(150)),
+                    ipo_params: Some(IPOParams {
+                        mint_end: env.block.height + 10000u64,
+                        min_collateral_ratio_after_ipo: Decimal::percent(150),
+                    }),
                 })
                 .unwrap(),
             }),
@@ -1374,179 +1374,6 @@ fn test_whitelist_pre_ipo_asset() {
                     init_hook: Some(InitHook {
                         msg: to_binary(&HandleMsg::TerraswapCreationHook {
                             asset_token: HumanAddr::from("asset0000"),
-                        })
-                        .unwrap(),
-                        contract_addr: HumanAddr::from(MOCK_CONTRACT_ADDR),
-                    }),
-                })
-                .unwrap(),
-            })
-        ]
-    );
-}
-
-#[test]
-fn test_migrate_pre_ipo_asset() {
-    let mut deps = mock_dependencies(20, &[]);
-    deps.querier.with_terraswap_pairs(&[(
-        &"uusdpreIPOasset0000".to_string(),
-        &HumanAddr::from("LP0000"),
-    )]);
-
-    let msg = InitMsg {
-        base_denom: BASE_DENOM.to_string(),
-        token_code_id: TOKEN_CODE_ID,
-        distribution_schedule: vec![],
-    };
-
-    let env = mock_env("addr0000", &[]);
-    let _res = init(&mut deps, env.clone(), msg).unwrap();
-
-    let msg = HandleMsg::PostInitialize {
-        owner: HumanAddr::from("owner0000"),
-        mirror_token: HumanAddr::from("mirror0000"),
-        mint_contract: HumanAddr::from("mint0000"),
-        staking_contract: HumanAddr::from("staking0000"),
-        commission_collector: HumanAddr::from("collector0000"),
-        oracle_contract: HumanAddr::from("oracle0000"),
-        terraswap_factory: HumanAddr::from("terraswapfactory"),
-    };
-    let _res = handle(&mut deps, env, msg).unwrap();
-
-    // whitelist pre-IPO asset
-    let msg = HandleMsg::Whitelist {
-        name: "Pre-IPO asset".to_string(),
-        symbol: "mPreIPO".to_string(),
-        oracle_feeder: HumanAddr::from("feeder0000"),
-        params: Params {
-            auction_discount: Decimal::percent(5),
-            min_collateral_ratio: Decimal::percent(1000),
-            weight: Some(100u32),
-            mint_period: Some(1000u64),
-            min_collateral_ratio_after_migration: Some(Decimal::percent(150)),
-        },
-    };
-    let env = mock_env("owner0000", &[]);
-    let _res = handle(&mut deps, env, msg).unwrap();
-
-    let msg = HandleMsg::TokenCreationHook {
-        oracle_feeder: HumanAddr::from("feeder0000"),
-    };
-    let env = mock_env("preIPOasset0000", &[]);
-    let _res = handle(&mut deps, env, msg).unwrap();
-
-    let msg = HandleMsg::TerraswapCreationHook {
-        asset_token: HumanAddr::from("preIPOasset0000"),
-    };
-    let env = mock_env("terraswapfactory", &[]);
-    let _res = handle(&mut deps, env, msg).unwrap();
-
-    // register queriers
-    deps.querier.with_mint_configs(&[(
-        &HumanAddr::from("preIPOasset0000"),
-        &(
-            Decimal::percent(5),
-            Decimal::percent(1000),
-            Some(Decimal::percent(150)),
-        ),
-    )]);
-    deps.querier.with_oracle_feeders(&[(
-        &HumanAddr::from("preIPOasset0000"),
-        &HumanAddr::from("feeder0000"),
-    )]);
-
-    // migration triggered by feeder
-    let msg = HandleMsg::MigrateAsset {
-        name: "Post-IPO asset".to_string(),
-        symbol: "mPostIPO".to_string(),
-        from_token: HumanAddr::from("preIPOasset0000"),
-        end_price: Decimal::from_ratio(2u128, 1u128), // give first IPO price
-    };
-
-    let env = mock_env("feeder0000", &[]);
-    let res = handle(&mut deps, env, msg).unwrap();
-    assert_eq!(
-        res.messages,
-        vec![
-            CosmosMsg::Wasm(WasmMsg::Execute {
-                contract_addr: HumanAddr::from("mint0000"),
-                send: vec![],
-                msg: to_binary(&MintHandleMsg::RegisterMigration {
-                    asset_token: HumanAddr::from("preIPOasset0000"),
-                    end_price: Decimal::from_ratio(2u128, 1u128),
-                })
-                .unwrap(),
-            }),
-            CosmosMsg::Wasm(WasmMsg::Instantiate {
-                code_id: TOKEN_CODE_ID,
-                send: vec![],
-                label: None,
-                msg: to_binary(&TokenInitMsg {
-                    name: "Post-IPO asset".to_string(),
-                    symbol: "mPostIPO".to_string(),
-                    decimals: 6u8,
-                    initial_balances: vec![],
-                    mint: Some(MinterResponse {
-                        minter: HumanAddr::from("mint0000"),
-                        cap: None,
-                    }),
-                    init_hook: Some(InitHook {
-                        contract_addr: HumanAddr::from(MOCK_CONTRACT_ADDR),
-                        msg: to_binary(&HandleMsg::TokenCreationHook {
-                            oracle_feeder: HumanAddr::from("feeder0000") // same feeder
-                        })
-                        .unwrap(),
-                    }),
-                })
-                .unwrap(),
-            })
-        ]
-    );
-
-    let msg = HandleMsg::TokenCreationHook {
-        oracle_feeder: HumanAddr::from("feeder0000"),
-    };
-    let env = mock_env("postIPOasset", &[]);
-    let res = handle(&mut deps, env.clone(), msg.clone()).unwrap();
-    assert_eq!(
-        res.messages,
-        vec![
-            CosmosMsg::Wasm(WasmMsg::Execute {
-                contract_addr: HumanAddr::from("mint0000"),
-                send: vec![],
-                msg: to_binary(&MintHandleMsg::RegisterAsset {
-                    asset_token: HumanAddr::from("postIPOasset"),
-                    auction_discount: Decimal::percent(5),
-                    min_collateral_ratio: Decimal::percent(150), // new collateral ratio
-                    mint_end: None,                              // reset to None
-                    min_collateral_ratio_after_migration: None,  // reset to None
-                })
-                .unwrap(),
-            }),
-            CosmosMsg::Wasm(WasmMsg::Execute {
-                contract_addr: HumanAddr::from("oracle0000"),
-                send: vec![],
-                msg: to_binary(&OracleHandleMsg::RegisterAsset {
-                    asset_token: HumanAddr::from("postIPOasset"),
-                    feeder: HumanAddr::from("feeder0000"),
-                })
-                .unwrap(),
-            }),
-            CosmosMsg::Wasm(WasmMsg::Execute {
-                contract_addr: HumanAddr::from("terraswapfactory"),
-                send: vec![],
-                msg: to_binary(&TerraswapFactoryHandleMsg::CreatePair {
-                    asset_infos: [
-                        AssetInfo::NativeToken {
-                            denom: BASE_DENOM.to_string(),
-                        },
-                        AssetInfo::Token {
-                            contract_addr: HumanAddr::from("postIPOasset"),
-                        },
-                    ],
-                    init_hook: Some(InitHook {
-                        msg: to_binary(&HandleMsg::TerraswapCreationHook {
-                            asset_token: HumanAddr::from("postIPOasset"),
                         })
                         .unwrap(),
                         contract_addr: HumanAddr::from(MOCK_CONTRACT_ADDR),

--- a/contracts/mirror_mint/schema/asset_config_response.json
+++ b/contracts/mirror_mint/schema/asset_config_response.json
@@ -50,7 +50,8 @@
       "type": "object",
       "required": [
         "min_collateral_ratio_after_ipo",
-        "mint_end"
+        "mint_end",
+        "pre_ipo_price"
       ],
       "properties": {
         "min_collateral_ratio_after_ipo": {
@@ -60,6 +61,9 @@
           "type": "integer",
           "format": "uint64",
           "minimum": 0.0
+        },
+        "pre_ipo_price": {
+          "$ref": "#/definitions/Decimal"
         }
       }
     }

--- a/contracts/mirror_mint/schema/asset_config_response.json
+++ b/contracts/mirror_mint/schema/asset_config_response.json
@@ -21,26 +21,18 @@
         }
       ]
     },
-    "min_collateral_ratio": {
-      "$ref": "#/definitions/Decimal"
-    },
-    "min_collateral_ratio_after_migration": {
+    "ipo_params": {
       "anyOf": [
         {
-          "$ref": "#/definitions/Decimal"
+          "$ref": "#/definitions/IPOParams"
         },
         {
           "type": "null"
         }
       ]
     },
-    "mint_end": {
-      "type": [
-        "integer",
-        "null"
-      ],
-      "format": "uint64",
-      "minimum": 0.0
+    "min_collateral_ratio": {
+      "$ref": "#/definitions/Decimal"
     },
     "token": {
       "$ref": "#/definitions/HumanAddr"
@@ -48,11 +40,28 @@
   },
   "definitions": {
     "Decimal": {
-      "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0 The greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
+      "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
       "type": "string"
     },
     "HumanAddr": {
       "type": "string"
+    },
+    "IPOParams": {
+      "type": "object",
+      "required": [
+        "min_collateral_ratio_after_ipo",
+        "mint_end"
+      ],
+      "properties": {
+        "min_collateral_ratio_after_ipo": {
+          "$ref": "#/definitions/Decimal"
+        },
+        "mint_end": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        }
+      }
     }
   }
 }

--- a/contracts/mirror_mint/schema/cw20_hook_msg.json
+++ b/contracts/mirror_mint/schema/cw20_hook_msg.json
@@ -140,7 +140,7 @@
       ]
     },
     "Decimal": {
-      "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0 The greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
+      "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
       "type": "string"
     },
     "HumanAddr": {

--- a/contracts/mirror_mint/schema/handle_msg.json
+++ b/contracts/mirror_mint/schema/handle_msg.json
@@ -141,6 +141,16 @@
                 }
               ]
             },
+            "ipo_params": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/IPOParams"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
             "min_collateral_ratio": {
               "anyOf": [
                 {
@@ -176,26 +186,18 @@
             "auction_discount": {
               "$ref": "#/definitions/Decimal"
             },
-            "min_collateral_ratio": {
-              "$ref": "#/definitions/Decimal"
-            },
-            "min_collateral_ratio_after_migration": {
+            "ipo_params": {
               "anyOf": [
                 {
-                  "$ref": "#/definitions/Decimal"
+                  "$ref": "#/definitions/IPOParams"
                 },
                 {
                   "type": "null"
                 }
               ]
             },
-            "mint_end": {
-              "type": [
-                "integer",
-                "null"
-              ],
-              "format": "uint64",
-              "minimum": 0.0
+            "min_collateral_ratio": {
+              "$ref": "#/definitions/Decimal"
             }
           }
         }
@@ -219,6 +221,26 @@
             },
             "end_price": {
               "$ref": "#/definitions/Decimal"
+            }
+          }
+        }
+      }
+    },
+    {
+      "description": "Asset feeder is allowed to trigger IPO event on preIPO assets",
+      "type": "object",
+      "required": [
+        "trigger_i_p_o"
+      ],
+      "properties": {
+        "trigger_i_p_o": {
+          "type": "object",
+          "required": [
+            "asset_token"
+          ],
+          "properties": {
+            "asset_token": {
+              "$ref": "#/definitions/HumanAddr"
             }
           }
         }
@@ -439,6 +461,23 @@
     },
     "HumanAddr": {
       "type": "string"
+    },
+    "IPOParams": {
+      "type": "object",
+      "required": [
+        "min_collateral_ratio_after_ipo",
+        "mint_end"
+      ],
+      "properties": {
+        "min_collateral_ratio_after_ipo": {
+          "$ref": "#/definitions/Decimal"
+        },
+        "mint_end": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        }
+      }
     },
     "ShortParams": {
       "type": "object",

--- a/contracts/mirror_mint/schema/short_params.json
+++ b/contracts/mirror_mint/schema/short_params.json
@@ -26,7 +26,7 @@
   },
   "definitions": {
     "Decimal": {
-      "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0 The greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
+      "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
       "type": "string"
     }
   }

--- a/contracts/mirror_mint/src/asserts.rs
+++ b/contracts/mirror_mint/src/asserts.rs
@@ -75,11 +75,11 @@ pub fn assert_min_collateral_ratio(min_collateral_ratio: Decimal) -> StdResult<(
 }
 
 pub fn assert_mint_period(env: &Env, asset_config: &AssetConfig) -> StdResult<()> {
-    if let Some(mint_end) = asset_config.mint_end {
-        if mint_end < env.block.height {
+    if let Some(ipo_params) = asset_config.ipo_params.clone() {
+        if ipo_params.mint_end < env.block.height {
             return Err(StdError::generic_err(format!(
                 "The minting period for this asset ended at height {}",
-                mint_end
+                ipo_params.mint_end
             )));
         }
     }
@@ -87,11 +87,11 @@ pub fn assert_mint_period(env: &Env, asset_config: &AssetConfig) -> StdResult<()
 }
 
 pub fn assert_burn_period(env: &Env, asset_config: &AssetConfig) -> StdResult<()> {
-    if let Some(mint_end) = asset_config.mint_end {
-        if mint_end < env.block.height {
+    if let Some(ipo_params) = asset_config.ipo_params.clone() {
+        if ipo_params.mint_end < env.block.height {
             return Err(StdError::generic_err(format!(
                 "Burning is disabled for assets with limitied minting time. Mint period ended at {}",
-                mint_end
+                ipo_params.mint_end
             )));
         }
     }

--- a/contracts/mirror_mint/src/asserts.rs
+++ b/contracts/mirror_mint/src/asserts.rs
@@ -76,9 +76,9 @@ pub fn assert_min_collateral_ratio(min_collateral_ratio: Decimal) -> StdResult<(
 
 pub fn assert_mint_period(env: &Env, asset_config: &AssetConfig) -> StdResult<()> {
     if let Some(ipo_params) = asset_config.ipo_params.clone() {
-        if ipo_params.mint_end < env.block.height {
+        if ipo_params.mint_end < env.block.time {
             return Err(StdError::generic_err(format!(
-                "The minting period for this asset ended at height {}",
+                "The minting period for this asset ended at time {}",
                 ipo_params.mint_end
             )));
         }
@@ -88,9 +88,9 @@ pub fn assert_mint_period(env: &Env, asset_config: &AssetConfig) -> StdResult<()
 
 pub fn assert_burn_period(env: &Env, asset_config: &AssetConfig) -> StdResult<()> {
     if let Some(ipo_params) = asset_config.ipo_params.clone() {
-        if ipo_params.mint_end < env.block.height {
+        if ipo_params.mint_end < env.block.time {
             return Err(StdError::generic_err(format!(
-                "Burning is disabled for assets with limitied minting time. Mint period ended at {}",
+                "Burning is disabled for assets with limitied minting time. Mint period ended at time {}",
                 ipo_params.mint_end
             )));
         }

--- a/contracts/mirror_mint/src/contract_test.rs
+++ b/contracts/mirror_mint/src/contract_test.rs
@@ -7,9 +7,7 @@ mod tests {
         from_binary, to_binary, CosmosMsg, Decimal, HumanAddr, StdError, WasmMsg, WasmQuery,
     };
     use mirror_protocol::collateral_oracle::{HandleMsg::RegisterCollateralAsset, SourceType};
-    use mirror_protocol::mint::{
-        AssetConfigResponse, ConfigResponse, HandleMsg, InitMsg, QueryMsg,
-    };
+    use mirror_protocol::mint::{AssetConfigResponse, ConfigResponse, HandleMsg, IPOParams, InitMsg, QueryMsg};
     use mirror_protocol::oracle::QueryMsg::Price;
     use terraswap::asset::AssetInfo;
 
@@ -124,8 +122,7 @@ mod tests {
             asset_token: HumanAddr::from("asset0000"),
             auction_discount: Decimal::percent(20),
             min_collateral_ratio: Decimal::percent(150),
-            mint_end: None,
-            min_collateral_ratio_after_migration: None,
+            ipo_params: None,
         };
         let env = mock_env("owner0000", &[]);
         let res = handle(&mut deps, env, msg).unwrap();
@@ -170,8 +167,7 @@ mod tests {
                 auction_discount: Decimal::percent(20),
                 min_collateral_ratio: Decimal::percent(150),
                 end_price: None,
-                mint_end: None,
-                min_collateral_ratio_after_migration: None,
+                ipo_params: None,
             }
         );
         // must be failed with the already registered token error
@@ -179,8 +175,7 @@ mod tests {
             asset_token: HumanAddr::from("asset0000"),
             auction_discount: Decimal::percent(20),
             min_collateral_ratio: Decimal::percent(150),
-            mint_end: None,
-            min_collateral_ratio_after_migration: None,
+            ipo_params: None,
         };
         let env = mock_env("owner0000", &[]);
         let res = handle(&mut deps, env, msg).unwrap_err();
@@ -193,8 +188,7 @@ mod tests {
             asset_token: HumanAddr::from("asset0000"),
             auction_discount: Decimal::percent(20),
             min_collateral_ratio: Decimal::percent(150),
-            mint_end: None,
-            min_collateral_ratio_after_migration: None,
+            ipo_params: None,
         };
         let env = mock_env("owner0001", &[]);
         let res = handle(&mut deps, env, msg).unwrap_err();
@@ -207,8 +201,7 @@ mod tests {
             asset_token: HumanAddr::from("asset0000"),
             auction_discount: Decimal::percent(150),
             min_collateral_ratio: Decimal::percent(150),
-            mint_end: None,
-            min_collateral_ratio_after_migration: None,
+            ipo_params: None,
         };
         let env = mock_env("owner0000", &[]);
         let res = handle(&mut deps, env, msg).unwrap_err();
@@ -223,8 +216,7 @@ mod tests {
             asset_token: HumanAddr::from("asset0000"),
             auction_discount: Decimal::percent(20),
             min_collateral_ratio: Decimal::percent(50),
-            mint_end: None,
-            min_collateral_ratio_after_migration: None,
+            ipo_params: None,
         };
         let env = mock_env("owner0000", &[]);
         let res = handle(&mut deps, env, msg).unwrap_err();
@@ -257,8 +249,7 @@ mod tests {
             asset_token: HumanAddr::from("asset0000"),
             auction_discount: Decimal::percent(20),
             min_collateral_ratio: Decimal::percent(150),
-            mint_end: None,
-            min_collateral_ratio_after_migration: None,
+            ipo_params: None,
         };
         let env = mock_env("owner0000", &[]);
         let _res = handle(&mut deps, env, msg).unwrap();
@@ -266,6 +257,10 @@ mod tests {
             asset_token: HumanAddr::from("asset0000"),
             auction_discount: Some(Decimal::percent(30)),
             min_collateral_ratio: Some(Decimal::percent(200)),
+            ipo_params: Some(IPOParams {
+                min_collateral_ratio_after_ipo: Decimal::percent(150),
+                mint_end: 10000u64,
+            }),
         };
         let env = mock_env("owner0000", &[]);
         let _res = handle(&mut deps, env, msg).unwrap();
@@ -284,14 +279,17 @@ mod tests {
                 auction_discount: Decimal::percent(30),
                 min_collateral_ratio: Decimal::percent(200),
                 end_price: None,
-                mint_end: None,
-                min_collateral_ratio_after_migration: None,
+                ipo_params: Some(IPOParams {
+                    min_collateral_ratio_after_ipo: Decimal::percent(150),
+                    mint_end: 10000u64,
+                }),
             }
         );
         let msg = HandleMsg::UpdateAsset {
             asset_token: HumanAddr::from("asset0000"),
             auction_discount: Some(Decimal::percent(130)),
             min_collateral_ratio: Some(Decimal::percent(150)),
+            ipo_params: None,
         };
         let env = mock_env("owner0000", &[]);
         let res = handle(&mut deps, env, msg).unwrap_err();
@@ -305,6 +303,7 @@ mod tests {
             asset_token: HumanAddr::from("asset0000"),
             auction_discount: Some(Decimal::percent(30)),
             min_collateral_ratio: Some(Decimal::percent(50)),
+            ipo_params: None,
         };
         let env = mock_env("owner0000", &[]);
         let res = handle(&mut deps, env, msg).unwrap_err();
@@ -318,6 +317,7 @@ mod tests {
             asset_token: HumanAddr::from("asset0000"),
             auction_discount: Some(Decimal::percent(30)),
             min_collateral_ratio: Some(Decimal::percent(200)),
+            ipo_params: None,
         };
         let env = mock_env("owner0001", &[]);
         let res = handle(&mut deps, env, msg).unwrap_err();

--- a/contracts/mirror_mint/src/contract_test.rs
+++ b/contracts/mirror_mint/src/contract_test.rs
@@ -7,7 +7,9 @@ mod tests {
         from_binary, to_binary, CosmosMsg, Decimal, HumanAddr, StdError, WasmMsg, WasmQuery,
     };
     use mirror_protocol::collateral_oracle::{HandleMsg::RegisterCollateralAsset, SourceType};
-    use mirror_protocol::mint::{AssetConfigResponse, ConfigResponse, HandleMsg, IPOParams, InitMsg, QueryMsg};
+    use mirror_protocol::mint::{
+        AssetConfigResponse, ConfigResponse, HandleMsg, IPOParams, InitMsg, QueryMsg,
+    };
     use mirror_protocol::oracle::QueryMsg::Price;
     use terraswap::asset::AssetInfo;
 
@@ -260,6 +262,7 @@ mod tests {
             ipo_params: Some(IPOParams {
                 min_collateral_ratio_after_ipo: Decimal::percent(150),
                 mint_end: 10000u64,
+                pre_ipo_price: Decimal::percent(1),
             }),
         };
         let env = mock_env("owner0000", &[]);
@@ -282,6 +285,7 @@ mod tests {
                 ipo_params: Some(IPOParams {
                     min_collateral_ratio_after_ipo: Decimal::percent(150),
                     mint_end: 10000u64,
+                    pre_ipo_price: Decimal::percent(1)
                 }),
             }
         );

--- a/contracts/mirror_mint/src/migrated_asset_test.rs
+++ b/contracts/mirror_mint/src/migrated_asset_test.rs
@@ -62,8 +62,7 @@ mod tests {
             asset_token: HumanAddr::from("asset0000"),
             auction_discount: Decimal::percent(20),
             min_collateral_ratio: Decimal::percent(150),
-            mint_end: None,
-            min_collateral_ratio_after_migration: None,
+            ipo_params: None,
         };
 
         let env = mock_env("owner0000", &[]);
@@ -134,8 +133,7 @@ mod tests {
                 auction_discount: Decimal::percent(20),
                 min_collateral_ratio: Decimal::percent(100),
                 end_price: Some(Decimal::percent(50)),
-                mint_end: None,
-                min_collateral_ratio_after_migration: None,
+                ipo_params: None,
             }
         );
     }
@@ -183,8 +181,7 @@ mod tests {
             asset_token: HumanAddr::from("asset0000"),
             auction_discount: Decimal::percent(20),
             min_collateral_ratio: Decimal::percent(150),
-            mint_end: None,
-            min_collateral_ratio_after_migration: None,
+            ipo_params: None,
         };
         let env = mock_env("owner0000", &[]);
         let _res = handle(&mut deps, env, msg).unwrap();
@@ -193,8 +190,7 @@ mod tests {
             asset_token: HumanAddr::from("asset0001"),
             auction_discount: Decimal::percent(20),
             min_collateral_ratio: Decimal::percent(150),
-            mint_end: None,
-            min_collateral_ratio_after_migration: None,
+            ipo_params: None,
         };
         let env = mock_env("owner0000", &[]);
         let _res = handle(&mut deps, env, msg).unwrap();
@@ -565,8 +561,7 @@ mod tests {
             asset_token: HumanAddr::from("asset0000"),
             auction_discount: Decimal::percent(20),
             min_collateral_ratio: Decimal::percent(150),
-            mint_end: None,
-            min_collateral_ratio_after_migration: None,
+            ipo_params: None,
         };
         let env = mock_env("owner0000", &[]);
         let _res = handle(&mut deps, env, msg).unwrap();
@@ -575,8 +570,7 @@ mod tests {
             asset_token: HumanAddr::from("asset0001"),
             auction_discount: Decimal::percent(20),
             min_collateral_ratio: Decimal::percent(150),
-            mint_end: None,
-            min_collateral_ratio_after_migration: None,
+            ipo_params: None,
         };
         let env = mock_env("owner0000", &[]);
         let _res = handle(&mut deps, env, msg).unwrap();
@@ -786,8 +780,7 @@ mod tests {
             asset_token: HumanAddr::from("asset0000"),
             auction_discount: Decimal::percent(20),
             min_collateral_ratio: Decimal::percent(150),
-            mint_end: None,
-            min_collateral_ratio_after_migration: None,
+            ipo_params: None,
         };
         let env = mock_env("owner0000", &[]);
         let _res = handle(&mut deps, env, msg).unwrap();

--- a/contracts/mirror_mint/src/migration.rs
+++ b/contracts/mirror_mint/src/migration.rs
@@ -82,8 +82,7 @@ pub fn migrate_asset_configs<S: Storage>(storage: &mut S) -> StdResult<()> {
                 auction_discount: legacy_config.auction_discount,
                 min_collateral_ratio: legacy_config.min_collateral_ratio,
                 end_price: legacy_config.end_price,
-                mint_end: None,
-                min_collateral_ratio_after_migration: None,
+                ipo_params: None,
             },
         )?
     }
@@ -222,8 +221,7 @@ mod migrate_tests {
                 auction_discount: legacy_asset_config.auction_discount,
                 min_collateral_ratio: legacy_asset_config.min_collateral_ratio,
                 end_price: legacy_asset_config.end_price,
-                mint_end: None,
-                min_collateral_ratio_after_migration: None,
+                ipo_params: None,
             }
         );
         assert_eq!(
@@ -233,8 +231,7 @@ mod migrate_tests {
                 auction_discount: legacy_asset_config_2.auction_discount,
                 min_collateral_ratio: legacy_asset_config_2.min_collateral_ratio,
                 end_price: legacy_asset_config_2.end_price,
-                mint_end: None,
-                min_collateral_ratio_after_migration: None,
+                ipo_params: None,
             }
         );
     }

--- a/contracts/mirror_mint/src/mock_querier.rs
+++ b/contracts/mirror_mint/src/mock_querier.rs
@@ -41,6 +41,7 @@ pub struct WasmMockQuerier {
     oracle_price_querier: OraclePriceQuerier,
     collateral_oracle_querier: CollateralOracleQuerier,
     terraswap_pair_querier: TerraswapPairQuerier,
+    oracle_querier: OracleQuerier,
     canonical_length: usize,
 }
 
@@ -177,6 +178,29 @@ pub(crate) fn paris_to_map(pairs: &[(&String, &String, &HumanAddr)]) -> HashMap<
     pairs_map
 }
 
+#[derive(Clone, Default)]
+pub struct OracleQuerier {
+    feeders: HashMap<HumanAddr, HumanAddr>,
+}
+
+impl OracleQuerier {
+    pub fn new(feeders: &[(&HumanAddr, &HumanAddr)]) -> Self {
+        OracleQuerier {
+            feeders: address_pair_to_map(feeders),
+        }
+    }
+}
+
+pub(crate) fn address_pair_to_map(
+    address_pair: &[(&HumanAddr, &HumanAddr)],
+) -> HashMap<HumanAddr, HumanAddr> {
+    let mut address_pair_map: HashMap<HumanAddr, HumanAddr> = HashMap::new();
+    for (addr1, addr2) in address_pair.iter() {
+        address_pair_map.insert(HumanAddr::from(addr1), HumanAddr::from(addr2));
+    }
+    address_pair_map
+}
+
 impl Querier for WasmMockQuerier {
     fn raw_query(&self, bin_request: &[u8]) -> QuerierResult {
         // MockQuerier doesn't support Custom, so we ignore it completely here
@@ -298,8 +322,9 @@ impl WasmMockQuerier {
             QueryRequest::Wasm(WasmQuery::Raw { contract_addr, key }) => {
                 let key: &[u8] = key.as_slice();
                 let prefix_balance = to_length_prefixed(b"balance").to_vec();
+                let prefix_feeder = to_length_prefixed(b"feeder").to_vec();
 
-                if key[..prefix_balance.len()].to_vec() == prefix_balance {
+                if key.len() > prefix_balance.len() && key[..prefix_balance.len()].to_vec() == prefix_balance {
                     let balances: &HashMap<HumanAddr, Uint128> =
                         match self.token_querier.balances.get(contract_addr) {
                             Some(balances) => balances,
@@ -339,6 +364,34 @@ impl WasmMockQuerier {
                     };
 
                     Ok(to_binary(&to_binary(&balance).unwrap()))
+                } else if key.len() > prefix_feeder.len() && key[..prefix_feeder.len()].to_vec() == prefix_feeder {
+                    let api: MockApi = MockApi::new(self.canonical_length);
+                    let rest_key: &[u8] = &key[prefix_feeder.len()..];
+
+                    if contract_addr == &HumanAddr::from("oracle0000") {
+                        let asset_token: HumanAddr = api
+                            .human_address(&(CanonicalAddr::from(rest_key.to_vec())))
+                            .unwrap();
+
+                        let feeder = match self.oracle_querier.feeders.get(&asset_token) {
+                            Some(v) => v,
+                            None => {
+                                return Err(SystemError::InvalidRequest {
+                                    error: format!(
+                                        "Oracle Feeder is not found for {}",
+                                        asset_token
+                                    ),
+                                    request: key.into(),
+                                })
+                            }
+                        };
+
+                        Ok(to_binary(
+                            &to_binary(&api.canonical_address(&feeder).unwrap()).unwrap(),
+                        ))
+                    } else {
+                        panic!("DO NOT ENTER HERE")
+                    }
                 } else {
                     panic!("DO NOT ENTER HERE")
                 }
@@ -361,6 +414,7 @@ impl WasmMockQuerier {
             oracle_price_querier: OraclePriceQuerier::default(),
             collateral_oracle_querier: CollateralOracleQuerier::default(),
             terraswap_pair_querier: TerraswapPairQuerier::default(),
+            oracle_querier: OracleQuerier::default(),
             canonical_length,
         }
     }
@@ -391,5 +445,9 @@ impl WasmMockQuerier {
     // configure the terraswap factory pair mock querier
     pub fn with_terraswap_pair(&mut self, pairs: &[(&String, &String, &HumanAddr)]) {
         self.terraswap_pair_querier = TerraswapPairQuerier::new(pairs);
+    }
+
+    pub fn with_oracle_feeders(&mut self, feeders: &[(&HumanAddr, &HumanAddr)]) {
+        self.oracle_querier = OracleQuerier::new(feeders);
     }
 }

--- a/contracts/mirror_mint/src/mock_querier.rs
+++ b/contracts/mirror_mint/src/mock_querier.rs
@@ -324,7 +324,9 @@ impl WasmMockQuerier {
                 let prefix_balance = to_length_prefixed(b"balance").to_vec();
                 let prefix_feeder = to_length_prefixed(b"feeder").to_vec();
 
-                if key.len() > prefix_balance.len() && key[..prefix_balance.len()].to_vec() == prefix_balance {
+                if key.len() > prefix_balance.len()
+                    && key[..prefix_balance.len()].to_vec() == prefix_balance
+                {
                     let balances: &HashMap<HumanAddr, Uint128> =
                         match self.token_querier.balances.get(contract_addr) {
                             Some(balances) => balances,
@@ -364,7 +366,9 @@ impl WasmMockQuerier {
                     };
 
                     Ok(to_binary(&to_binary(&balance).unwrap()))
-                } else if key.len() > prefix_feeder.len() && key[..prefix_feeder.len()].to_vec() == prefix_feeder {
+                } else if key.len() > prefix_feeder.len()
+                    && key[..prefix_feeder.len()].to_vec() == prefix_feeder
+                {
                     let api: MockApi = MockApi::new(self.canonical_length);
                     let rest_key: &[u8] = &key[prefix_feeder.len()..];
 

--- a/contracts/mirror_mint/src/positions.rs
+++ b/contracts/mirror_mint/src/positions.rs
@@ -8,7 +8,7 @@ use crate::{
         assert_asset, assert_burn_period, assert_collateral, assert_migrated_asset,
         assert_mint_period, assert_revoked_collateral,
     },
-    math::{decimal_division, decimal_subtraction, reverse_decimal, decimal_multiplication},
+    math::{decimal_division, decimal_multiplication, decimal_subtraction, reverse_decimal},
     querier::{load_asset_price, load_collateral_info},
     state::{
         create_position, is_short_position, read_asset_config, read_config, read_position,
@@ -85,7 +85,8 @@ pub fn open_position<S: Storage, A: Api, Q: Querier>(
     let effective_cr = decimal_multiplication(collateral_ratio, collateral_multiplier);
 
     // Convert collateral to mint amount
-    let mint_amount = collateral.amount * asset_price_in_collateral_asset * reverse_decimal(effective_cr);
+    let mint_amount =
+        collateral.amount * asset_price_in_collateral_asset * reverse_decimal(effective_cr);
     if mint_amount.is_zero() {
         return Err(StdError::generic_err("collateral is too small"));
     }
@@ -355,11 +356,9 @@ pub fn withdraw<S: Storage, A: Api, Q: Querier>(
 
     Ok(HandleResponse {
         messages: vec![
-            vec![collateral.clone().into_msg(
-                &deps,
-                env.contract.address,
-                position_owner,
-            )?],
+            vec![collateral
+                .clone()
+                .into_msg(&deps, env.contract.address, position_owner)?],
             messages,
         ]
         .concat(),
@@ -580,10 +579,8 @@ pub fn burn<S: Storage, A: Api, Q: Querier>(
     // If the collateral is default denom asset and the asset is deprecated,
     // anyone can execute burn the asset to any position without permission
     let mut close_position: bool = false;
-    if asset_config.end_price.is_some() {
-        let oracle: HumanAddr = deps.api.human_address(&config.oracle)?;
-        let asset_price: Decimal =
-            load_asset_price(&deps, &oracle, &position.asset.info, Some(env.block.time))?;
+    if let Some(end_price) = asset_config.end_price {
+        let asset_price: Decimal = end_price;
 
         // fetch collateral info from collateral oracle
         let collateral_oracle: HumanAddr = deps.api.human_address(&config.collateral_oracle)?;

--- a/contracts/mirror_mint/src/positions.rs
+++ b/contracts/mirror_mint/src/positions.rs
@@ -570,9 +570,8 @@ pub fn burn<S: Storage, A: Api, Q: Querier>(
     let mut messages: Vec<CosmosMsg> = vec![];
     let mut logs: Vec<LogAttribute> = vec![];
 
-    // If mint_end is different than None, it is a pre-IPO asset.
-    // In that case, burning should be disabled after the minting period is over.
-    // Burning is enabled again after asset migration (IPO event), when mint_end is reset to None
+    // For preIPO assets, burning should be disabled after the minting period is over.
+    // Burning is enabled again after IPO event is triggered, when ipo_params are set to None
     assert_burn_period(&env, &asset_config)?;
 
     // Check if it is a short position

--- a/contracts/mirror_mint/src/positions_test.rs
+++ b/contracts/mirror_mint/src/positions_test.rs
@@ -66,8 +66,7 @@ mod tests {
             asset_token: HumanAddr::from("asset0000"),
             auction_discount: Decimal::percent(20),
             min_collateral_ratio: Decimal::percent(150),
-            mint_end: None,
-            min_collateral_ratio_after_migration: None,
+            ipo_params: None,
         };
 
         let env = mock_env("owner0000", &[]);
@@ -77,8 +76,7 @@ mod tests {
             asset_token: HumanAddr::from("asset0001"),
             auction_discount: Decimal::percent(20),
             min_collateral_ratio: Decimal::percent(150),
-            mint_end: None,
-            min_collateral_ratio_after_migration: None,
+            ipo_params: None,
         };
 
         let env = mock_env("owner0000", &[]);
@@ -456,8 +454,7 @@ mod tests {
             asset_token: HumanAddr::from("asset0000"),
             auction_discount: Decimal::percent(20),
             min_collateral_ratio: Decimal::percent(150),
-            mint_end: None,
-            min_collateral_ratio_after_migration: None,
+            ipo_params: None,
         };
 
         let env = mock_env("owner0000", &[]);
@@ -467,8 +464,7 @@ mod tests {
             asset_token: HumanAddr::from("asset0001"),
             auction_discount: Decimal::percent(20),
             min_collateral_ratio: Decimal::percent(150),
-            mint_end: None,
-            min_collateral_ratio_after_migration: None,
+            ipo_params: None,
         };
 
         let env = mock_env("owner0000", &[]);
@@ -668,8 +664,7 @@ mod tests {
             asset_token: HumanAddr::from("asset0000"),
             auction_discount: Decimal::percent(20),
             min_collateral_ratio: Decimal::percent(150),
-            mint_end: None,
-            min_collateral_ratio_after_migration: None,
+            ipo_params: None,
         };
 
         let env = mock_env("owner0000", &[]);
@@ -679,8 +674,7 @@ mod tests {
             asset_token: HumanAddr::from("asset0001"),
             auction_discount: Decimal::percent(20),
             min_collateral_ratio: Decimal::percent(150),
-            mint_end: None,
-            min_collateral_ratio_after_migration: None,
+            ipo_params: None,
         };
 
         let env = mock_env("owner0000", &[]);
@@ -916,8 +910,7 @@ mod tests {
             asset_token: HumanAddr::from("asset0000"),
             auction_discount: Decimal::percent(20),
             min_collateral_ratio: Decimal::percent(150),
-            mint_end: None,
-            min_collateral_ratio_after_migration: None,
+            ipo_params: None,
         };
 
         let env = mock_env("owner0000", &[]);
@@ -927,8 +920,7 @@ mod tests {
             asset_token: HumanAddr::from("asset0001"),
             auction_discount: Decimal::percent(20),
             min_collateral_ratio: Decimal::percent(150),
-            mint_end: None,
-            min_collateral_ratio_after_migration: None,
+            ipo_params: None,
         };
 
         let env = mock_env("owner0000", &[]);
@@ -1188,8 +1180,7 @@ mod tests {
             asset_token: HumanAddr::from("asset0000"),
             auction_discount: Decimal::percent(20),
             min_collateral_ratio: Decimal::percent(150),
-            mint_end: None,
-            min_collateral_ratio_after_migration: None,
+            ipo_params: None,
         };
 
         let env = mock_env("owner0000", &[]);
@@ -1199,8 +1190,7 @@ mod tests {
             asset_token: HumanAddr::from("asset0001"),
             auction_discount: Decimal::percent(20),
             min_collateral_ratio: Decimal::percent(150),
-            mint_end: None,
-            min_collateral_ratio_after_migration: None,
+            ipo_params: None,
         };
 
         let env = mock_env("owner0000", &[]);
@@ -1390,8 +1380,7 @@ mod tests {
             asset_token: HumanAddr::from("asset0000"),
             auction_discount: Decimal::percent(20),
             min_collateral_ratio: Decimal::percent(130),
-            mint_end: None,
-            min_collateral_ratio_after_migration: None,
+            ipo_params: None,
         };
 
         let env = mock_env("owner0000", &[]);
@@ -1401,8 +1390,7 @@ mod tests {
             asset_token: HumanAddr::from("asset0001"),
             auction_discount: Decimal::percent(20),
             min_collateral_ratio: Decimal::percent(150),
-            mint_end: None,
-            min_collateral_ratio_after_migration: None,
+            ipo_params: None,
         };
 
         let env = mock_env("owner0000", &[]);

--- a/contracts/mirror_mint/src/pre_ipo_test.rs
+++ b/contracts/mirror_mint/src/pre_ipo_test.rs
@@ -4,10 +4,15 @@ mod tests {
     use crate::mock_querier::mock_dependencies;
     use cosmwasm_std::testing::mock_env;
     use cosmwasm_std::{
-        from_binary, log, to_binary, BlockInfo, Coin, Decimal, Env, HumanAddr, StdError, Uint128,
+        from_binary, log, to_binary, BlockInfo, Coin, CosmosMsg, Decimal, Env, HumanAddr, StdError,
+        Uint128, WasmMsg, WasmQuery,
     };
     use cw20::Cw20ReceiveMsg;
-    use mirror_protocol::mint::{AssetConfigResponse, Cw20HookMsg, HandleMsg, InitMsg, QueryMsg, IPOParams};
+    use mirror_protocol::collateral_oracle::{HandleMsg::RegisterCollateralAsset, SourceType};
+    use mirror_protocol::mint::{
+        AssetConfigResponse, Cw20HookMsg, HandleMsg, IPOParams, InitMsg, QueryMsg,
+    };
+    use mirror_protocol::oracle::QueryMsg::Price;
     use terraswap::asset::{Asset, AssetInfo};
 
     static TOKEN_CODE_ID: u64 = 10u64;
@@ -34,9 +39,10 @@ mod tests {
                 &Decimal::from_ratio(10u128, 1u128),
             ),
         ]);
-        deps.querier.with_oracle_feeders(&[
-            (&HumanAddr::from("preIPOAsset0000"), &HumanAddr::from("feeder0000"))
-        ]);
+        deps.querier.with_oracle_feeders(&[(
+            &HumanAddr::from("preIPOAsset0000"),
+            &HumanAddr::from("feeder0000"),
+        )]);
 
         let base_denom = "uusd".to_string();
 
@@ -56,7 +62,7 @@ mod tests {
         let _res = init(&mut deps, creator_env.clone(), msg).unwrap();
 
         // register preIPO asset with mint_end parameter (10 blocks)
-        let mint_end = creator_env.clone().block.height + 10u64;
+        let mint_end = creator_env.clone().block.time + 10u64;
         let msg = HandleMsg::RegisterAsset {
             asset_token: HumanAddr::from("preIPOAsset0000"),
             auction_discount: Decimal::percent(20),
@@ -64,42 +70,53 @@ mod tests {
             ipo_params: Some(IPOParams {
                 mint_end,
                 min_collateral_ratio_after_ipo: Decimal::percent(150),
+                pre_ipo_price: Decimal::percent(100),
             }),
         };
         let env = mock_env("owner0000", &[]);
-        let _res = handle(&mut deps, env, msg).unwrap();
+        let res = handle(&mut deps, env, msg).unwrap();
+        assert_eq!(res.messages.len(), 0); // not registered as collateral
 
         ///////////////////
         // Minting phase
         ///////////////////
-        let mut current_height = creator_env.block.height + 1;
+        let mut current_time = creator_env.block.time + 1;
 
-        // open position successfully at creation_height + 1
+        // open position successfully at creation_time + 1
         let msg = HandleMsg::OpenPosition {
             collateral: Asset {
                 info: AssetInfo::NativeToken {
                     denom: "uusd".to_string(),
                 },
-                amount: Uint128(1000000000u128),
+                amount: Uint128(2000000000u128),
             },
             asset_info: AssetInfo::Token {
                 contract_addr: HumanAddr::from("preIPOAsset0000"),
             },
-            collateral_ratio: Decimal::percent(10000),
+            collateral_ratio: Decimal::percent(2000),
             short_params: None,
         };
-        let mut env = mock_env_with_block_time(
+        let env = mock_env_with_block_time(
             "addr0000",
             &[Coin {
                 denom: "uusd".to_string(),
-                amount: Uint128(1000000000u128),
+                amount: Uint128(2000000000u128),
             }],
-            1000u64,
+            current_time,
         );
-        env.block.height = current_height;
-        let _res = handle(&mut deps, env.clone(), msg).unwrap();
+        let res = handle(&mut deps, env.clone(), msg).unwrap();
+        assert_eq!(
+            res.log,
+            vec![
+                log("action", "open_position"),
+                log("position_idx", "1"),
+                log("mint_amount", "100000000preIPOAsset0000"), // 2000% cr with pre_ipo_price=1
+                log("collateral_amount", "2000000000uusd"),
+                log("is_short", "false"),
+            ]
+        );
 
-        // mint successfully at creation_height + 1
+        // mint successfully at creation_time + 1
         let msg = HandleMsg::Mint {
             position_idx: Uint128(1u128),
             asset: Asset {
@@ -112,7 +129,7 @@ mod tests {
         };
         let _res = handle(&mut deps, env.clone(), msg).unwrap();
 
-        // burn successfully at creation_height + 1
+        // burn successfully at creation_time + 1
         let msg = HandleMsg::Receive(Cw20ReceiveMsg {
             sender: HumanAddr::from("addr0000"),
             amount: Uint128::from(1000000u128),
@@ -123,14 +140,13 @@ mod tests {
                 .unwrap(),
             ),
         });
-        let mut env = mock_env("preIPOAsset0000", &[]);
-        env.block.height = current_height;
+        let env = mock_env_with_block_time("preIPOAsset0000", &[], current_time);
         let _res = handle(&mut deps, env, msg).unwrap();
 
         ///////////////////
         // Trading phase
         ///////////////////
-        current_height = creator_env.block.height + 11; // > mint_end
+        current_time = creator_env.block.time + 11; // > mint_end
 
         // open position disabled
         let msg = HandleMsg::OpenPosition {
@@ -146,20 +162,19 @@ mod tests {
             collateral_ratio: Decimal::percent(10000),
             short_params: None,
         };
-        let mut env = mock_env_with_block_time(
+        let env = mock_env_with_block_time(
             "addr0000",
             &[Coin {
                 denom: "uusd".to_string(),
                 amount: Uint128(1000000000u128),
             }],
-            1000u64,
+            current_time,
         );
-        env.block.height = current_height;
         let res = handle(&mut deps, env.clone(), msg).unwrap_err();
         assert_eq!(
             res,
             StdError::generic_err(format!(
-                "The minting period for this asset ended at height {}",
+                "The minting period for this asset ended at time {}",
                 mint_end
             ))
         );
@@ -179,7 +194,7 @@ mod tests {
         assert_eq!(
             res,
             StdError::generic_err(format!(
-                "The minting period for this asset ended at height {}",
+                "The minting period for this asset ended at time {}",
                 mint_end
             ))
         );
@@ -195,13 +210,12 @@ mod tests {
                 .unwrap(),
             ),
         });
-        let mut env = mock_env("preIPOAsset0000", &[]);
-        env.block.height = current_height;
+        let env = mock_env_with_block_time("preIPOAsset0000", &[], current_time);
         let res = handle(&mut deps, env, msg).unwrap_err();
         assert_eq!(
             res,
             StdError::generic_err(format!(
-            "Burning is disabled for assets with limitied minting time. Mint period ended at {}",
+            "Burning is disabled for assets with limitied minting time. Mint period ended at time {}",
             mint_end
         ))
         );
@@ -209,7 +223,7 @@ mod tests {
         ///////////////////
         // IPO/Migration
         ///////////////////
-        current_height = creator_env.block.height + 20;
+        current_time = creator_env.block.time + 20;
 
         // register migration initiated by the feeder
         let msg = HandleMsg::TriggerIPO {
@@ -219,14 +233,10 @@ mod tests {
         // unauthorized attempt
         let env = mock_env("owner", &[]);
         let res = handle(&mut deps, env, msg.clone()).unwrap_err();
-        assert_eq!(
-            res,
-            StdError::unauthorized()
-        );
+        assert_eq!(res, StdError::unauthorized());
 
         // succesfull attempt
-        let mut env = mock_env("feeder0000", &[]);
-        env.block.height = current_height;
+        let env = mock_env_with_block_time("feeder0000", &[], current_time);
         let res = handle(&mut deps, env, msg).unwrap();
         assert_eq!(
             res.log,
@@ -234,6 +244,31 @@ mod tests {
                 log("action", "trigger_ipo"),
                 log("asset_token", "preIPOAsset0000"),
             ]
+        );
+        assert_eq!(
+            res.messages,
+            vec![CosmosMsg::Wasm(WasmMsg::Execute {
+                contract_addr: HumanAddr::from("collateraloracle0000"),
+                send: vec![],
+                msg: to_binary(&RegisterCollateralAsset {
+                    asset: AssetInfo::Token {
+                        contract_addr: HumanAddr::from("preIPOAsset0000"),
+                    },
+                    multiplier: Decimal::one(),
+                    price_source: SourceType::TerraOracle {
+                        terra_oracle_query: to_binary(&WasmQuery::Smart {
+                            contract_addr: HumanAddr::from("oracle0000"),
+                            msg: to_binary(&Price {
+                                base_asset: "uusd".to_string(),
+                                quote_asset: "preIPOAsset0000".to_string(),
+                            })
+                            .unwrap()
+                        })
+                        .unwrap(),
+                    },
+                })
+                .unwrap(),
+            })]
         );
 
         let res = query(
@@ -254,6 +289,40 @@ mod tests {
                 end_price: None,
                 ipo_params: None,
             }
+        );
+
+        // open position as a postIPO asset
+        let msg = HandleMsg::OpenPosition {
+            collateral: Asset {
+                info: AssetInfo::NativeToken {
+                    denom: "uusd".to_string(),
+                },
+                amount: Uint128(9000u128),
+            },
+            asset_info: AssetInfo::Token {
+                contract_addr: HumanAddr::from("preIPOAsset0000"),
+            },
+            collateral_ratio: Decimal::percent(150), // new minCR
+            short_params: None,
+        };
+        let env = mock_env_with_block_time(
+            "addr0000",
+            &[Coin {
+                denom: "uusd".to_string(),
+                amount: Uint128(9000u128),
+            }],
+            1000u64,
+        );
+        let res = handle(&mut deps, env.clone(), msg).unwrap();
+        assert_eq!(
+            res.log,
+            vec![
+                log("action", "open_position"),
+                log("position_idx", "2"),
+                log("mint_amount", "599preIPOAsset0000"), // 150% cr with oracle_price=10
+                log("collateral_amount", "9000uusd"),
+                log("is_short", "false"),
+            ]
         );
     }
 }

--- a/contracts/mirror_mint/src/querier.rs
+++ b/contracts/mirror_mint/src/querier.rs
@@ -1,7 +1,8 @@
 use cosmwasm_std::{
-    to_binary, Api, Decimal, Extern, HumanAddr, Querier, QueryRequest, StdError, StdResult,
-    Storage, WasmQuery,
+    to_binary, from_binary, Binary, Api, Decimal, Extern, HumanAddr, Querier, QueryRequest, StdError, StdResult,
+    Storage, WasmQuery, CanonicalAddr,
 };
+use cosmwasm_storage::to_length_prefixed;
 
 use crate::state::{read_config, read_end_price, Config};
 use mirror_protocol::collateral_oracle::{
@@ -11,6 +12,37 @@ use mirror_protocol::oracle::{PriceResponse, QueryMsg as OracleQueryMsg};
 use terraswap::asset::AssetInfoRaw;
 
 const PRICE_EXPIRE_TIME: u64 = 60;
+
+pub fn load_oracle_feeder<S: Storage, A: Api, Q: Querier>(
+    deps: &Extern<S, A, Q>,
+    contract_addr: &HumanAddr,
+    asset_token: &CanonicalAddr,
+) -> StdResult<CanonicalAddr> {
+    let res: StdResult<Binary> = deps.querier.query(&QueryRequest::Wasm(WasmQuery::Raw {
+        contract_addr: HumanAddr::from(contract_addr),
+        key: Binary::from(concat(
+            &to_length_prefixed(b"feeder"),
+            asset_token.as_slice(),
+        )),
+    }));
+
+    let res = match res {
+        Ok(v) => v,
+        Err(_) => {
+            return Err(StdError::generic_err("Falied to fetch the oracle feeder"));
+        }
+    };
+
+    let feeder: StdResult<CanonicalAddr> = from_binary(&res);
+    let feeder: CanonicalAddr = match feeder {
+        Ok(v) => v,
+        Err(_) => {
+            return Err(StdError::generic_err("Falied to fetch the oracle feeder"));
+        }
+    };
+
+    Ok(feeder)
+}
 
 pub fn load_asset_price<S: Storage, A: Api, Q: Querier>(
     deps: &Extern<S, A, Q>,
@@ -110,4 +142,11 @@ pub fn query_collateral<S: Storage, A: Api, Q: Querier>(
     }
 
     Ok((res.rate, res.multiplier, res.is_revoked))
+}
+
+#[inline]
+fn concat(namespace: &[u8], key: &[u8]) -> Vec<u8> {
+    let mut k = namespace.to_vec();
+    k.extend_from_slice(key);
+    k
 }

--- a/contracts/mirror_mint/src/short_test.rs
+++ b/contracts/mirror_mint/src/short_test.rs
@@ -63,8 +63,7 @@ mod test {
             asset_token: HumanAddr::from("asset0000"),
             auction_discount: Decimal::percent(20),
             min_collateral_ratio: Decimal::percent(150),
-            mint_end: None,
-            min_collateral_ratio_after_migration: None,
+            ipo_params: None,
         };
 
         let env = mock_env("owner0000", &[]);
@@ -74,8 +73,7 @@ mod test {
             asset_token: HumanAddr::from("asset0001"),
             auction_discount: Decimal::percent(20),
             min_collateral_ratio: Decimal::percent(150),
-            mint_end: None,
-            min_collateral_ratio_after_migration: None,
+            ipo_params: None,
         };
 
         let env = mock_env("owner0000", &[]);
@@ -238,8 +236,7 @@ mod test {
             asset_token: HumanAddr::from("asset0000"),
             auction_discount: Decimal::percent(20),
             min_collateral_ratio: Decimal::percent(150),
-            mint_end: None,
-            min_collateral_ratio_after_migration: None,
+            ipo_params: None,
         };
 
         let env = mock_env("owner0000", &[]);
@@ -249,8 +246,7 @@ mod test {
             asset_token: HumanAddr::from("asset0001"),
             auction_discount: Decimal::percent(20),
             min_collateral_ratio: Decimal::percent(150),
-            mint_end: None,
-            min_collateral_ratio_after_migration: None,
+            ipo_params: None,
         };
 
         let env = mock_env("owner0000", &[]);
@@ -395,8 +391,7 @@ mod test {
             asset_token: HumanAddr::from("asset0000"),
             auction_discount: Decimal::percent(20),
             min_collateral_ratio: Decimal::percent(150),
-            mint_end: None,
-            min_collateral_ratio_after_migration: None,
+            ipo_params: None,
         };
 
         let env = mock_env("owner0000", &[]);
@@ -406,8 +401,7 @@ mod test {
             asset_token: HumanAddr::from("asset0001"),
             auction_discount: Decimal::percent(20),
             min_collateral_ratio: Decimal::percent(150),
-            mint_end: None,
-            min_collateral_ratio_after_migration: None,
+            ipo_params: None,
         };
 
         let env = mock_env("owner0000", &[]);
@@ -526,8 +520,7 @@ mod test {
             asset_token: HumanAddr::from("asset0000"),
             auction_discount: Decimal::percent(20),
             min_collateral_ratio: Decimal::percent(150),
-            mint_end: None,
-            min_collateral_ratio_after_migration: None,
+            ipo_params: None,
         };
 
         let env = mock_env("owner0000", &[]);
@@ -537,8 +530,7 @@ mod test {
             asset_token: HumanAddr::from("asset0001"),
             auction_discount: Decimal::percent(20),
             min_collateral_ratio: Decimal::percent(150),
-            mint_end: None,
-            min_collateral_ratio_after_migration: None,
+            ipo_params: None,
         };
 
         let env = mock_env("owner0000", &[]);
@@ -681,8 +673,7 @@ mod test {
             asset_token: HumanAddr::from("asset0000"),
             auction_discount: Decimal::percent(20),
             min_collateral_ratio: Decimal::percent(200),
-            mint_end: None,
-            min_collateral_ratio_after_migration: None,
+            ipo_params: None,
         };
 
         let env = mock_env("owner0000", &[]);

--- a/contracts/mirror_mint/src/state.rs
+++ b/contracts/mirror_mint/src/state.rs
@@ -7,6 +7,7 @@ use cosmwasm_std::{
 
 use cosmwasm_storage::{singleton, singleton_read, Bucket, ReadonlyBucket};
 use mirror_protocol::common::OrderBy;
+use mirror_protocol::mint::IPOParams;
 use std::convert::TryInto;
 use terraswap::asset::{AssetInfoRaw, AssetRaw};
 
@@ -55,8 +56,7 @@ pub struct AssetConfig {
     pub auction_discount: Decimal,
     pub min_collateral_ratio: Decimal,
     pub end_price: Option<Decimal>,
-    pub mint_end: Option<u64>,
-    pub min_collateral_ratio_after_migration: Option<Decimal>,
+    pub ipo_params: Option<IPOParams>,
 }
 
 pub fn store_asset_config<S: Storage>(

--- a/packages/mirror_protocol/src/factory.rs
+++ b/packages/mirror_protocol/src/factory.rs
@@ -130,4 +130,6 @@ pub struct Params {
     pub mint_period: Option<u64>,
     /// For pre-IPO assets, collateral ratio for the asset after ipo
     pub min_collateral_ratio_after_ipo: Option<Decimal>,
+    /// For pre-IPO assets, fixed price during minting period
+    pub pre_ipo_price: Option<Decimal>,
 }

--- a/packages/mirror_protocol/src/factory.rs
+++ b/packages/mirror_protocol/src/factory.rs
@@ -128,6 +128,6 @@ pub struct Params {
     pub weight: Option<u32>,
     /// For pre-IPO assets, time period after asset creation in which minting is enabled
     pub mint_period: Option<u64>,
-    /// For pre-IPO assets, collateral ratio for the asset after migration
-    pub min_collateral_ratio_after_migration: Option<Decimal>,
+    /// For pre-IPO assets, collateral ratio for the asset after ipo
+    pub min_collateral_ratio_after_ipo: Option<Decimal>,
 }

--- a/packages/mirror_protocol/src/mint.rs
+++ b/packages/mirror_protocol/src/mint.rs
@@ -47,18 +47,22 @@ pub enum HandleMsg {
         asset_token: HumanAddr,
         auction_discount: Option<Decimal>,
         min_collateral_ratio: Option<Decimal>,
+        ipo_params: Option<IPOParams>,
     },
     /// Generate asset token initialize msg and register required infos except token address
     RegisterAsset {
         asset_token: HumanAddr,
         auction_discount: Decimal,
         min_collateral_ratio: Decimal,
-        mint_end: Option<u64>,
-        min_collateral_ratio_after_migration: Option<Decimal>,
+        ipo_params: Option<IPOParams>,
     },
     RegisterMigration {
         asset_token: HumanAddr,
         end_price: Decimal,
+    },
+    /// Asset feeder is allowed to trigger IPO event on preIPO assets
+    TriggerIPO {
+        asset_token: HumanAddr,
     },
 
     //////////////////////
@@ -93,6 +97,12 @@ pub enum HandleMsg {
 pub struct ShortParams {
     pub belief_price: Option<Decimal>,
     pub max_spread: Option<Decimal>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct IPOParams {
+    pub mint_end: u64,
+    pub min_collateral_ratio_after_ipo: Decimal,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
@@ -154,8 +164,7 @@ pub struct AssetConfigResponse {
     pub auction_discount: Decimal,
     pub min_collateral_ratio: Decimal,
     pub end_price: Option<Decimal>,
-    pub mint_end: Option<u64>,
-    pub min_collateral_ratio_after_migration: Option<Decimal>,
+    pub ipo_params: Option<IPOParams>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/packages/mirror_protocol/src/mint.rs
+++ b/packages/mirror_protocol/src/mint.rs
@@ -102,6 +102,7 @@ pub struct ShortParams {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct IPOParams {
     pub mint_end: u64,
+    pub pre_ipo_price: Decimal,
     pub min_collateral_ratio_after_ipo: Decimal,
 }
 


### PR DESCRIPTION
### Overview

We implement a new mechanism that prevents having to migrate from preIPO asset to postIPO asset and allow preIPO traders to hold the assets without having to burn and re-mint new assets.

Instead of relying on asset migration to mark the event of an IPO, we add a new mint contract operation `TriggerIPO` to make the transition from preIPO to postIPO. 

Asset lifecycle:
 1. Asset is whitelisted through factory contract, filling `mint_period` parameter and `min_collateral_ratio_after_ipo` parameters.
```
pub struct Params {
    /// Auction discount rate applied to asset mint
    pub auction_discount: Decimal,
    /// Minium collateral ratio applied to asset mint
    pub min_collateral_ratio: Decimal,
    /// Distribution weight (default is 30, which is 1/10 of MIR distribution weight)
    pub weight: Option<u32>,
    /// For pre-IPO assets, time period after asset creation in which minting is enabled
    pub mint_period: Option<u64>,
    /// For pre-IPO assets, collateral ratio for the asset after ipo
    pub min_collateral_ratio_after_ipo: Option<Decimal>,
}
```
2. Asset is registered to mint_contract, with `ipo_params`:
```
RegisterAsset {
    asset_token: HumanAddr,
    auction_discount: Decimal,
    min_collateral_ratio: Decimal,
    ipo_params: Option<IPOParams>,
},
pub struct IPOParams {
    pub mint_end: u64,
    pub min_collateral_ratio_after_ipo: Decimal,
}
```
3. When IPO event happens, feeder executes `TriggerIPO` operation and starts feeding real price. This operation will assign a new `min_cr` to the asset, making the asset a traditional asset without `mint_period`.
```
TriggerIPO {
    asset_token: HumanAddr, 
},
```

### Behaviour summary

- During mint_period:
   - All operations enabled
   - Feeder feeds fixed price
- After mint_period (Trading phase):
   - Mint and burn disabled
   - Feeder keeps feeding fixed price
- After IPO event:
   - `min_cr` is updated
   - Feeder executes `TriggerIPO`
   - Feeder starts feeding real price 

*Migration of preIPO asset is not contemplated
