### PR TITLE
Use hook instead of reply after terraswap pair creation on factory whitelist

### DIFF
--- a/contracts/mirror_factory/schema/execute_msg.json
+++ b/contracts/mirror_factory/schema/execute_msg.json
@@ -192,6 +192,26 @@
       "additionalProperties": false
     },
     {
+      "type": "object",
+      "required": [
+        "terraswap_creation_hook"
+      ],
+      "properties": {
+        "terraswap_creation_hook": {
+          "type": "object",
+          "required": [
+            "asset_token"
+          ],
+          "properties": {
+            "asset_token": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
       "description": "Feeder Operations ////////////////// Revoke asset from MIR rewards pool and register end_price to mint contract Only feeder can set end_price",
       "type": "object",
       "required": [

--- a/contracts/mirror_factory/src/asserts.rs
+++ b/contracts/mirror_factory/src/asserts.rs
@@ -1,0 +1,28 @@
+use cosmwasm_std::{StdError, StdResult};
+
+pub fn assert_valid_token_name(name: &str) -> StdResult<()> {
+    let bytes = name.as_bytes();
+    if bytes.len() < 3 || bytes.len() > 50 {
+        return Err(StdError::generic_err(
+            "Name is not in the expected format (3-50 UTF-8 bytes)",
+        ));
+    }
+    Ok(())
+}
+
+pub fn assert_valid_token_symbol(symbol: &str) -> StdResult<()> {
+    let bytes = symbol.as_bytes();
+    if bytes.len() < 3 || bytes.len() > 12 {
+        return Err(StdError::generic_err(
+            "Ticker symbol is not in expected format [a-zA-Z\\-]{3,12}",
+        ));
+    }
+    for byte in bytes.iter() {
+        if (*byte != 45) && (*byte < 65 || *byte > 90) && (*byte < 97 || *byte > 122) {
+            return Err(StdError::generic_err(
+                "Ticker symbol is not in expected format [a-zA-Z\\-]{3,12}",
+            ));
+        }
+    }
+    Ok(())
+}

--- a/contracts/mirror_factory/src/lib.rs
+++ b/contracts/mirror_factory/src/lib.rs
@@ -1,3 +1,4 @@
+mod asserts;
 pub mod contract;
 pub mod math;
 pub mod querier;

--- a/contracts/mirror_factory/src/state.rs
+++ b/contracts/mirror_factory/src/state.rs
@@ -11,7 +11,6 @@ static KEY_PARAMS: &[u8] = b"params";
 static KEY_TOTAL_WEIGHT: &[u8] = b"total_weight";
 static KEY_LAST_DISTRIBUTED: &[u8] = b"last_distributed";
 static KEY_TMP_ORACLE: &[u8] = b"tmp_oracle_feeder";
-static KEY_TMP_ASSET: &[u8] = b"tmp_asset_token";
 
 static PREFIX_WEIGHT: &[u8] = b"weight";
 
@@ -38,12 +37,9 @@ pub fn read_tmp_oracle(storage: &dyn Storage) -> StdResult<Addr> {
     singleton_read(storage, KEY_TMP_ORACLE).load()
 }
 
-pub fn store_tmp_asset(storage: &mut dyn Storage, tmp_asset: &Addr) -> StdResult<()> {
-    singleton(storage, KEY_TMP_ASSET).save(tmp_asset)
-}
-
-pub fn read_tmp_asset(storage: &dyn Storage) -> StdResult<Addr> {
-    singleton_read(storage, KEY_TMP_ASSET).load()
+pub fn remove_tmp_oracle(storage: &mut dyn Storage) {
+    let mut store: Singleton<Addr> = singleton(storage, KEY_TMP_ORACLE);
+    store.remove()
 }
 
 pub fn store_config(storage: &mut dyn Storage, config: &Config) -> StdResult<()> {

--- a/packages/mirror_protocol/src/factory.rs
+++ b/packages/mirror_protocol/src/factory.rs
@@ -48,6 +48,9 @@ pub enum ExecuteMsg {
         contract_addr: String,
         msg: Binary,
     },
+    TerraswapCreationHook {
+        asset_token: String,
+    },
 
     //////////////////////
     /// Feeder Operations


### PR DESCRIPTION
For columbus5 contracts version we used reply instead of hooks. The problem with this is that if the terraswap pair creation fails, or the staking register_asset operation fails, the state would not be reverted. 
For that, I propose using again a hook instead of reply for the terraswap pair instantiation part of the process.