### PR TITLE
Auth changes

### DIFF
--- a/contracts/mirror_collateral_oracle/schema/config_response.json
+++ b/contracts/mirror_collateral_oracle/schema/config_response.json
@@ -6,7 +6,6 @@
     "anchor_oracle",
     "band_oracle",
     "base_denom",
-    "factory_contract",
     "mint_contract",
     "mirror_oracle",
     "owner"
@@ -20,9 +19,6 @@
     },
     "base_denom": {
       "type": "string"
-    },
-    "factory_contract": {
-      "$ref": "#/definitions/HumanAddr"
     },
     "mint_contract": {
       "$ref": "#/definitions/HumanAddr"

--- a/contracts/mirror_collateral_oracle/schema/handle_msg.json
+++ b/contracts/mirror_collateral_oracle/schema/handle_msg.json
@@ -37,16 +37,6 @@
                 "null"
               ]
             },
-            "factory_contract": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/HumanAddr"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            },
             "mint_contract": {
               "anyOf": [
                 {

--- a/contracts/mirror_collateral_oracle/schema/init_msg.json
+++ b/contracts/mirror_collateral_oracle/schema/init_msg.json
@@ -6,7 +6,6 @@
     "anchor_oracle",
     "band_oracle",
     "base_denom",
-    "factory_contract",
     "mint_contract",
     "mirror_oracle",
     "owner"
@@ -20,9 +19,6 @@
     },
     "base_denom": {
       "type": "string"
-    },
-    "factory_contract": {
-      "$ref": "#/definitions/HumanAddr"
     },
     "mint_contract": {
       "$ref": "#/definitions/HumanAddr"

--- a/contracts/mirror_collateral_oracle/src/contract.rs
+++ b/contracts/mirror_collateral_oracle/src/contract.rs
@@ -25,7 +25,6 @@ pub fn init<S: Storage, A: Api, Q: Querier>(
         &Config {
             owner: deps.api.canonical_address(&msg.owner)?,
             mint_contract: deps.api.canonical_address(&msg.mint_contract)?,
-            factory_contract: deps.api.canonical_address(&msg.factory_contract)?,
             base_denom: msg.base_denom,
             mirror_oracle: deps.api.canonical_address(&msg.mirror_oracle)?,
             anchor_oracle: deps.api.canonical_address(&msg.anchor_oracle)?,
@@ -45,7 +44,6 @@ pub fn handle<S: Storage, A: Api, Q: Querier>(
         HandleMsg::UpdateConfig {
             owner,
             mint_contract,
-            factory_contract,
             base_denom,
             mirror_oracle,
             anchor_oracle,
@@ -55,7 +53,6 @@ pub fn handle<S: Storage, A: Api, Q: Querier>(
             env,
             owner,
             mint_contract,
-            factory_contract,
             base_denom,
             mirror_oracle,
             anchor_oracle,
@@ -82,7 +79,6 @@ pub fn update_config<S: Storage, A: Api, Q: Querier>(
     env: Env,
     owner: Option<HumanAddr>,
     mint_contract: Option<HumanAddr>,
-    factory_contract: Option<HumanAddr>,
     base_denom: Option<String>,
     mirror_oracle: Option<HumanAddr>,
     anchor_oracle: Option<HumanAddr>,
@@ -99,10 +95,6 @@ pub fn update_config<S: Storage, A: Api, Q: Querier>(
 
     if let Some(mint_contract) = mint_contract {
         config.mint_contract = deps.api.canonical_address(&mint_contract)?;
-    }
-
-    if let Some(factory_contract) = factory_contract {
-        config.factory_contract = deps.api.canonical_address(&factory_contract)?;
     }
 
     if let Some(base_denom) = base_denom {
@@ -221,8 +213,8 @@ pub fn update_collateral_multiplier<S: Storage, A: Api, Q: Querier>(
 ) -> HandleResult {
     let config: Config = read_config(&deps.storage)?;
     let sender_address_raw: CanonicalAddr = deps.api.canonical_address(&env.message.sender)?;
-    // only factory contract can update collateral premium
-    if config.factory_contract != sender_address_raw {
+    // only owner can update collateral premium
+    if config.owner != sender_address_raw {
         return Err(StdError::unauthorized());
     }
 
@@ -262,7 +254,6 @@ pub fn query_config<S: Storage, A: Api, Q: Querier>(
     let resp = ConfigResponse {
         owner: deps.api.human_address(&config.owner)?,
         mint_contract: deps.api.human_address(&config.mint_contract)?,
-        factory_contract: deps.api.human_address(&config.factory_contract)?,
         base_denom: config.base_denom,
         mirror_oracle: deps.api.human_address(&config.mirror_oracle)?,
         anchor_oracle: deps.api.human_address(&config.anchor_oracle)?,

--- a/contracts/mirror_collateral_oracle/src/state.rs
+++ b/contracts/mirror_collateral_oracle/src/state.rs
@@ -13,7 +13,6 @@ static KEY_CONFIG: &[u8] = b"config";
 pub struct Config {
     pub owner: CanonicalAddr,
     pub mint_contract: CanonicalAddr,
-    pub factory_contract: CanonicalAddr,
     pub base_denom: String,
     pub mirror_oracle: CanonicalAddr,
     pub anchor_oracle: CanonicalAddr,

--- a/contracts/mirror_collateral_oracle/src/testing.rs
+++ b/contracts/mirror_collateral_oracle/src/testing.rs
@@ -15,7 +15,6 @@ fn proper_initialization() {
     let msg = InitMsg {
         owner: HumanAddr("owner0000".to_string()),
         mint_contract: HumanAddr("mint0000".to_string()),
-        factory_contract: HumanAddr("factory0000".to_string()),
         base_denom: "uusd".to_string(),
         mirror_oracle: HumanAddr("mirrororacle0000".to_string()),
         anchor_oracle: HumanAddr("anchororacle0000".to_string()),
@@ -32,7 +31,6 @@ fn proper_initialization() {
     let value = query_config(&deps).unwrap();
     assert_eq!("owner0000", value.owner.as_str());
     assert_eq!("mint0000", value.mint_contract.as_str());
-    assert_eq!("factory0000", value.factory_contract.as_str());
     assert_eq!("uusd", value.base_denom.as_str());
 }
 
@@ -43,7 +41,6 @@ fn update_config() {
     let msg = InitMsg {
         owner: HumanAddr("owner0000".to_string()),
         mint_contract: HumanAddr("mint0000".to_string()),
-        factory_contract: HumanAddr("factory0000".to_string()),
         base_denom: "uusd".to_string(),
         mirror_oracle: HumanAddr("mirrororacle0000".to_string()),
         anchor_oracle: HumanAddr("anchororacle0000".to_string()),
@@ -58,7 +55,6 @@ fn update_config() {
     let msg = HandleMsg::UpdateConfig {
         owner: Some(HumanAddr("owner0001".to_string())),
         mint_contract: Some(HumanAddr("mint0001".to_string())),
-        factory_contract: Some(HumanAddr("factory0001".to_string())),
         base_denom: Some("uluna".to_string()),
         mirror_oracle: Some(HumanAddr("mirrororacle0001".to_string())),
         anchor_oracle: Some(HumanAddr("anchororacle0001".to_string())),
@@ -72,7 +68,6 @@ fn update_config() {
     let value = query_config(&deps).unwrap();
     assert_eq!("owner0001", value.owner.as_str());
     assert_eq!("mint0001", value.mint_contract.as_str());
-    assert_eq!("factory0001", value.factory_contract.as_str());
     assert_eq!("uluna", value.base_denom.as_str());
     assert_eq!("mirrororacle0001", value.mirror_oracle.as_str());
     assert_eq!("anchororacle0001", value.anchor_oracle.as_str());
@@ -83,7 +78,6 @@ fn update_config() {
     let msg = HandleMsg::UpdateConfig {
         owner: None,
         mint_contract: None,
-        factory_contract: None,
         base_denom: None,
         mirror_oracle: None,
         anchor_oracle: None,
@@ -108,7 +102,6 @@ fn register_collateral() {
     let msg = InitMsg {
         owner: HumanAddr("owner0000".to_string()),
         mint_contract: HumanAddr("mint0000".to_string()),
-        factory_contract: HumanAddr("factory0000".to_string()),
         base_denom: "uusd".to_string(),
         mirror_oracle: HumanAddr("mirrororacle0000".to_string()),
         anchor_oracle: HumanAddr("anchororacle0000".to_string()),
@@ -160,7 +153,6 @@ fn update_collateral() {
     let msg = InitMsg {
         owner: HumanAddr("owner0000".to_string()),
         mint_contract: HumanAddr("mint0000".to_string()),
-        factory_contract: HumanAddr("factory0000".to_string()),
         base_denom: "uusd".to_string(),
         mirror_oracle: HumanAddr("mirrororacle0000".to_string()),
         anchor_oracle: HumanAddr("anchororacle0000".to_string()),
@@ -236,7 +228,7 @@ fn update_collateral() {
     };
 
     // invalid multiplier
-    let env = mock_env("factory0000", &[]);
+    let env = mock_env("owner0000", &[]);
     let res = handle(&mut deps, env, msg).unwrap_err();
     assert_eq!(
         res,
@@ -252,12 +244,12 @@ fn update_collateral() {
     };
 
     // unauthorized attempt
-    let env = mock_env("owner0000", &[]);
+    let env = mock_env("addr0000", &[]);
     let res = handle(&mut deps, env, msg.clone()).unwrap_err();
     assert_eq!(res, StdError::unauthorized());
 
     // successfull attempt
-    let env = mock_env("factory0000", &[]);
+    let env = mock_env("owner0000", &[]);
     let res = handle(&mut deps, env, msg).unwrap();
     assert_eq!(0, res.messages.len());
 
@@ -285,7 +277,6 @@ fn get_oracle_price() {
     let msg = InitMsg {
         owner: HumanAddr("owner0000".to_string()),
         mint_contract: HumanAddr("mint0000".to_string()),
-        factory_contract: HumanAddr("factory0000".to_string()),
         base_denom: "uusd".to_string(),
         mirror_oracle: HumanAddr("mirrororacle0000".to_string()),
         anchor_oracle: HumanAddr("anchororacle0000".to_string()),
@@ -347,7 +338,6 @@ fn get_terraswap_price() {
     let msg = InitMsg {
         owner: HumanAddr("owner0000".to_string()),
         mint_contract: HumanAddr("mint0000".to_string()),
-        factory_contract: HumanAddr("factory0000".to_string()),
         base_denom: "uusd".to_string(),
         mirror_oracle: HumanAddr("mirrororacle0000".to_string()),
         anchor_oracle: HumanAddr("anchororacle0000".to_string()),
@@ -420,7 +410,6 @@ fn get_fixed_price() {
     let msg = InitMsg {
         owner: HumanAddr("owner0000".to_string()),
         mint_contract: HumanAddr("mint0000".to_string()),
-        factory_contract: HumanAddr("factory0000".to_string()),
         base_denom: "uusd".to_string(),
         mirror_oracle: HumanAddr("mirrororacle0000".to_string()),
         anchor_oracle: HumanAddr("anchororacle0000".to_string()),
@@ -464,7 +453,6 @@ fn get_band_oracle_price() {
     let msg = InitMsg {
         owner: HumanAddr("owner0000".to_string()),
         mint_contract: HumanAddr("mint0000".to_string()),
-        factory_contract: HumanAddr("factory0000".to_string()),
         base_denom: "uusd".to_string(),
         mirror_oracle: HumanAddr("mirrororacle0000".to_string()),
         anchor_oracle: HumanAddr("anchororacle0000".to_string()),
@@ -506,7 +494,6 @@ fn get_anchor_market_price() {
     let msg = InitMsg {
         owner: HumanAddr("owner0000".to_string()),
         mint_contract: HumanAddr("mint0000".to_string()),
-        factory_contract: HumanAddr("factory0000".to_string()),
         base_denom: "uusd".to_string(),
         mirror_oracle: HumanAddr("mirrororacle0000".to_string()),
         anchor_oracle: HumanAddr("anchororacle0000".to_string()),
@@ -550,7 +537,6 @@ fn get_native_price() {
     let msg = InitMsg {
         owner: HumanAddr("owner0000".to_string()),
         mint_contract: HumanAddr("mint0000".to_string()),
-        factory_contract: HumanAddr("factory0000".to_string()),
         base_denom: "uusd".to_string(),
         mirror_oracle: HumanAddr("mirrororacle0000".to_string()),
         anchor_oracle: HumanAddr("anchororacle0000".to_string()),
@@ -594,7 +580,6 @@ fn revoke_collateral() {
     let msg = InitMsg {
         owner: HumanAddr("owner0000".to_string()),
         mint_contract: HumanAddr("mint0000".to_string()),
-        factory_contract: HumanAddr("factory0000".to_string()),
         base_denom: "uusd".to_string(),
         mirror_oracle: HumanAddr("mirrororacle0000".to_string()),
         anchor_oracle: HumanAddr("anchororacle0000".to_string()),

--- a/contracts/mirror_factory/schema/handle_msg.json
+++ b/contracts/mirror_factory/schema/handle_msg.json
@@ -235,7 +235,7 @@
       }
     },
     {
-      "description": "Feeder Operations ////////////////// Revoke asset from MIR rewards pool and register end_price to mint contract",
+      "description": "Feeder Operations ////////////////// Revoke asset from MIR rewards pool and register end_price to mint contract Only feeder can set end_price",
       "type": "object",
       "required": [
         "revoke_asset"
@@ -244,15 +244,21 @@
         "revoke_asset": {
           "type": "object",
           "required": [
-            "asset_token",
-            "end_price"
+            "asset_token"
           ],
           "properties": {
             "asset_token": {
               "$ref": "#/definitions/HumanAddr"
             },
             "end_price": {
-              "$ref": "#/definitions/Decimal"
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Decimal"
+                },
+                {
+                  "type": "null"
+                }
+              ]
             }
           }
         }

--- a/contracts/mirror_factory/src/math.rs
+++ b/contracts/mirror_factory/src/math.rs
@@ -16,3 +16,8 @@ pub fn decimal_subtraction(a: Decimal, b: Decimal) -> Decimal {
         DECIMAL_FRACTIONAL,
     )
 }
+
+/// return a / b
+pub fn decimal_division(a: Decimal, b: Decimal) -> Decimal {
+    Decimal::from_ratio(DECIMAL_FRACTIONAL * a, b * DECIMAL_FRACTIONAL)
+}

--- a/packages/mirror_protocol/src/collateral_oracle.rs
+++ b/packages/mirror_protocol/src/collateral_oracle.rs
@@ -10,7 +10,6 @@ use terraswap::asset::AssetInfo;
 pub struct InitMsg {
     pub owner: HumanAddr,
     pub mint_contract: HumanAddr,
-    pub factory_contract: HumanAddr,
     pub base_denom: String,
     pub mirror_oracle: HumanAddr,
     pub anchor_oracle: HumanAddr,
@@ -23,7 +22,6 @@ pub enum HandleMsg {
     UpdateConfig {
         owner: Option<HumanAddr>,
         mint_contract: Option<HumanAddr>,
-        factory_contract: Option<HumanAddr>,
         base_denom: Option<String>,
         mirror_oracle: Option<HumanAddr>,
         anchor_oracle: Option<HumanAddr>,
@@ -64,7 +62,6 @@ pub enum QueryMsg {
 pub struct ConfigResponse {
     pub owner: HumanAddr,
     pub mint_contract: HumanAddr,
-    pub factory_contract: HumanAddr,
     pub base_denom: String,
     pub mirror_oracle: HumanAddr,
     pub anchor_oracle: HumanAddr,

--- a/packages/mirror_protocol/src/factory.rs
+++ b/packages/mirror_protocol/src/factory.rs
@@ -63,9 +63,10 @@ pub enum HandleMsg {
 
     /// Revoke asset from MIR rewards pool
     /// and register end_price to mint contract
+    /// Only feeder can set end_price
     RevokeAsset {
         asset_token: HumanAddr,
-        end_price: Decimal,
+        end_price: Option<Decimal>,
     },
     /// Migrate asset to new asset by registering
     /// end_price to mint contract and add


### PR DESCRIPTION
### Overview

Two changes:
1. We want users to `RevokeAsset` through gov poll, but instead of setting an `end_price`, the `end_price` will be set as the last reported price from the oracle. If feeder is the one calling RevokeAsset, setting `end_price` should be allowed.
```
/// Revoke asset from MIR rewards pool
/// and register end_price to mint contract
/// Only feeder can set end_price
RevokeAsset {
    asset_token: HumanAddr,
    end_price: Option<Decimal>,
},
```
2. For collateral oracle , assuming that gov is owner of collateral oracle, all register and update operations are callable by owner.