### PR TITLE
[Quickfix] provisional swap of quote_denom and base_denom 

### DIFF
--- a/contracts/mirror_collateral_oracle/src/querier.rs
+++ b/contracts/mirror_collateral_oracle/src/querier.rs
@@ -198,7 +198,7 @@ fn query_native_rate<Q: Querier>(
 ) -> StdResult<Decimal> {
     let terra_querier = TerraQuerier::new(querier);
     let res: ExchangeRatesResponse =
-        terra_querier.query_exchange_rates(base_denom, vec![quote_denom])?;
+        terra_querier.query_exchange_rates(quote_denom, vec![base_denom])?;
 
     Ok(res.exchange_rates[0].exchange_rate)
 }


### PR DESCRIPTION
Provisional change due to bug on core terra-money/core/issues/496 
