### PR TITLE
Release v2.2.x

### DIFF
--- a/contracts/mirror_admin_manager/.cargo/config
+++ b/contracts/mirror_admin_manager/.cargo/config
@@ -1,0 +1,6 @@
+[alias]
+wasm = "build --release --target wasm32-unknown-unknown"
+wasm-debug = "build --target wasm32-unknown-unknown"
+unit-test = "test --lib"
+integration-test = "test --test integration"
+schema = "run --example schema"

--- a/contracts/mirror_admin_manager/Cargo.toml
+++ b/contracts/mirror_admin_manager/Cargo.toml
@@ -1,0 +1,47 @@
+[package]
+name = "mirror-admin-manager"
+version = "2.1.1"
+authors = ["Terraform Labs, PTE."]
+edition = "2018"
+description = "Admin manager contract for Mirror Protocol - holds and manages admin privileges for Mirror contracts"
+license = "Apache-2.0"
+
+exclude = [
+  # Those files are rust-optimizer artifacts. You might want to commit them for convenience but they should not be part of the source code publication.
+  "contract.wasm",
+  "hash.txt",
+]
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[profile.release]
+opt-level = 3
+debug = false
+rpath = false
+lto = true
+debug-assertions = false
+codegen-units = 1
+panic = 'abort'
+incremental = false
+overflow-checks = true
+
+[features]
+# for quicker tests, cargo test --lib
+# for more explicit tests, cargo test --features=backtraces
+backtraces = ["cosmwasm-std/backtraces"]
+
+[dependencies]
+cw20 = { version = "0.8.0" }
+cosmwasm-std = { version = "0.16.0", features = ["iterator"] }
+cosmwasm-storage = { version = "0.16.0", features = ["iterator"] }
+mirror-protocol = { version = "2.1.1", path = "../../packages/mirror_protocol" }
+schemars = "0.8.1"
+serde = { version = "1.0.103", default-features = false, features = ["derive"] }
+cw-storage-plus = { version = "0.8.0", features = ["iterator"]}
+thiserror = { version = "1.0.20" }
+
+[dev-dependencies]
+cosmwasm-schema = "0.16.0"

--- a/contracts/mirror_admin_manager/README.md
+++ b/contracts/mirror_admin_manager/README.md
@@ -1,0 +1,1 @@
+# Mirror Admin Manager <!-- omit in toc -->

--- a/contracts/mirror_admin_manager/examples/schema.rs
+++ b/contracts/mirror_admin_manager/examples/schema.rs
@@ -1,0 +1,23 @@
+use std::env::current_dir;
+use std::fs::create_dir_all;
+
+use cosmwasm_schema::{export_schema, remove_schemas, schema_for};
+
+use mirror_protocol::admin_manager::{
+    AuthRecordResponse, ConfigResponse, ExecuteMsg, InstantiateMsg, MigrationRecordResponse,
+    QueryMsg,
+};
+
+fn main() {
+    let mut out_dir = current_dir().unwrap();
+    out_dir.push("schema");
+    create_dir_all(&out_dir).unwrap();
+    remove_schemas(&out_dir).unwrap();
+
+    export_schema(&schema_for!(InstantiateMsg), &out_dir);
+    export_schema(&schema_for!(ExecuteMsg), &out_dir);
+    export_schema(&schema_for!(QueryMsg), &out_dir);
+    export_schema(&schema_for!(ConfigResponse), &out_dir);
+    export_schema(&schema_for!(AuthRecordResponse), &out_dir);
+    export_schema(&schema_for!(MigrationRecordResponse), &out_dir);
+}

--- a/contracts/mirror_admin_manager/rustfmt.toml
+++ b/contracts/mirror_admin_manager/rustfmt.toml
@@ -1,0 +1,15 @@
+# stable
+newline_style = "unix"
+hard_tabs = false
+tab_spaces = 4
+
+# unstable... should we require `rustup run nightly cargo fmt` ?
+# or just update the style guide when they are stable?
+#fn_single_line = true
+#format_code_in_doc_comments = true
+#overflow_delimited_expr = true
+#reorder_impl_items = true
+#struct_field_align_threshold = 20
+#struct_lit_single_line = true
+#report_todo = "Always"
+

--- a/contracts/mirror_admin_manager/schema/auth_record_response.json
+++ b/contracts/mirror_admin_manager/schema/auth_record_response.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "AuthRecordResponse",
+  "type": "object",
+  "required": [
+    "address",
+    "end_time",
+    "start_time"
+  ],
+  "properties": {
+    "address": {
+      "type": "string"
+    },
+    "end_time": {
+      "type": "integer",
+      "format": "uint64",
+      "minimum": 0.0
+    },
+    "start_time": {
+      "type": "integer",
+      "format": "uint64",
+      "minimum": 0.0
+    }
+  }
+}

--- a/contracts/mirror_admin_manager/schema/config_response.json
+++ b/contracts/mirror_admin_manager/schema/config_response.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "ConfigResponse",
+  "type": "object",
+  "required": [
+    "admin_claim_period",
+    "owner"
+  ],
+  "properties": {
+    "admin_claim_period": {
+      "type": "integer",
+      "format": "uint64",
+      "minimum": 0.0
+    },
+    "owner": {
+      "type": "string"
+    }
+  }
+}

--- a/contracts/mirror_admin_manager/schema/execute_msg.json
+++ b/contracts/mirror_admin_manager/schema/execute_msg.json
@@ -1,0 +1,110 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "ExecuteMsg",
+  "oneOf": [
+    {
+      "type": "object",
+      "required": [
+        "update_owner"
+      ],
+      "properties": {
+        "update_owner": {
+          "type": "object",
+          "required": [
+            "owner"
+          ],
+          "properties": {
+            "owner": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "execute_migrations"
+      ],
+      "properties": {
+        "execute_migrations": {
+          "type": "object",
+          "required": [
+            "migrations"
+          ],
+          "properties": {
+            "migrations": {
+              "type": "array",
+              "items": {
+                "type": "array",
+                "items": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "integer",
+                    "format": "uint64",
+                    "minimum": 0.0
+                  },
+                  {
+                    "$ref": "#/definitions/Binary"
+                  }
+                ],
+                "maxItems": 3,
+                "minItems": 3
+              }
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "authorize_claim"
+      ],
+      "properties": {
+        "authorize_claim": {
+          "type": "object",
+          "required": [
+            "authorized_addr"
+          ],
+          "properties": {
+            "authorized_addr": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "claim_admin"
+      ],
+      "properties": {
+        "claim_admin": {
+          "type": "object",
+          "required": [
+            "contract"
+          ],
+          "properties": {
+            "contract": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    }
+  ],
+  "definitions": {
+    "Binary": {
+      "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>",
+      "type": "string"
+    }
+  }
+}

--- a/contracts/mirror_admin_manager/schema/instantiate_msg.json
+++ b/contracts/mirror_admin_manager/schema/instantiate_msg.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "InstantiateMsg",
+  "type": "object",
+  "required": [
+    "admin_claim_period",
+    "owner"
+  ],
+  "properties": {
+    "admin_claim_period": {
+      "type": "integer",
+      "format": "uint64",
+      "minimum": 0.0
+    },
+    "owner": {
+      "type": "string"
+    }
+  }
+}

--- a/contracts/mirror_admin_manager/schema/migration_record_response.json
+++ b/contracts/mirror_admin_manager/schema/migration_record_response.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "MigrationRecordResponse",
+  "type": "object",
+  "required": [
+    "executor",
+    "migrations",
+    "time"
+  ],
+  "properties": {
+    "executor": {
+      "type": "string"
+    },
+    "migrations": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/MigrationItem"
+      }
+    },
+    "time": {
+      "type": "integer",
+      "format": "uint64",
+      "minimum": 0.0
+    }
+  },
+  "definitions": {
+    "Binary": {
+      "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>",
+      "type": "string"
+    },
+    "MigrationItem": {
+      "type": "object",
+      "required": [
+        "contract",
+        "msg",
+        "new_code_id"
+      ],
+      "properties": {
+        "contract": {
+          "type": "string"
+        },
+        "msg": {
+          "$ref": "#/definitions/Binary"
+        },
+        "new_code_id": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        }
+      }
+    }
+  }
+}

--- a/contracts/mirror_admin_manager/schema/query_msg.json
+++ b/contracts/mirror_admin_manager/schema/query_msg.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "QueryMsg",
+  "oneOf": [
+    {
+      "type": "object",
+      "required": [
+        "config"
+      ],
+      "properties": {
+        "config": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "migration_records"
+      ],
+      "properties": {
+        "migration_records": {
+          "type": "object",
+          "properties": {
+            "limit": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint32",
+              "minimum": 0.0
+            },
+            "start_after": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint64",
+              "minimum": 0.0
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "auth_records"
+      ],
+      "properties": {
+        "auth_records": {
+          "type": "object",
+          "properties": {
+            "limit": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint32",
+              "minimum": 0.0
+            },
+            "start_after": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint64",
+              "minimum": 0.0
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    }
+  ]
+}

--- a/contracts/mirror_admin_manager/src/contract.rs
+++ b/contracts/mirror_admin_manager/src/contract.rs
@@ -1,0 +1,60 @@
+#[cfg(not(feature = "library"))]
+use cosmwasm_std::entry_point;
+use cosmwasm_std::{to_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response, StdResult};
+use mirror_protocol::admin_manager::{ExecuteMsg, InstantiateMsg, QueryMsg};
+
+use crate::{
+    error::ContractError,
+    handle::{authorize_claim, claim_admin, execute_migrations, update_owner},
+    query::{query_auth_records, query_config, query_migration_records},
+    state::{Config, CONFIG},
+};
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn instantiate(
+    deps: DepsMut,
+    _env: Env,
+    _info: MessageInfo,
+    msg: InstantiateMsg,
+) -> StdResult<Response> {
+    let config = Config {
+        owner: deps.api.addr_canonicalize(&msg.owner)?,
+        admin_claim_period: msg.admin_claim_period,
+    };
+
+    CONFIG.save(deps.storage, &config)?;
+
+    Ok(Response::default())
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn execute(
+    deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+    msg: ExecuteMsg,
+) -> Result<Response, ContractError> {
+    match msg {
+        ExecuteMsg::UpdateOwner { owner } => update_owner(deps, info, owner),
+        ExecuteMsg::AuthorizeClaim { authorized_addr } => {
+            authorize_claim(deps, info, env, authorized_addr)
+        }
+        ExecuteMsg::ClaimAdmin { contract } => claim_admin(deps, info, env, contract),
+        ExecuteMsg::ExecuteMigrations { migrations } => {
+            execute_migrations(deps, info, env, migrations)
+        }
+    }
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
+    match msg {
+        QueryMsg::Config {} => to_binary(&query_config(deps)?),
+        QueryMsg::AuthRecords { start_after, limit } => {
+            to_binary(&query_auth_records(deps, start_after, limit)?)
+        }
+        QueryMsg::MigrationRecords { start_after, limit } => {
+            to_binary(&query_migration_records(deps, start_after, limit)?)
+        }
+    }
+}

--- a/contracts/mirror_admin_manager/src/error.rs
+++ b/contracts/mirror_admin_manager/src/error.rs
@@ -1,0 +1,11 @@
+use cosmwasm_std::StdError;
+use thiserror::Error;
+
+#[derive(Error, Debug, PartialEq)]
+pub enum ContractError {
+    #[error("{0}")]
+    Std(#[from] StdError),
+
+    #[error("Unauthorized")]
+    Unauthorized {},
+}

--- a/contracts/mirror_admin_manager/src/handle.rs
+++ b/contracts/mirror_admin_manager/src/handle.rs
@@ -1,0 +1,132 @@
+use cosmwasm_std::{
+    attr, Binary, CanonicalAddr, CosmosMsg, DepsMut, Env, MessageInfo, Response, WasmMsg,
+};
+
+use crate::{
+    error::ContractError,
+    state::{
+        create_auth_record, is_addr_authorized, Config, MigrationRecord, CONFIG,
+        MIGRATION_RECORDS_BY_TIME,
+    },
+};
+
+/// Updates the owner of the contract
+pub fn update_owner(
+    deps: DepsMut,
+    info: MessageInfo,
+    owner: String,
+) -> Result<Response, ContractError> {
+    let mut config: Config = CONFIG.load(deps.storage)?;
+    let sender_raw: CanonicalAddr = deps.api.addr_canonicalize(info.sender.as_str())?;
+
+    if sender_raw != config.owner {
+        return Err(ContractError::Unauthorized {});
+    }
+
+    // validate and convert to raw
+    deps.api.addr_validate(owner.as_str())?;
+    let new_owner_raw: CanonicalAddr = deps.api.addr_canonicalize(owner.as_str())?;
+
+    config.owner = new_owner_raw;
+    CONFIG.save(deps.storage, &config)?;
+
+    Ok(Response::new().add_attribute("action", "update_owner"))
+}
+
+/// Owner can authorize an `authorized_address` to execute `claim_admin` for a limited time period
+pub fn authorize_claim(
+    deps: DepsMut,
+    info: MessageInfo,
+    env: Env,
+    authorized_addr: String,
+) -> Result<Response, ContractError> {
+    let config: Config = CONFIG.load(deps.storage)?;
+    let sender_raw: CanonicalAddr = deps.api.addr_canonicalize(info.sender.as_str())?;
+
+    if sender_raw != config.owner {
+        return Err(ContractError::Unauthorized {});
+    }
+
+    // validate and convert authorized address
+    deps.api.addr_validate(authorized_addr.as_str())?;
+    let authorized_addr_raw: CanonicalAddr =
+        deps.api.addr_canonicalize(authorized_addr.as_str())?;
+
+    let claim_start = env.block.time.seconds();
+    let claim_end = claim_start + config.admin_claim_period;
+    create_auth_record(deps.storage, authorized_addr_raw, claim_start, claim_end)?;
+
+    Ok(Response::new().add_attributes(vec![
+        attr("action", "authorize_claim"),
+        attr("claim_start", claim_start.to_string()),
+        attr("claim_end", claim_end.to_string()),
+    ]))
+}
+
+/// An `authorized_address` can claim admin privilages on a `contract` during the auth period
+pub fn claim_admin(
+    deps: DepsMut,
+    info: MessageInfo,
+    env: Env,
+    contract: String,
+) -> Result<Response, ContractError> {
+    let sender_raw: CanonicalAddr = deps.api.addr_canonicalize(info.sender.as_str())?;
+
+    if !is_addr_authorized(deps.storage, sender_raw, env.block.time.seconds()) {
+        return Err(ContractError::Unauthorized {});
+    }
+
+    Ok(Response::new()
+        .add_message(CosmosMsg::Wasm(WasmMsg::UpdateAdmin {
+            contract_addr: contract.to_string(),
+            admin: info.sender.to_string(),
+        }))
+        .add_attributes(vec![
+            attr("action", "claim_admin"),
+            attr("contract", contract),
+        ]))
+}
+
+/// Owner (gov contract) can execute_migrations on any of the managed contracts, creating a migration_record
+pub fn execute_migrations(
+    deps: DepsMut,
+    info: MessageInfo,
+    env: Env,
+    migrations: Vec<(String, u64, Binary)>,
+) -> Result<Response, ContractError> {
+    let config: Config = CONFIG.load(deps.storage)?;
+    let sender_raw: CanonicalAddr = deps.api.addr_canonicalize(info.sender.as_str())?;
+
+    if sender_raw != config.owner {
+        return Err(ContractError::Unauthorized {});
+    }
+
+    let mut migration_msgs: Vec<CosmosMsg> = vec![];
+    let mut migrations_raw: Vec<(CanonicalAddr, u64, Binary)> = vec![];
+
+    for migration in migrations.iter() {
+        migration_msgs.push(CosmosMsg::Wasm(WasmMsg::Migrate {
+            contract_addr: migration.0.to_string(),
+            new_code_id: migration.1,
+            msg: migration.2.clone(),
+        }));
+
+        let contract_addr_raw: CanonicalAddr = deps.api.addr_canonicalize(migration.0.as_str())?;
+        migrations_raw.push((contract_addr_raw, migration.1, migration.2.clone()));
+    }
+
+    let migration_record = MigrationRecord {
+        executor: sender_raw,
+        time: env.block.time.seconds(),
+        migrations: migrations_raw,
+    };
+    MIGRATION_RECORDS_BY_TIME.save(
+        deps.storage,
+        env.block.time.seconds().into(),
+        &migration_record,
+    )?;
+
+    Ok(Response::new()
+        .add_messages(migration_msgs)
+        .add_attribute("action", "execute_migrations"))
+}

--- a/contracts/mirror_admin_manager/src/lib.rs
+++ b/contracts/mirror_admin_manager/src/lib.rs
@@ -1,0 +1,8 @@
+pub mod contract;
+mod error;
+mod handle;
+mod query;
+mod state;
+
+#[cfg(test)]
+mod testing;

--- a/contracts/mirror_admin_manager/src/query.rs
+++ b/contracts/mirror_admin_manager/src/query.rs
@@ -1,0 +1,31 @@
+use cosmwasm_std::{Deps, StdResult};
+use mirror_protocol::admin_manager::{
+    AuthRecordsResponse, ConfigResponse, MigrationRecordsResponse,
+};
+
+use crate::state::{read_latest_auth_records, read_latest_migration_records, Config, CONFIG};
+
+/// Queries contract Config
+pub fn query_config(deps: Deps) -> StdResult<ConfigResponse> {
+    let config: Config = CONFIG.load(deps.storage)?;
+
+    config.as_res(deps.api)
+}
+
+/// Queries all auth records, ordered by timestamp (desc)
+pub fn query_auth_records(
+    deps: Deps,
+    start_after: Option<u64>,
+    limit: Option<u32>,
+) -> StdResult<AuthRecordsResponse> {
+    read_latest_auth_records(deps.storage, deps.api, start_after, limit)
+}
+
+/// Queries all migration records, ordered by timestamp (desc)
+pub fn query_migration_records(
+    deps: Deps,
+    start_after: Option<u64>,
+    limit: Option<u32>,
+) -> StdResult<MigrationRecordsResponse> {
+    read_latest_migration_records(deps.storage, deps.api, start_after, limit)
+}

--- a/contracts/mirror_admin_manager/src/state.rs
+++ b/contracts/mirror_admin_manager/src/state.rs
@@ -1,0 +1,171 @@
+use cosmwasm_std::{Api, Binary, CanonicalAddr, Order, StdResult, Storage};
+use cw_storage_plus::{Bound, Item, Map, U64Key};
+use mirror_protocol::admin_manager::{
+    AuthRecordResponse, AuthRecordsResponse, ConfigResponse, MigrationItem,
+    MigrationRecordResponse, MigrationRecordsResponse,
+};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+pub const CONFIG: Item<Config> = Item::new("config");
+pub const MIGRATION_RECORDS_BY_TIME: Map<U64Key, MigrationRecord> = Map::new("migration_records");
+pub const AUTH_RECORDS_BY_TIME: Map<U64Key, AuthRecord> = Map::new("auth_records");
+pub const AUTH_LIST: Map<&[u8], u64> = Map::new("auth_list");
+
+const MAX_LIMIT: u32 = 30;
+const DEFAULT_LIMIT: u32 = 10;
+
+//////////////////////////////////////////////////////////////////////
+/// CONFIG
+//////////////////////////////////////////////////////////////////////
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct Config {
+    pub owner: CanonicalAddr,
+    pub admin_claim_period: u64,
+}
+
+impl Config {
+    pub fn as_res(&self, api: &dyn Api) -> StdResult<ConfigResponse> {
+        let res = ConfigResponse {
+            owner: api.addr_humanize(&self.owner)?.to_string(),
+            admin_claim_period: self.admin_claim_period,
+        };
+        Ok(res)
+    }
+}
+
+//////////////////////////////////////////////////////////////////////
+/// AUTH RECORDS
+//////////////////////////////////////////////////////////////////////
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct AuthRecord {
+    pub address: CanonicalAddr,
+    pub start_time: u64,
+    pub end_time: u64,
+}
+
+impl AuthRecord {
+    pub fn as_res(&self, api: &dyn Api) -> StdResult<AuthRecordResponse> {
+        let res = AuthRecordResponse {
+            address: api.addr_humanize(&self.address)?.to_string(),
+            start_time: self.start_time,
+            end_time: self.end_time,
+        };
+        Ok(res)
+    }
+}
+
+pub fn create_auth_record(
+    storage: &mut dyn Storage,
+    addr_raw: CanonicalAddr,
+    claim_start: u64,
+    claim_end: u64,
+) -> StdResult<()> {
+    let record = AuthRecord {
+        address: addr_raw.clone(),
+        start_time: claim_start,
+        end_time: claim_end,
+    };
+
+    // stores the record and adds a new entry to the list
+    AUTH_LIST.save(storage, addr_raw.as_slice(), &claim_end)?;
+    AUTH_RECORDS_BY_TIME.save(storage, claim_start.into(), &record)?;
+
+    Ok(())
+}
+
+pub fn is_addr_authorized(
+    storage: &dyn Storage,
+    addr_raw: CanonicalAddr,
+    current_time: u64,
+) -> bool {
+    match AUTH_LIST.load(storage, addr_raw.as_slice()) {
+        Ok(claim_end) => claim_end >= current_time,
+        Err(_) => false,
+    }
+}
+
+pub fn read_latest_auth_records(
+    storage: &dyn Storage,
+    api: &dyn Api,
+    start_after: Option<u64>,
+    limit: Option<u32>,
+) -> StdResult<AuthRecordsResponse> {
+    let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
+    let end = calc_range_end(start_after).map(Bound::exclusive);
+
+    let records: Vec<AuthRecordResponse> = AUTH_RECORDS_BY_TIME
+        .range(storage, None, end, Order::Descending)
+        .take(limit)
+        .map(|item| {
+            let (_, record) = item?;
+
+            record.as_res(api)
+        })
+        .collect::<StdResult<Vec<AuthRecordResponse>>>()?;
+
+    Ok(AuthRecordsResponse { records })
+}
+
+//////////////////////////////////////////////////////////////////////
+/// MIGRATION RECORDS
+//////////////////////////////////////////////////////////////////////
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct MigrationRecord {
+    pub executor: CanonicalAddr,
+    pub time: u64,
+    pub migrations: Vec<(CanonicalAddr, u64, Binary)>,
+}
+
+impl MigrationRecord {
+    pub fn as_res(&self, api: &dyn Api) -> StdResult<MigrationRecordResponse> {
+        let migration_items: Vec<MigrationItem> = self
+            .migrations
+            .iter()
+            .map(|item| {
+                let res = MigrationItem {
+                    contract: api.addr_humanize(&item.0)?.to_string(),
+                    new_code_id: item.1,
+                    msg: item.2.clone(),
+                };
+                Ok(res)
+            })
+            .collect::<StdResult<Vec<MigrationItem>>>()?;
+        let res = MigrationRecordResponse {
+            executor: api.addr_humanize(&self.executor)?.to_string(),
+            time: self.time,
+            migrations: migration_items,
+        };
+        Ok(res)
+    }
+}
+
+pub fn read_latest_migration_records(
+    storage: &dyn Storage,
+    api: &dyn Api,
+    start_after: Option<u64>,
+    limit: Option<u32>,
+) -> StdResult<MigrationRecordsResponse> {
+    let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
+    let end = calc_range_end(start_after).map(Bound::exclusive);
+
+    let records: Vec<MigrationRecordResponse> = MIGRATION_RECORDS_BY_TIME
+        .range(storage, None, end, Order::Descending)
+        .take(limit)
+        .map(|item| {
+            let (_, record) = item?;
+
+            record.as_res(api)
+        })
+        .collect::<StdResult<Vec<MigrationRecordResponse>>>()?;
+
+    Ok(MigrationRecordsResponse { records })
+}
+
+// this will set the first key after the provided key, by appending a 1 byte
+fn calc_range_end(start_after: Option<u64>) -> Option<Vec<u8>> {
+    start_after.map(|id| id.to_be_bytes().to_vec())
+}

--- a/contracts/mirror_admin_manager/src/testing/mod.rs
+++ b/contracts/mirror_admin_manager/src/testing/mod.rs
@@ -1,0 +1,1 @@
+mod tests;

--- a/contracts/mirror_admin_manager/src/testing/tests.rs
+++ b/contracts/mirror_admin_manager/src/testing/tests.rs
@@ -1,0 +1,460 @@
+use crate::contract::{execute, instantiate, query};
+use crate::error::ContractError;
+use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
+use cosmwasm_std::{
+    attr, from_binary, to_binary, BlockInfo, CosmosMsg, Empty, Env, SubMsg, Timestamp, WasmMsg,
+};
+use mirror_protocol::admin_manager::{
+    AuthRecordResponse, AuthRecordsResponse, ConfigResponse, ExecuteMsg, InstantiateMsg,
+    MigrationItem, MigrationRecordResponse, MigrationRecordsResponse, QueryMsg,
+};
+
+fn mock_env_with_block_time(time: u64) -> Env {
+    let env = mock_env();
+    // register time
+    Env {
+        block: BlockInfo {
+            height: 1,
+            time: Timestamp::from_seconds(time),
+            chain_id: "columbus".to_string(),
+        },
+        ..env
+    }
+}
+
+#[test]
+fn proper_initialization() {
+    let mut deps = mock_dependencies(&[]);
+    let msg = InstantiateMsg {
+        owner: "owner0000".to_string(),
+        admin_claim_period: 100u64,
+    };
+    let info = mock_info("addr0000", &[]);
+    instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
+
+    let res = query(deps.as_ref(), mock_env(), QueryMsg::Config {}).unwrap();
+    let config: ConfigResponse = from_binary(&res).unwrap();
+    assert_eq!(
+        config,
+        ConfigResponse {
+            owner: "owner0000".to_string(),
+            admin_claim_period: 100u64,
+        }
+    )
+}
+
+#[test]
+fn update_owner() {
+    let mut deps = mock_dependencies(&[]);
+    let msg = InstantiateMsg {
+        owner: "owner0000".to_string(),
+        admin_claim_period: 100u64,
+    };
+    let info = mock_info("addr0000", &[]);
+    instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
+
+    // update owner, unauth attempt
+    let info = mock_info("addr0000", &[]);
+    let msg = ExecuteMsg::UpdateOwner {
+        owner: "owner0001".to_string(),
+    };
+    let err = execute(deps.as_mut(), mock_env(), info, msg.clone()).unwrap_err();
+    assert_eq!(err, ContractError::Unauthorized {});
+
+    // successfull attempt
+    let info = mock_info("owner0000", &[]);
+    let res = execute(deps.as_mut(), mock_env(), info, msg).unwrap();
+    assert_eq!(res.attributes, vec![attr("action", "update_owner")]);
+
+    let res = query(deps.as_ref(), mock_env(), QueryMsg::Config {}).unwrap();
+    let config: ConfigResponse = from_binary(&res).unwrap();
+    assert_eq!(
+        config,
+        ConfigResponse {
+            owner: "owner0001".to_string(),
+            admin_claim_period: 100u64,
+        }
+    )
+}
+
+#[test]
+fn execute_migrations() {
+    let mut deps = mock_dependencies(&[]);
+    let msg = InstantiateMsg {
+        owner: "owner0000".to_string(),
+        admin_claim_period: 100u64,
+    };
+    let info = mock_info("addr0000", &[]);
+    instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
+
+    let msg = ExecuteMsg::ExecuteMigrations {
+        migrations: vec![
+            (
+                "contract0000".to_string(),
+                12u64,
+                to_binary(&Empty {}).unwrap(),
+            ),
+            (
+                "contract0001".to_string(),
+                13u64,
+                to_binary(&Empty {}).unwrap(),
+            ),
+        ],
+    };
+
+    // unauthorized attempt
+    let info = mock_info("addr0000", &[]);
+    let err = execute(deps.as_mut(), mock_env(), info, msg.clone()).unwrap_err();
+    assert_eq!(err, ContractError::Unauthorized {});
+
+    // successfull attempt
+    let info = mock_info("owner0000", &[]);
+    let res = execute(deps.as_mut(), mock_env(), info, msg).unwrap();
+    assert_eq!(res.attributes, vec![attr("action", "execute_migrations"),]);
+
+    let res: MigrationRecordsResponse = from_binary(
+        &query(
+            deps.as_ref(),
+            mock_env(),
+            QueryMsg::MigrationRecords {
+                start_after: None,
+                limit: None,
+            },
+        )
+        .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(
+        res,
+        MigrationRecordsResponse {
+            records: vec![MigrationRecordResponse {
+                executor: "owner0000".to_string(),
+                time: mock_env().block.time.seconds(),
+                migrations: vec![
+                    MigrationItem {
+                        contract: "contract0000".to_string(),
+                        new_code_id: 12u64,
+                        msg: to_binary(&Empty {}).unwrap(),
+                    },
+                    MigrationItem {
+                        contract: "contract0001".to_string(),
+                        new_code_id: 13u64,
+                        msg: to_binary(&Empty {}).unwrap(),
+                    }
+                ],
+            }]
+        }
+    );
+}
+
+#[test]
+fn authorize_claim() {
+    let mut deps = mock_dependencies(&[]);
+    let msg = InstantiateMsg {
+        owner: "owner0000".to_string(),
+        admin_claim_period: 100u64,
+    };
+    let info = mock_info("addr0000", &[]);
+    instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
+
+    let msg = ExecuteMsg::AuthorizeClaim {
+        authorized_addr: "auth0000".to_string(),
+    };
+
+    // unauthorized attempt
+    let info = mock_info("addr0000", &[]);
+    let err = execute(deps.as_mut(), mock_env(), info, msg.clone()).unwrap_err();
+    assert_eq!(err, ContractError::Unauthorized {});
+
+    // successfull attempt
+    let info = mock_info("owner0000", &[]);
+    let env = mock_env_with_block_time(10u64);
+    let res = execute(deps.as_mut(), env, info, msg).unwrap();
+    assert_eq!(
+        res.attributes,
+        vec![
+            attr("action", "authorize_claim"),
+            attr("claim_start", "10"),
+            attr("claim_end", "110"), // 10 + 100
+        ]
+    );
+
+    let res: AuthRecordsResponse = from_binary(
+        &query(
+            deps.as_ref(),
+            mock_env(),
+            QueryMsg::AuthRecords {
+                start_after: None,
+                limit: None,
+            },
+        )
+        .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(
+        res,
+        AuthRecordsResponse {
+            records: vec![AuthRecordResponse {
+                address: "auth0000".to_string(),
+                start_time: 10u64,
+                end_time: 110u64,
+            }]
+        }
+    );
+}
+
+#[test]
+fn claim_admin() {
+    let mut deps = mock_dependencies(&[]);
+    let msg = InstantiateMsg {
+        owner: "owner0000".to_string(),
+        admin_claim_period: 100u64,
+    };
+    let info = mock_info("addr0000", &[]);
+    instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
+
+    let msg = ExecuteMsg::AuthorizeClaim {
+        authorized_addr: "auth0000".to_string(),
+    };
+
+    let info = mock_info("owner0000", &[]);
+    let env = mock_env_with_block_time(10u64);
+    execute(deps.as_mut(), env, info, msg).unwrap();
+
+    let msg = ExecuteMsg::ClaimAdmin {
+        contract: "contract0000".to_string(),
+    };
+
+    // unauthorized attempt
+    let info = mock_info("addr0000", &[]);
+    let err = execute(deps.as_mut(), mock_env(), info, msg.clone()).unwrap_err();
+    assert_eq!(err, ContractError::Unauthorized {});
+
+    // claim after claim_end, exepct unauthorized error
+    let info = mock_info("auth0000", &[]);
+    let env = mock_env_with_block_time(111u64);
+    let err = execute(deps.as_mut(), env, info.clone(), msg.clone()).unwrap_err();
+    assert_eq!(err, ContractError::Unauthorized {});
+
+    // successful attempt
+    let env = mock_env_with_block_time(109u64);
+    let res = execute(deps.as_mut(), env, info, msg).unwrap();
+    assert_eq!(
+        res.attributes,
+        vec![
+            attr("action", "claim_admin"),
+            attr("contract", "contract0000"),
+        ]
+    );
+    assert_eq!(
+        res.messages,
+        vec![SubMsg::new(CosmosMsg::Wasm(WasmMsg::UpdateAdmin {
+            contract_addr: "contract0000".to_string(),
+            admin: "auth0000".to_string(),
+        }))]
+    )
+}
+
+#[test]
+fn query_auth_records() {
+    let mut deps = mock_dependencies(&[]);
+    let msg = InstantiateMsg {
+        owner: "owner0000".to_string(),
+        admin_claim_period: 100u64,
+    };
+    let info = mock_info("addr0000", &[]);
+    instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
+
+    let msg = ExecuteMsg::AuthorizeClaim {
+        authorized_addr: "auth0000".to_string(),
+    };
+    let info = mock_info("owner0000", &[]);
+    let env = mock_env_with_block_time(10u64);
+    execute(deps.as_mut(), env, info.clone(), msg).unwrap();
+
+    let msg = ExecuteMsg::AuthorizeClaim {
+        authorized_addr: "auth0001".to_string(),
+    };
+    let env = mock_env_with_block_time(20u64);
+    execute(deps.as_mut(), env, info.clone(), msg).unwrap();
+
+    let msg = ExecuteMsg::AuthorizeClaim {
+        authorized_addr: "auth0002".to_string(),
+    };
+    let env = mock_env_with_block_time(30u64);
+    execute(deps.as_mut(), env, info, msg).unwrap();
+
+    let res: AuthRecordsResponse = from_binary(
+        &query(
+            deps.as_ref(),
+            mock_env(),
+            QueryMsg::AuthRecords {
+                start_after: None,
+                limit: None,
+            },
+        )
+        .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(
+        res,
+        AuthRecordsResponse {
+            records: vec![
+                AuthRecordResponse {
+                    address: "auth0002".to_string(),
+                    start_time: 30u64,
+                    end_time: 130u64,
+                },
+                AuthRecordResponse {
+                    address: "auth0001".to_string(),
+                    start_time: 20u64,
+                    end_time: 120u64,
+                },
+                AuthRecordResponse {
+                    address: "auth0000".to_string(),
+                    start_time: 10u64,
+                    end_time: 110u64,
+                }
+            ]
+        }
+    );
+
+    let res: AuthRecordsResponse = from_binary(
+        &query(
+            deps.as_ref(),
+            mock_env(),
+            QueryMsg::AuthRecords {
+                start_after: Some(21u64),
+                limit: Some(1u32),
+            },
+        )
+        .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(
+        res,
+        AuthRecordsResponse {
+            records: vec![AuthRecordResponse {
+                address: "auth0001".to_string(),
+                start_time: 20u64,
+                end_time: 120u64,
+            },]
+        }
+    );
+}
+
+#[test]
+fn query_migration_records() {
+    let mut deps = mock_dependencies(&[]);
+    let msg = InstantiateMsg {
+        owner: "owner0000".to_string(),
+        admin_claim_period: 100u64,
+    };
+    let info = mock_info("addr0000", &[]);
+    instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
+
+    let msg = ExecuteMsg::ExecuteMigrations {
+        migrations: vec![(
+            "contract0000".to_string(),
+            12u64,
+            to_binary(&Empty {}).unwrap(),
+        )],
+    };
+    let info = mock_info("owner0000", &[]);
+    let env = mock_env_with_block_time(10u64);
+    execute(deps.as_mut(), env, info.clone(), msg).unwrap();
+
+    let msg = ExecuteMsg::ExecuteMigrations {
+        migrations: vec![(
+            "contract0001".to_string(),
+            13u64,
+            to_binary(&Empty {}).unwrap(),
+        )],
+    };
+    let env = mock_env_with_block_time(20u64);
+    execute(deps.as_mut(), env, info.clone(), msg).unwrap();
+
+    let msg = ExecuteMsg::ExecuteMigrations {
+        migrations: vec![(
+            "contract0002".to_string(),
+            14u64,
+            to_binary(&Empty {}).unwrap(),
+        )],
+    };
+    let env = mock_env_with_block_time(30u64);
+    execute(deps.as_mut(), env, info, msg).unwrap();
+
+    let res: MigrationRecordsResponse = from_binary(
+        &query(
+            deps.as_ref(),
+            mock_env(),
+            QueryMsg::MigrationRecords {
+                start_after: None,
+                limit: None,
+            },
+        )
+        .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(
+        res,
+        MigrationRecordsResponse {
+            records: vec![
+                MigrationRecordResponse {
+                    executor: "owner0000".to_string(),
+                    time: 30u64,
+                    migrations: vec![MigrationItem {
+                        contract: "contract0002".to_string(),
+                        new_code_id: 14u64,
+                        msg: to_binary(&Empty {}).unwrap(),
+                    },],
+                },
+                MigrationRecordResponse {
+                    executor: "owner0000".to_string(),
+                    time: 20u64,
+                    migrations: vec![MigrationItem {
+                        contract: "contract0001".to_string(),
+                        new_code_id: 13u64,
+                        msg: to_binary(&Empty {}).unwrap(),
+                    },],
+                },
+                MigrationRecordResponse {
+                    executor: "owner0000".to_string(),
+                    time: 10u64,
+                    migrations: vec![MigrationItem {
+                        contract: "contract0000".to_string(),
+                        new_code_id: 12u64,
+                        msg: to_binary(&Empty {}).unwrap(),
+                    },],
+                },
+            ]
+        }
+    );
+
+    let res: MigrationRecordsResponse = from_binary(
+        &query(
+            deps.as_ref(),
+            mock_env(),
+            QueryMsg::MigrationRecords {
+                start_after: Some(21u64),
+                limit: Some(1u32),
+            },
+        )
+        .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(
+        res,
+        MigrationRecordsResponse {
+            records: vec![MigrationRecordResponse {
+                executor: "owner0000".to_string(),
+                time: 20u64,
+                migrations: vec![MigrationItem {
+                    contract: "contract0001".to_string(),
+                    new_code_id: 13u64,
+                    msg: to_binary(&Empty {}).unwrap(),
+                },],
+            },]
+        }
+    );
+}

--- a/contracts/mirror_collateral_oracle/Cargo.toml
+++ b/contracts/mirror_collateral_oracle/Cargo.toml
@@ -37,6 +37,7 @@ backtraces = ["cosmwasm-std/backtraces"]
 cosmwasm-std = { version = "0.16.0", features = ["iterator"] }
 cosmwasm-storage = { version = "0.16.0", features = ["iterator"] }
 mirror-protocol = { version = "2.1.1", path = "../../packages/mirror_protocol" }
+tefi-oracle = { version = "0.1.0", path = "../../packages/tefi_oracle" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 terraswap = "2.4.0"

--- a/contracts/mirror_collateral_oracle/src/contract.rs
+++ b/contracts/mirror_collateral_oracle/src/contract.rs
@@ -1,4 +1,4 @@
-use crate::migration::migrate_collateral_infos;
+use crate::migration::{migrate_collateral_infos, migrate_config};
 use crate::querier::query_price;
 use crate::state::{
     read_collateral_info, read_collateral_infos, read_config, store_collateral_info, store_config,
@@ -291,6 +291,8 @@ pub fn query_collateral_infos(deps: Deps) -> StdResult<CollateralInfosResponse> 
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn migrate(deps: DepsMut, _env: Env, msg: MigrateMsg) -> StdResult<Response> {
+    migrate_config(deps.storage)?;
+
     migrate_collateral_infos(
         deps.storage,
         msg.mirror_tefi_oracle_addr,

--- a/contracts/mirror_collateral_oracle/src/contract.rs
+++ b/contracts/mirror_collateral_oracle/src/contract.rs
@@ -1,3 +1,4 @@
+use crate::migration::migrate_collateral_infos;
 use crate::querier::query_price;
 use crate::state::{
     read_collateral_info, read_collateral_infos, read_config, store_collateral_info, store_config,
@@ -28,9 +29,6 @@ pub fn instantiate(
             owner: deps.api.addr_canonicalize(&msg.owner)?,
             mint_contract: deps.api.addr_canonicalize(&msg.mint_contract)?,
             base_denom: msg.base_denom,
-            mirror_oracle: deps.api.addr_canonicalize(&msg.mirror_oracle)?,
-            anchor_oracle: deps.api.addr_canonicalize(&msg.anchor_oracle)?,
-            band_oracle: deps.api.addr_canonicalize(&msg.band_oracle)?,
         },
     )?;
 
@@ -49,19 +47,7 @@ pub fn execute(
             owner,
             mint_contract,
             base_denom,
-            mirror_oracle,
-            anchor_oracle,
-            band_oracle,
-        } => update_config(
-            deps,
-            info,
-            owner,
-            mint_contract,
-            base_denom,
-            mirror_oracle,
-            anchor_oracle,
-            band_oracle,
-        ),
+        } => update_config(deps, info, owner, mint_contract, base_denom),
         ExecuteMsg::RegisterCollateralAsset {
             asset,
             price_source,
@@ -85,9 +71,6 @@ pub fn update_config(
     owner: Option<String>,
     mint_contract: Option<String>,
     base_denom: Option<String>,
-    mirror_oracle: Option<String>,
-    anchor_oracle: Option<String>,
-    band_oracle: Option<String>,
 ) -> StdResult<Response> {
     let mut config: Config = read_config(deps.storage)?;
     if deps.api.addr_canonicalize(info.sender.as_str())? != config.owner {
@@ -104,18 +87,6 @@ pub fn update_config(
 
     if let Some(base_denom) = base_denom {
         config.base_denom = base_denom;
-    }
-
-    if let Some(mirror_oracle) = mirror_oracle {
-        config.mirror_oracle = deps.api.addr_canonicalize(&mirror_oracle)?;
-    }
-
-    if let Some(anchor_oracle) = anchor_oracle {
-        config.anchor_oracle = deps.api.addr_canonicalize(&anchor_oracle)?;
-    }
-
-    if let Some(band_oracle) = band_oracle {
-        config.band_oracle = deps.api.addr_canonicalize(&band_oracle)?;
     }
 
     store_config(deps.storage, &config)?;
@@ -241,13 +212,12 @@ pub fn update_collateral_multiplier(
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]
-pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
+pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
     match msg {
         QueryMsg::Config {} => to_binary(&query_config(deps)?),
-        QueryMsg::CollateralPrice {
-            asset,
-            block_height,
-        } => to_binary(&query_collateral_price(deps, asset, block_height)?),
+        QueryMsg::CollateralPrice { asset, timeframe } => {
+            to_binary(&query_collateral_price(deps, env, asset, timeframe)?)
+        }
         QueryMsg::CollateralAssetInfo { asset } => to_binary(&query_collateral_info(deps, asset)?),
         QueryMsg::CollateralAssetInfos {} => to_binary(&query_collateral_infos(deps)?),
     }
@@ -259,9 +229,6 @@ pub fn query_config(deps: Deps) -> StdResult<ConfigResponse> {
         owner: deps.api.addr_humanize(&config.owner)?.to_string(),
         mint_contract: deps.api.addr_humanize(&config.mint_contract)?.to_string(),
         base_denom: config.base_denom,
-        mirror_oracle: deps.api.addr_humanize(&config.mirror_oracle)?.to_string(),
-        anchor_oracle: deps.api.addr_humanize(&config.anchor_oracle)?.to_string(),
-        band_oracle: deps.api.addr_humanize(&config.band_oracle)?.to_string(),
     };
 
     Ok(resp)
@@ -269,8 +236,9 @@ pub fn query_config(deps: Deps) -> StdResult<ConfigResponse> {
 
 pub fn query_collateral_price(
     deps: Deps,
+    env: Env,
     quote_asset: String,
-    block_height: Option<u64>,
+    timeframe: Option<u64>,
 ) -> StdResult<CollateralPriceResponse> {
     let config: Config = read_config(deps.storage)?;
 
@@ -283,9 +251,10 @@ pub fn query_collateral_price(
 
     let (price, last_updated): (Decimal, u64) = query_price(
         deps,
+        env,
         &config,
         &quote_asset,
-        block_height,
+        timeframe,
         &collateral.price_source,
     )?;
 
@@ -321,6 +290,12 @@ pub fn query_collateral_infos(deps: Deps) -> StdResult<CollateralInfosResponse> 
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]
-pub fn migrate(_deps: DepsMut, _env: Env, _msg: MigrateMsg) -> StdResult<Response> {
+pub fn migrate(deps: DepsMut, _env: Env, msg: MigrateMsg) -> StdResult<Response> {
+    migrate_collateral_infos(
+        deps.storage,
+        msg.mirror_tefi_oracle_addr,
+        msg.anchor_tefi_oracle_addr,
+    )?;
+
     Ok(Response::default())
 }

--- a/contracts/mirror_collateral_oracle/src/lib.rs
+++ b/contracts/mirror_collateral_oracle/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod contract;
 pub mod math;
+pub mod migration;
 pub mod querier;
 pub mod state;
 

--- a/contracts/mirror_collateral_oracle/src/migration.rs
+++ b/contracts/mirror_collateral_oracle/src/migration.rs
@@ -109,7 +109,7 @@ pub fn migrate_collateral_infos(
             asset: legacy_collateral_info.asset,
             multiplier: legacy_collateral_info.multiplier,
             price_source: new_price_source,
-            is_revoked: false,
+            is_revoked: legacy_collateral_info.is_revoked,
         };
         new_pool_infos_bucket.save(new_collateral_info.asset.as_bytes(), new_collateral_info)?;
     }

--- a/contracts/mirror_collateral_oracle/src/migration.rs
+++ b/contracts/mirror_collateral_oracle/src/migration.rs
@@ -1,0 +1,219 @@
+use cosmwasm_storage::{singleton, singleton_read, Bucket, ReadonlySingleton, Singleton};
+use mirror_protocol::collateral_oracle::SourceType;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use cosmwasm_std::{CanonicalAddr, Decimal, Order, StdError, StdResult, Storage};
+
+use crate::state::{CollateralAssetInfo, Config, KEY_CONFIG, PREFIX_COLLATERAL_ASSET_INFO};
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct LegacyConfig {
+    pub owner: CanonicalAddr,
+    pub mint_contract: CanonicalAddr,
+    pub base_denom: String,
+    pub mirror_oracle: CanonicalAddr,
+    pub anchor_oracle: CanonicalAddr,
+    pub band_oracle: CanonicalAddr,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct LegacyCollateralAssetInfo {
+    pub asset: String,
+    pub price_source: LegacySourceType,
+    pub multiplier: Decimal,
+    pub is_revoked: bool,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum LegacySourceType {
+    MirrorOracle {},
+    AnchorOracle {},
+    BandOracle {},
+    FixedPrice {
+        price: Decimal,
+    },
+    Terraswap {
+        terraswap_pair_addr: String,
+        intermediate_denom: Option<String>,
+    },
+    AnchorMarket {
+        anchor_market_addr: String,
+    },
+    Native {
+        native_denom: String,
+    },
+}
+
+pub fn migrate_config(storage: &mut dyn Storage) -> StdResult<()> {
+    let legacty_store: ReadonlySingleton<LegacyConfig> = singleton_read(storage, KEY_CONFIG);
+    let legacy_config: LegacyConfig = legacty_store.load()?;
+    let config = Config {
+        owner: legacy_config.owner,
+        mint_contract: legacy_config.mint_contract,
+        base_denom: legacy_config.base_denom,
+    };
+    let mut store: Singleton<Config> = singleton(storage, KEY_CONFIG);
+    store.save(&config)?;
+    Ok(())
+}
+
+pub fn migrate_collateral_infos(
+    storage: &mut dyn Storage,
+    mirror_tefi_oracle_addr: String,
+    anchor_tefi_oracle_addr: String,
+) -> StdResult<()> {
+    let mut legacy_collateral_infos_bucket: Bucket<LegacyCollateralAssetInfo> =
+        Bucket::new(storage, PREFIX_COLLATERAL_ASSET_INFO);
+
+    let mut collateral_infos: Vec<(String, LegacyCollateralAssetInfo)> = vec![];
+    for item in legacy_collateral_infos_bucket.range(None, None, Order::Ascending) {
+        let (k, p) = item?;
+        collateral_infos.push((String::from_utf8(k)?, p));
+    }
+
+    for (asset, _) in collateral_infos.clone().into_iter() {
+        legacy_collateral_infos_bucket.remove(asset.as_bytes());
+    }
+
+    let mut new_pool_infos_bucket: Bucket<CollateralAssetInfo> =
+        Bucket::new(storage, PREFIX_COLLATERAL_ASSET_INFO);
+
+    for (_, legacy_collateral_info) in collateral_infos.into_iter() {
+        let new_price_source: SourceType = match legacy_collateral_info.price_source {
+            LegacySourceType::BandOracle { .. } => {
+                return Err(StdError::generic_err("not supported"))
+            } // currently there are no assets with this config
+            LegacySourceType::AnchorOracle { .. } => SourceType::TeFiOracle {
+                oracle_addr: anchor_tefi_oracle_addr.clone(),
+            },
+            LegacySourceType::MirrorOracle { .. } => SourceType::TeFiOracle {
+                oracle_addr: mirror_tefi_oracle_addr.clone(),
+            },
+            LegacySourceType::AnchorMarket { anchor_market_addr } => {
+                SourceType::AnchorMarket { anchor_market_addr }
+            }
+            LegacySourceType::FixedPrice { price } => SourceType::FixedPrice { price },
+            LegacySourceType::Native { native_denom } => SourceType::Native { native_denom },
+            LegacySourceType::Terraswap {
+                terraswap_pair_addr,
+                intermediate_denom,
+            } => SourceType::AMMPair {
+                pair_addr: terraswap_pair_addr,
+                intermediate_denom,
+            },
+        };
+
+        let new_collateral_info = &CollateralAssetInfo {
+            asset: legacy_collateral_info.asset,
+            multiplier: legacy_collateral_info.multiplier,
+            price_source: new_price_source,
+            is_revoked: false,
+        };
+        new_pool_infos_bucket.save(new_collateral_info.asset.as_bytes(), new_collateral_info)?;
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod migrate_tests {
+    use crate::state::read_collateral_info;
+
+    use super::*;
+    use cosmwasm_std::testing::mock_dependencies;
+
+    pub fn collateral_infos_old_store(
+        storage: &mut dyn Storage,
+    ) -> Bucket<LegacyCollateralAssetInfo> {
+        Bucket::new(storage, PREFIX_COLLATERAL_ASSET_INFO)
+    }
+
+    #[test]
+    fn test_collateral_infos_migration() {
+        let mut deps = mock_dependencies(&[]);
+        let mut legacy_store = collateral_infos_old_store(&mut deps.storage);
+
+        let col_info_1 = LegacyCollateralAssetInfo {
+            asset: "mAPPL0000".to_string(),
+            multiplier: Decimal::one(),
+            price_source: LegacySourceType::MirrorOracle {},
+            is_revoked: false,
+        };
+        let col_info_2 = LegacyCollateralAssetInfo {
+            asset: "anc0000".to_string(),
+            multiplier: Decimal::one(),
+            price_source: LegacySourceType::Terraswap {
+                terraswap_pair_addr: "pair0000".to_string(),
+                intermediate_denom: None,
+            },
+            is_revoked: false,
+        };
+        let col_info_3 = LegacyCollateralAssetInfo {
+            asset: "bluna0000".to_string(),
+            multiplier: Decimal::one(),
+            price_source: LegacySourceType::AnchorOracle {},
+            is_revoked: false,
+        };
+
+        legacy_store
+            .save(col_info_1.asset.as_bytes(), &col_info_1)
+            .unwrap();
+        legacy_store
+            .save(col_info_2.asset.as_bytes(), &col_info_2)
+            .unwrap();
+        legacy_store
+            .save(col_info_3.asset.as_bytes(), &col_info_3)
+            .unwrap();
+
+        migrate_collateral_infos(
+            deps.as_mut().storage,
+            "mirrortefi0000".to_string(),
+            "anctefi0000".to_string(),
+        )
+        .unwrap();
+
+        let new_col_info_1: CollateralAssetInfo =
+            read_collateral_info(deps.as_mut().storage, &col_info_1.asset).unwrap();
+        let new_col_info_2: CollateralAssetInfo =
+            read_collateral_info(deps.as_mut().storage, &col_info_2.asset).unwrap();
+        let new_col_info_3: CollateralAssetInfo =
+            read_collateral_info(deps.as_mut().storage, &col_info_3.asset).unwrap();
+
+        assert_eq!(
+            new_col_info_1,
+            CollateralAssetInfo {
+                asset: "mAPPL0000".to_string(),
+                multiplier: Decimal::one(),
+                price_source: SourceType::TeFiOracle {
+                    oracle_addr: "mirrortefi0000".to_string(),
+                },
+                is_revoked: false,
+            }
+        );
+        assert_eq!(
+            new_col_info_2,
+            CollateralAssetInfo {
+                asset: "anc0000".to_string(),
+                multiplier: Decimal::one(),
+                price_source: SourceType::AMMPair {
+                    pair_addr: "pair0000".to_string(),
+                    intermediate_denom: None,
+                },
+                is_revoked: false,
+            }
+        );
+        assert_eq!(
+            new_col_info_3,
+            CollateralAssetInfo {
+                asset: "bluna0000".to_string(),
+                multiplier: Decimal::one(),
+                price_source: SourceType::TeFiOracle {
+                    oracle_addr: "anctefi0000".to_string(),
+                },
+                is_revoked: false,
+            }
+        )
+    }
+}

--- a/contracts/mirror_collateral_oracle/src/querier.rs
+++ b/contracts/mirror_collateral_oracle/src/querier.rs
@@ -2,27 +2,23 @@ use crate::math::decimal_multiplication;
 use crate::state::Config;
 use cosmwasm_bignumber::{Decimal256, Uint256};
 use cosmwasm_std::{
-    to_binary, Decimal, Deps, QuerierWrapper, QueryRequest, StdError, StdResult, Uint128, WasmQuery,
+    to_binary, Decimal, Deps, Env, QuerierWrapper, QueryRequest, StdError, StdResult, WasmQuery,
 };
 use mirror_protocol::collateral_oracle::SourceType;
 use serde::{Deserialize, Serialize};
-use std::str::FromStr;
+use tefi_oracle::hub::{
+    HubQueryMsg as TeFiOracleQueryMsg, PriceResponse as TeFiOraclePriceResponse,
+};
 use terra_cosmwasm::{ExchangeRatesResponse, TerraQuerier};
 use terraswap::asset::{Asset, AssetInfo};
-use terraswap::pair::QueryMsg as TerraswapPairQueryMsg;
+use terraswap::pair::QueryMsg as AMMPairQueryMsg;
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum SourceQueryMsg {
-    Price {
-        base_asset: String,
-        quote_asset: String,
-    },
+    // Query message for terraswap pool
     Pool {},
-    GetReferenceData {
-        base_symbol: String,
-        quote_symbol: String,
-    },
+    // Query message for anchor market
     EpochState {
         block_heigth: Option<u64>,
         distributed_interest: Option<Uint256>,
@@ -30,21 +26,9 @@ pub enum SourceQueryMsg {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
-pub struct TerraOracleResponse {
-    // oracle queries returns rate
-    pub rate: Decimal,
-    pub last_updated_base: u64,
-}
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
-pub struct TerraswapResponse {
-    // terraswap queries return pool assets
+pub struct AMMPairResponse {
+    // queries return pool assets
     pub assets: [Asset; 2],
-}
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
-pub struct BandOracleResponse {
-    // band oracle queries returns rate (uint128)
-    pub rate: Uint128,
-    pub last_updated_base: u64,
 }
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct AnchorMarketResponse {
@@ -55,61 +39,35 @@ pub struct AnchorMarketResponse {
 #[allow(clippy::ptr_arg)]
 pub fn query_price(
     deps: Deps,
+    env: Env,
     config: &Config,
     asset: &String,
-    block_height: Option<u64>,
+    timeframe: Option<u64>,
     price_source: &SourceType,
 ) -> StdResult<(Decimal, u64)> {
     match price_source {
-        SourceType::BandOracle {} => {
-            let res: BandOracleResponse =
-                deps.querier.query(&QueryRequest::Wasm(WasmQuery::Smart {
-                    contract_addr: deps.api.addr_humanize(&config.band_oracle)?.to_string(),
-                    msg: to_binary(&SourceQueryMsg::GetReferenceData {
-                        base_symbol: asset.to_string(),
-                        quote_symbol: config.base_denom.clone(),
-                    })
-                    .unwrap(),
-                }))?;
-            let rate: Decimal = parse_band_rate(res.rate)?;
-
-            Ok((rate, res.last_updated_base))
-        }
         SourceType::FixedPrice { price } => Ok((*price, u64::MAX)),
-        SourceType::MirrorOracle {} => {
-            let res: TerraOracleResponse =
+        SourceType::TeFiOracle { oracle_addr } => {
+            let res: TeFiOraclePriceResponse =
                 deps.querier.query(&QueryRequest::Wasm(WasmQuery::Smart {
-                    contract_addr: deps.api.addr_humanize(&config.mirror_oracle)?.to_string(),
-                    msg: to_binary(&SourceQueryMsg::Price {
-                        base_asset: asset.to_string(),
-                        quote_asset: config.base_denom.clone(),
+                    contract_addr: oracle_addr.to_string(),
+                    msg: to_binary(&TeFiOracleQueryMsg::Price {
+                        asset_token: asset.to_string(),
+                        timeframe,
                     })
                     .unwrap(),
                 }))?;
 
-            Ok((res.rate, res.last_updated_base))
+            Ok((res.rate, res.last_updated))
         }
-        SourceType::AnchorOracle {} => {
-            let res: TerraOracleResponse =
-                deps.querier.query(&QueryRequest::Wasm(WasmQuery::Smart {
-                    contract_addr: deps.api.addr_humanize(&config.anchor_oracle)?.to_string(),
-                    msg: to_binary(&SourceQueryMsg::Price {
-                        base_asset: asset.to_string(),
-                        quote_asset: config.base_denom.clone(),
-                    })
-                    .unwrap(),
-                }))?;
-
-            Ok((res.rate, res.last_updated_base))
-        }
-        SourceType::Terraswap {
-            terraswap_pair_addr,
+        SourceType::AMMPair {
+            pair_addr,
             intermediate_denom,
         } => {
-            let res: TerraswapResponse =
+            let res: AMMPairResponse =
                 deps.querier.query(&QueryRequest::Wasm(WasmQuery::Smart {
-                    contract_addr: terraswap_pair_addr.to_string(),
-                    msg: to_binary(&TerraswapPairQueryMsg::Pool {}).unwrap(),
+                    contract_addr: pair_addr.to_string(),
+                    msg: to_binary(&AMMPairQueryMsg::Pool {}).unwrap(),
                 }))?;
             let assets: [Asset; 2] = res.assets;
 
@@ -147,7 +105,7 @@ pub fn query_price(
                 deps.querier.query(&QueryRequest::Wasm(WasmQuery::Smart {
                     contract_addr: anchor_market_addr.to_string(),
                     msg: to_binary(&SourceQueryMsg::EpochState {
-                        block_heigth: block_height,
+                        block_heigth: Some(env.block.height),
                         distributed_interest: None,
                     })
                     .unwrap(),
@@ -168,27 +126,6 @@ pub fn query_price(
     }
 }
 
-/// Parses a uint that contains the price multiplied by 1e18
-fn parse_band_rate(uint_rate: Uint128) -> StdResult<Decimal> {
-    // manipulate the uint as a string to prevent overflow
-    let mut rate_uint_string: String = uint_rate.to_string();
-
-    let uint_len = rate_uint_string.len();
-    if uint_len > 18 {
-        let dec_point = rate_uint_string.len() - 18;
-        rate_uint_string.insert(dec_point, '.');
-    } else {
-        let mut prefix: String = "0.".to_owned();
-        let dec_zeros = 18 - uint_len;
-        for _ in 0..dec_zeros {
-            prefix.push('0');
-        }
-        rate_uint_string = prefix + rate_uint_string.as_str();
-    }
-
-    Decimal::from_str(rate_uint_string.as_str())
-}
-
 fn query_native_rate(
     querier: &QuerierWrapper,
     base_denom: String,
@@ -199,31 +136,4 @@ fn query_native_rate(
         terra_querier.query_exchange_rates(base_denom, vec![quote_denom])?;
 
     Ok(res.exchange_rates[0].exchange_rate)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_parse_band_rate() {
-        let rate_dec_1: Decimal =
-            parse_band_rate(Uint128::from(3493968700000000000000u128)).unwrap();
-        assert_eq!(
-            rate_dec_1,
-            Decimal::from_str("3493.968700000000000000").unwrap()
-        );
-
-        let rate_dec_2: Decimal = parse_band_rate(Uint128::from(1234u128)).unwrap();
-        assert_eq!(
-            rate_dec_2,
-            Decimal::from_str("0.000000000000001234").unwrap()
-        );
-
-        let rate_dec_3: Decimal = parse_band_rate(Uint128::from(100000000000000001u128)).unwrap();
-        assert_eq!(
-            rate_dec_3,
-            Decimal::from_str("0.100000000000000001").unwrap()
-        );
-    }
 }

--- a/contracts/mirror_collateral_oracle/src/querier.rs
+++ b/contracts/mirror_collateral_oracle/src/querier.rs
@@ -20,7 +20,7 @@ pub enum SourceQueryMsg {
     Pool {},
     // Query message for anchor market
     EpochState {
-        block_heigth: Option<u64>,
+        block_height: Option<u64>,
         distributed_interest: Option<Uint256>,
     },
 }
@@ -105,7 +105,7 @@ pub fn query_price(
                 deps.querier.query(&QueryRequest::Wasm(WasmQuery::Smart {
                     contract_addr: anchor_market_addr.to_string(),
                     msg: to_binary(&SourceQueryMsg::EpochState {
-                        block_heigth: Some(env.block.height),
+                        block_height: Some(env.block.height),
                         distributed_interest: None,
                     })
                     .unwrap(),

--- a/contracts/mirror_collateral_oracle/src/state.rs
+++ b/contracts/mirror_collateral_oracle/src/state.rs
@@ -4,17 +4,14 @@ use mirror_protocol::collateral_oracle::{CollateralInfoResponse, SourceType};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-static PREFIX_COLLATERAL_ASSET_INFO: &[u8] = b"collateral_asset_info";
-static KEY_CONFIG: &[u8] = b"config";
+pub static PREFIX_COLLATERAL_ASSET_INFO: &[u8] = b"collateral_asset_info";
+pub static KEY_CONFIG: &[u8] = b"config";
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct Config {
     pub owner: CanonicalAddr,
     pub mint_contract: CanonicalAddr,
     pub base_denom: String,
-    pub mirror_oracle: CanonicalAddr,
-    pub anchor_oracle: CanonicalAddr,
-    pub band_oracle: CanonicalAddr,
 }
 
 pub fn store_config(storage: &mut dyn Storage, config: &Config) -> StdResult<()> {

--- a/contracts/mirror_collateral_oracle/src/testing/mock_querier.rs
+++ b/contracts/mirror_collateral_oracle/src/testing/mock_querier.rs
@@ -1,15 +1,14 @@
-use crate::math::decimal_division;
 use cosmwasm_bignumber::{Decimal256, Uint256};
 use cosmwasm_std::testing::{MockApi, MockQuerier, MockStorage, MOCK_CONTRACT_ADDR};
 use cosmwasm_std::{
     from_binary, from_slice, to_binary, Coin, ContractResult, Decimal, OwnedDeps, Querier,
     QuerierResult, QueryRequest, SystemError, SystemResult, Uint128, WasmQuery,
 };
-use mirror_protocol::oracle::PriceResponse;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::str::FromStr;
+use tefi_oracle::hub::PriceResponse as TeFiOraclePriceResponse;
 use terra_cosmwasm::{
     ExchangeRateItem, ExchangeRatesResponse, TerraQuery, TerraQueryWrapper, TerraRoute,
 };
@@ -108,14 +107,6 @@ impl Querier for WasmMockQuerier {
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
-pub struct ReferenceData {
-    rate: Uint128,
-    last_updated_base: u64,
-    last_updated_quote: u64,
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-#[serde(rename_all = "snake_case")]
 pub struct EpochStateResponse {
     exchange_rate: Decimal256,
     aterra_supply: Uint256,
@@ -125,14 +116,10 @@ pub struct EpochStateResponse {
 #[serde(rename_all = "snake_case")]
 pub enum QueryMsg {
     Price {
-        base_asset: String,
-        quote_asset: String,
+        asset_token: String,
+        timeframe: Option<u64>,
     },
     Pool {},
-    GetReferenceData {
-        base_symbol: String,
-        quote_symbol: String,
-    },
     EpochState {
         block_heigth: Option<u64>,
         distributed_interest: Option<Uint256>,
@@ -168,24 +155,15 @@ impl WasmMockQuerier {
                 .unwrap()
             {
                 QueryMsg::Price {
-                    base_asset,
-                    quote_asset,
-                } => match self.oracle_price_querier.oracle_price.get(&base_asset) {
-                    Some(base_price) => {
-                        match self.oracle_price_querier.oracle_price.get(&quote_asset) {
-                            Some(quote_price) => {
-                                SystemResult::Ok(ContractResult::from(to_binary(&PriceResponse {
-                                    rate: decimal_division(*base_price, *quote_price),
-                                    last_updated_base: 1000u64,
-                                    last_updated_quote: 1000u64,
-                                })))
-                            }
-                            None => SystemResult::Err(SystemError::InvalidRequest {
-                                error: "No oracle price exists".to_string(),
-                                request: msg.as_slice().into(),
-                            }),
-                        }
-                    }
+                    asset_token,
+                    timeframe: _,
+                } => match self.oracle_price_querier.oracle_price.get(&asset_token) {
+                    Some(base_price) => SystemResult::Ok(ContractResult::from(to_binary(
+                        &TeFiOraclePriceResponse {
+                            rate: *base_price,
+                            last_updated: 1000u64,
+                        },
+                    ))),
                     None => SystemResult::Err(SystemError::InvalidRequest {
                         error: "No oracle price exists".to_string(),
                         request: msg.as_slice().into(),
@@ -212,13 +190,6 @@ impl WasmMockQuerier {
                         request: msg.as_slice().into(),
                     }),
                 },
-                QueryMsg::GetReferenceData { .. } => {
-                    SystemResult::Ok(ContractResult::from(to_binary(&ReferenceData {
-                        rate: Uint128::from(3465211050000000000000u128),
-                        last_updated_base: 100u64,
-                        last_updated_quote: 100u64,
-                    })))
-                }
                 QueryMsg::EpochState { .. } => {
                     SystemResult::Ok(ContractResult::from(to_binary(&EpochStateResponse {
                         exchange_rate: Decimal256::from_ratio(10, 3),

--- a/contracts/mirror_collateral_oracle/src/testing/tests.rs
+++ b/contracts/mirror_collateral_oracle/src/testing/tests.rs
@@ -7,7 +7,6 @@ use cosmwasm_std::{Decimal, StdError, Uint128};
 use mirror_protocol::collateral_oracle::{
     CollateralInfoResponse, CollateralPriceResponse, ExecuteMsg, InstantiateMsg, SourceType,
 };
-use std::str::FromStr;
 use terraswap::asset::AssetInfo;
 
 #[test]
@@ -18,9 +17,6 @@ fn proper_initialization() {
         owner: "owner0000".to_string(),
         mint_contract: "mint0000".to_string(),
         base_denom: "uusd".to_string(),
-        mirror_oracle: "mirrororacle0000".to_string(),
-        anchor_oracle: "anchororacle0000".to_string(),
-        band_oracle: "bandoracle0000".to_string(),
     };
 
     let info = mock_info("addr0000", &[]);
@@ -44,9 +40,6 @@ fn update_config() {
         owner: "owner0000".to_string(),
         mint_contract: "mint0000".to_string(),
         base_denom: "uusd".to_string(),
-        mirror_oracle: "mirrororacle0000".to_string(),
-        anchor_oracle: "anchororacle0000".to_string(),
-        band_oracle: "bandoracle0000".to_string(),
     };
 
     let info = mock_info("addr0000", &[]);
@@ -58,9 +51,6 @@ fn update_config() {
         owner: Some("owner0001".to_string()),
         mint_contract: Some("mint0001".to_string()),
         base_denom: Some("uluna".to_string()),
-        mirror_oracle: Some("mirrororacle0001".to_string()),
-        anchor_oracle: Some("anchororacle0001".to_string()),
-        band_oracle: Some("bandoracle0001".to_string()),
     };
 
     let res = execute(deps.as_mut(), mock_env(), info, msg).unwrap();
@@ -71,9 +61,6 @@ fn update_config() {
     assert_eq!("owner0001", value.owner.as_str());
     assert_eq!("mint0001", value.mint_contract.as_str());
     assert_eq!("uluna", value.base_denom.as_str());
-    assert_eq!("mirrororacle0001", value.mirror_oracle.as_str());
-    assert_eq!("anchororacle0001", value.anchor_oracle.as_str());
-    assert_eq!("bandoracle0001", value.band_oracle.as_str());
 
     // Unauthorized err
     let info = mock_info("owner0000", &[]);
@@ -81,9 +68,6 @@ fn update_config() {
         owner: None,
         mint_contract: None,
         base_denom: None,
-        mirror_oracle: None,
-        anchor_oracle: None,
-        band_oracle: None,
     };
 
     let res = execute(deps.as_mut(), mock_env(), info, msg);
@@ -105,9 +89,6 @@ fn register_collateral() {
         owner: "owner0000".to_string(),
         mint_contract: "mint0000".to_string(),
         base_denom: "uusd".to_string(),
-        mirror_oracle: "mirrororacle0000".to_string(),
-        anchor_oracle: "anchororacle0000".to_string(),
-        band_oracle: "bandoracle0000".to_string(),
     };
 
     let info = mock_info("addr0000", &[]);
@@ -118,7 +99,9 @@ fn register_collateral() {
             contract_addr: "mTSLA".to_string(),
         },
         multiplier: Decimal::percent(100),
-        price_source: SourceType::MirrorOracle {},
+        price_source: SourceType::TeFiOracle {
+            oracle_addr: "mirrorOracle0000".to_string(),
+        },
     };
 
     // unauthorized attempt
@@ -137,7 +120,7 @@ fn register_collateral() {
         query_res,
         CollateralInfoResponse {
             asset: "mTSLA".to_string(),
-            source_type: "mirror_oracle".to_string(),
+            source_type: "tefi_oracle".to_string(),
             multiplier: Decimal::percent(100),
             is_revoked: false,
         }
@@ -156,9 +139,6 @@ fn update_collateral() {
         owner: "owner0000".to_string(),
         mint_contract: "mint0000".to_string(),
         base_denom: "uusd".to_string(),
-        mirror_oracle: "mirrororacle0000".to_string(),
-        anchor_oracle: "anchororacle0000".to_string(),
-        band_oracle: "bandoracle0000".to_string(),
     };
 
     let info = mock_info("addr0000", &[]);
@@ -169,7 +149,9 @@ fn update_collateral() {
             contract_addr: "mTSLA".to_string(),
         },
         multiplier: Decimal::percent(100),
-        price_source: SourceType::MirrorOracle {},
+        price_source: SourceType::TeFiOracle {
+            oracle_addr: "mirrorOracle0000".to_string(),
+        },
     };
 
     // successfull attempt
@@ -183,7 +165,7 @@ fn update_collateral() {
         query_res,
         CollateralInfoResponse {
             asset: "mTSLA".to_string(),
-            source_type: "mirror_oracle".to_string(),
+            source_type: "tefi_oracle".to_string(),
             multiplier: Decimal::percent(100),
             is_revoked: false,
         }
@@ -280,9 +262,6 @@ fn get_oracle_price() {
         owner: "owner0000".to_string(),
         mint_contract: "mint0000".to_string(),
         base_denom: "uusd".to_string(),
-        mirror_oracle: "mirrororacle0000".to_string(),
-        anchor_oracle: "anchororacle0000".to_string(),
-        band_oracle: "bandoracle0000".to_string(),
     };
 
     let info = mock_info("addr0000", &[]);
@@ -293,13 +272,16 @@ fn get_oracle_price() {
             contract_addr: "mTSLA".to_string(),
         },
         multiplier: Decimal::percent(100),
-        price_source: SourceType::MirrorOracle {},
+        price_source: SourceType::TeFiOracle {
+            oracle_addr: "mirrorOracle0000".to_string(),
+        },
     };
 
     let info = mock_info("owner0000", &[]);
     let _res = execute(deps.as_mut(), mock_env(), info, msg).unwrap();
     // attempt to query price
-    let query_res = query_collateral_price(deps.as_ref(), "mTSLA".to_string(), None).unwrap();
+    let query_res =
+        query_collateral_price(deps.as_ref(), mock_env(), "mTSLA".to_string(), None).unwrap();
     assert_eq!(
         query_res,
         CollateralPriceResponse {
@@ -313,7 +295,7 @@ fn get_oracle_price() {
 }
 
 #[test]
-fn get_terraswap_price() {
+fn get_amm_pair_price() {
     let mut deps = mock_dependencies(&[]);
     deps.querier.with_terraswap_pools(&[
         (
@@ -340,9 +322,6 @@ fn get_terraswap_price() {
         owner: "owner0000".to_string(),
         mint_contract: "mint0000".to_string(),
         base_denom: "uusd".to_string(),
-        mirror_oracle: "mirrororacle0000".to_string(),
-        anchor_oracle: "anchororacle0000".to_string(),
-        band_oracle: "bandoracle0000".to_string(),
     };
 
     let info = mock_info("addr0000", &[]);
@@ -353,8 +332,8 @@ fn get_terraswap_price() {
             contract_addr: "anc0000".to_string(),
         },
         multiplier: Decimal::percent(100),
-        price_source: SourceType::Terraswap {
-            terraswap_pair_addr: "ustancpair0000".to_string(),
+        price_source: SourceType::AMMPair {
+            pair_addr: "ustancpair0000".to_string(),
             intermediate_denom: None,
         },
     };
@@ -363,7 +342,8 @@ fn get_terraswap_price() {
     let _res = execute(deps.as_mut(), mock_env(), info, msg).unwrap();
 
     // attempt to query price
-    let query_res = query_collateral_price(deps.as_ref(), "anc0000".to_string(), None).unwrap();
+    let query_res =
+        query_collateral_price(deps.as_ref(), mock_env(), "anc0000".to_string(), None).unwrap();
     assert_eq!(
         query_res,
         CollateralPriceResponse {
@@ -381,8 +361,8 @@ fn get_terraswap_price() {
             contract_addr: "bluna0000".to_string(),
         },
         multiplier: Decimal::percent(100),
-        price_source: SourceType::Terraswap {
-            terraswap_pair_addr: "lunablunapair0000".to_string(),
+        price_source: SourceType::AMMPair {
+            pair_addr: "lunablunapair0000".to_string(),
             intermediate_denom: Some("uluna".to_string()),
         },
     };
@@ -391,7 +371,8 @@ fn get_terraswap_price() {
     let _res = execute(deps.as_mut(), mock_env(), info, msg).unwrap();
 
     // attempt to query price
-    let query_res = query_collateral_price(deps.as_ref(), "bluna0000".to_string(), None).unwrap();
+    let query_res =
+        query_collateral_price(deps.as_ref(), mock_env(), "bluna0000".to_string(), None).unwrap();
     assert_eq!(
         query_res,
         CollateralPriceResponse {
@@ -412,9 +393,6 @@ fn get_fixed_price() {
         owner: "owner0000".to_string(),
         mint_contract: "mint0000".to_string(),
         base_denom: "uusd".to_string(),
-        mirror_oracle: "mirrororacle0000".to_string(),
-        anchor_oracle: "anchororacle0000".to_string(),
-        band_oracle: "bandoracle0000".to_string(),
     };
 
     let info = mock_info("addr0000", &[]);
@@ -434,54 +412,14 @@ fn get_fixed_price() {
     let _res = execute(deps.as_mut(), mock_env(), info, msg).unwrap();
 
     // attempt to query price
-    let query_res = query_collateral_price(deps.as_ref(), "aUST".to_string(), None).unwrap();
+    let query_res =
+        query_collateral_price(deps.as_ref(), mock_env(), "aUST".to_string(), None).unwrap();
     assert_eq!(
         query_res,
         CollateralPriceResponse {
             asset: "aUST".to_string(),
             rate: Decimal::from_ratio(1u128, 2u128),
             last_updated: u64::MAX,
-            multiplier: Decimal::percent(100),
-            is_revoked: false,
-        }
-    );
-}
-
-#[test]
-fn get_band_oracle_price() {
-    let mut deps = mock_dependencies(&[]);
-
-    let msg = InstantiateMsg {
-        owner: "owner0000".to_string(),
-        mint_contract: "mint0000".to_string(),
-        base_denom: "uusd".to_string(),
-        mirror_oracle: "mirrororacle0000".to_string(),
-        anchor_oracle: "anchororacle0000".to_string(),
-        band_oracle: "bandoracle0000".to_string(),
-    };
-
-    let info = mock_info("addr0000", &[]);
-    let _res = instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
-
-    let msg = ExecuteMsg::RegisterCollateralAsset {
-        asset: AssetInfo::NativeToken {
-            denom: "uluna".to_string(),
-        },
-        multiplier: Decimal::percent(100),
-        price_source: SourceType::BandOracle {},
-    };
-
-    let info = mock_info("owner0000", &[]);
-    let _res = execute(deps.as_mut(), mock_env(), info, msg).unwrap();
-
-    // attempt to query price
-    let query_res = query_collateral_price(deps.as_ref(), "uluna".to_string(), None).unwrap();
-    assert_eq!(
-        query_res,
-        CollateralPriceResponse {
-            asset: "uluna".to_string(),
-            rate: Decimal::from_str("3465.211050000000000000").unwrap(),
-            last_updated: 100u64,
             multiplier: Decimal::percent(100),
             is_revoked: false,
         }
@@ -496,9 +434,6 @@ fn get_anchor_market_price() {
         owner: "owner0000".to_string(),
         mint_contract: "mint0000".to_string(),
         base_denom: "uusd".to_string(),
-        mirror_oracle: "mirrororacle0000".to_string(),
-        anchor_oracle: "anchororacle0000".to_string(),
-        band_oracle: "bandoracle0000".to_string(),
     };
 
     let info = mock_info("addr0000", &[]);
@@ -518,7 +453,8 @@ fn get_anchor_market_price() {
     let _res = execute(deps.as_mut(), mock_env(), info, msg).unwrap();
 
     // attempt to query price
-    let query_res = query_collateral_price(deps.as_ref(), "aust0000".to_string(), None).unwrap();
+    let query_res =
+        query_collateral_price(deps.as_ref(), mock_env(), "aust0000".to_string(), None).unwrap();
     assert_eq!(
         query_res,
         CollateralPriceResponse {
@@ -539,9 +475,6 @@ fn get_native_price() {
         owner: "owner0000".to_string(),
         mint_contract: "mint0000".to_string(),
         base_denom: "uusd".to_string(),
-        mirror_oracle: "mirrororacle0000".to_string(),
-        anchor_oracle: "anchororacle0000".to_string(),
-        band_oracle: "bandoracle0000".to_string(),
     };
 
     let info = mock_info("addr0000", &[]);
@@ -561,7 +494,8 @@ fn get_native_price() {
     let _res = execute(deps.as_mut(), mock_env(), info, msg).unwrap();
 
     // attempt to query price
-    let query_res = query_collateral_price(deps.as_ref(), "uluna".to_string(), None).unwrap();
+    let query_res =
+        query_collateral_price(deps.as_ref(), mock_env(), "uluna".to_string(), None).unwrap();
     assert_eq!(
         query_res,
         CollateralPriceResponse {
@@ -582,9 +516,6 @@ fn revoke_collateral() {
         owner: "owner0000".to_string(),
         mint_contract: "mint0000".to_string(),
         base_denom: "uusd".to_string(),
-        mirror_oracle: "mirrororacle0000".to_string(),
-        anchor_oracle: "anchororacle0000".to_string(),
-        band_oracle: "bandoracle0000".to_string(),
     };
 
     let info = mock_info("addr0000", &[]);
@@ -604,7 +535,8 @@ fn revoke_collateral() {
     let _res = execute(deps.as_mut(), mock_env(), info, msg).unwrap();
 
     // attempt to query price
-    let query_res = query_collateral_price(deps.as_ref(), "aUST".to_string(), None).unwrap();
+    let query_res =
+        query_collateral_price(deps.as_ref(), mock_env(), "aUST".to_string(), None).unwrap();
     assert_eq!(
         query_res,
         CollateralPriceResponse {
@@ -646,7 +578,8 @@ fn revoke_collateral() {
     );
 
     // attempt to query price of revoked asset
-    let query_res = query_collateral_price(deps.as_ref(), "aUST".to_string(), None).unwrap();
+    let query_res =
+        query_collateral_price(deps.as_ref(), mock_env(), "aUST".to_string(), None).unwrap();
     assert_eq!(
         query_res,
         CollateralPriceResponse {

--- a/contracts/mirror_collector/schema/config_response.json
+++ b/contracts/mirror_collector/schema/config_response.json
@@ -32,6 +32,12 @@
     "distribution_contract": {
       "type": "string"
     },
+    "mir_ust_pair": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "mirror_token": {
       "type": "string"
     },

--- a/contracts/mirror_collector/schema/execute_msg.json
+++ b/contracts/mirror_collector/schema/execute_msg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "ExecuteMsg",
-  "anyOf": [
+  "oneOf": [
     {
       "type": "object",
       "required": [
@@ -42,6 +42,12 @@
               ]
             },
             "distribution_contract": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "mir_ust_pair": {
               "type": [
                 "string",
                 "null"

--- a/contracts/mirror_collector/schema/instantiate_msg.json
+++ b/contracts/mirror_collector/schema/instantiate_msg.json
@@ -32,6 +32,12 @@
     "distribution_contract": {
       "type": "string"
     },
+    "mir_ust_pair": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "mirror_token": {
       "type": "string"
     },

--- a/contracts/mirror_collector/schema/migrate_msg.json
+++ b/contracts/mirror_collector/schema/migrate_msg.json
@@ -1,5 +1,13 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "MigrateMsg",
-  "type": "object"
+  "type": "object",
+  "required": [
+    "mir_ust_pair"
+  ],
+  "properties": {
+    "mir_ust_pair": {
+      "type": "string"
+    }
+  }
 }

--- a/contracts/mirror_collector/schema/query_msg.json
+++ b/contracts/mirror_collector/schema/query_msg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "QueryMsg",
-  "anyOf": [
+  "oneOf": [
     {
       "type": "object",
       "required": [

--- a/contracts/mirror_collector/src/contract.rs
+++ b/contracts/mirror_collector/src/contract.rs
@@ -1,4 +1,5 @@
 use crate::errors::ContractError;
+use crate::migration::migrate_config;
 use crate::state::{read_config, store_config, Config};
 use crate::swap::{convert, luna_swap_hook};
 #[cfg(not(feature = "library"))]
@@ -22,6 +23,11 @@ pub fn instantiate(
     _info: MessageInfo,
     msg: InstantiateMsg,
 ) -> StdResult<Response> {
+    let mir_ust_pair = if let Some(mir_ust_pair) = msg.mir_ust_pair {
+        Some(deps.api.addr_canonicalize(&mir_ust_pair)?)
+    } else {
+        None
+    };
     store_config(
         deps.storage,
         &Config {
@@ -34,6 +40,7 @@ pub fn instantiate(
             anchor_market: deps.api.addr_canonicalize(&msg.anchor_market)?,
             bluna_token: deps.api.addr_canonicalize(&msg.bluna_token)?,
             bluna_swap_denom: msg.bluna_swap_denom,
+            mir_ust_pair,
         },
     )?;
 
@@ -58,6 +65,7 @@ pub fn execute(
             anchor_market,
             bluna_token,
             bluna_swap_denom,
+            mir_ust_pair,
         } => update_config(
             deps,
             info,
@@ -70,6 +78,7 @@ pub fn execute(
             anchor_market,
             bluna_token,
             bluna_swap_denom,
+            mir_ust_pair,
         ),
         ExecuteMsg::Convert { asset_token } => {
             let asset_addr = deps.api.addr_validate(&asset_token)?;
@@ -93,6 +102,7 @@ pub fn update_config(
     anchor_market: Option<String>,
     bluna_token: Option<String>,
     bluna_swap_denom: Option<String>,
+    mir_ust_pair: Option<String>,
 ) -> Result<Response<TerraMsgWrapper>, ContractError> {
     let mut config: Config = read_config(deps.storage)?;
     if config.owner != deps.api.addr_canonicalize(info.sender.as_str())? {
@@ -134,6 +144,13 @@ pub fn update_config(
     if let Some(bluna_swap_denom) = bluna_swap_denom {
         config.bluna_swap_denom = bluna_swap_denom;
     }
+
+    // this triggers switching to use astroport for MIR swaps
+    if let Some(mir_ust_pair) = mir_ust_pair {
+        config.mir_ust_pair = Some(deps.api.addr_canonicalize(&mir_ust_pair)?);
+    }
+
+    store_config(deps.storage, &config)?;
 
     Ok(Response::new().add_attributes(vec![attr("action", "update_config")]))
 }
@@ -191,12 +208,17 @@ pub fn query_config(deps: Deps) -> StdResult<ConfigResponse> {
         anchor_market: deps.api.addr_humanize(&state.anchor_market)?.to_string(),
         bluna_token: deps.api.addr_humanize(&state.bluna_token)?.to_string(),
         bluna_swap_denom: state.bluna_swap_denom,
+        mir_ust_pair: state
+            .mir_ust_pair
+            .map(|raw| deps.api.addr_humanize(&raw).unwrap().to_string()),
     };
 
     Ok(resp)
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]
-pub fn migrate(_deps: DepsMut, _env: Env, _msg: MigrateMsg) -> StdResult<Response> {
+pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> StdResult<Response> {
+    migrate_config(deps.storage)?;
+
     Ok(Response::default())
 }

--- a/contracts/mirror_collector/src/contract.rs
+++ b/contracts/mirror_collector/src/contract.rs
@@ -5,8 +5,8 @@ use crate::swap::{convert, luna_swap_hook};
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
-    attr, to_binary, Binary, CosmosMsg, Deps, DepsMut, Env, MessageInfo, Response, StdResult,
-    WasmMsg,
+    attr, to_binary, Binary, CanonicalAddr, CosmosMsg, Deps, DepsMut, Env, MessageInfo, Response,
+    StdResult, WasmMsg,
 };
 use cw20::Cw20ExecuteMsg;
 use mirror_protocol::collector::{
@@ -217,8 +217,15 @@ pub fn query_config(deps: Deps) -> StdResult<ConfigResponse> {
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]
-pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> StdResult<Response> {
+pub fn migrate(deps: DepsMut, _env: Env, msg: MigrateMsg) -> StdResult<Response> {
     migrate_config(deps.storage)?;
+
+    let mut config = read_config(deps.storage)?;
+
+    let mir_ust_pair_raw: CanonicalAddr = deps.api.addr_canonicalize(&msg.mir_ust_pair)?;
+    config.mir_ust_pair = Some(mir_ust_pair_raw);
+
+    store_config(deps.storage, &config)?;
 
     Ok(Response::default())
 }

--- a/contracts/mirror_collector/src/lib.rs
+++ b/contracts/mirror_collector/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod contract;
 mod errors;
+mod migration;
 pub mod state;
 mod swap;
 

--- a/contracts/mirror_collector/src/migration.rs
+++ b/contracts/mirror_collector/src/migration.rs
@@ -1,0 +1,89 @@
+use cosmwasm_std::{CanonicalAddr, StdResult, Storage};
+use cosmwasm_storage::{singleton, singleton_read, ReadonlySingleton, Singleton};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::state::{Config, KEY_CONFIG};
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct LegacyConfig {
+    pub owner: CanonicalAddr,
+    pub distribution_contract: CanonicalAddr,
+    pub terraswap_factory: CanonicalAddr,
+    pub mirror_token: CanonicalAddr,
+    pub base_denom: String,
+    pub aust_token: CanonicalAddr,
+    pub anchor_market: CanonicalAddr,
+    pub bluna_token: CanonicalAddr,
+    pub bluna_swap_denom: String,
+}
+
+pub fn migrate_config(storage: &mut dyn Storage) -> StdResult<()> {
+    let legacty_store: ReadonlySingleton<LegacyConfig> = singleton_read(storage, KEY_CONFIG);
+    let legacy_config: LegacyConfig = legacty_store.load()?;
+    let config = Config {
+        owner: legacy_config.owner,
+        distribution_contract: legacy_config.distribution_contract,
+        terraswap_factory: legacy_config.terraswap_factory,
+        mirror_token: legacy_config.mirror_token,
+        base_denom: legacy_config.base_denom,
+        aust_token: legacy_config.aust_token,
+        anchor_market: legacy_config.anchor_market,
+        bluna_token: legacy_config.bluna_token,
+        bluna_swap_denom: legacy_config.bluna_swap_denom,
+        mir_ust_pair: None,
+    };
+    let mut store: Singleton<Config> = singleton(storage, KEY_CONFIG);
+    store.save(&config)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod migrate_tests {
+    use crate::state::read_config;
+
+    use super::*;
+    use cosmwasm_std::{testing::mock_dependencies, Api};
+
+    pub fn config_old_store(storage: &mut dyn Storage) -> Singleton<LegacyConfig> {
+        Singleton::new(storage, KEY_CONFIG)
+    }
+
+    #[test]
+    fn test_config_migration() {
+        let mut deps = mock_dependencies(&[]);
+        let mut legacy_config_store = config_old_store(&mut deps.storage);
+        legacy_config_store
+            .save(&LegacyConfig {
+                owner: deps.api.addr_canonicalize("owner0000").unwrap(),
+                terraswap_factory: deps.api.addr_canonicalize("terraswapfactory").unwrap(),
+                distribution_contract: deps.api.addr_canonicalize("gov0000").unwrap(),
+                mirror_token: deps.api.addr_canonicalize("mirror0000").unwrap(),
+                base_denom: "uusd".to_string(),
+                aust_token: deps.api.addr_canonicalize("aust0000").unwrap(),
+                anchor_market: deps.api.addr_canonicalize("anchormarket0000").unwrap(),
+                bluna_token: deps.api.addr_canonicalize("bluna0000").unwrap(),
+                bluna_swap_denom: "uluna".to_string(),
+            })
+            .unwrap();
+
+        migrate_config(&mut deps.storage).unwrap();
+
+        let config: Config = read_config(&deps.storage).unwrap();
+        assert_eq!(
+            config,
+            Config {
+                owner: deps.api.addr_canonicalize("owner0000").unwrap(),
+                terraswap_factory: deps.api.addr_canonicalize("terraswapfactory").unwrap(),
+                distribution_contract: deps.api.addr_canonicalize("gov0000").unwrap(),
+                mirror_token: deps.api.addr_canonicalize("mirror0000").unwrap(),
+                base_denom: "uusd".to_string(),
+                aust_token: deps.api.addr_canonicalize("aust0000").unwrap(),
+                anchor_market: deps.api.addr_canonicalize("anchormarket0000").unwrap(),
+                bluna_token: deps.api.addr_canonicalize("bluna0000").unwrap(),
+                bluna_swap_denom: "uluna".to_string(),
+                mir_ust_pair: None,
+            }
+        )
+    }
+}

--- a/contracts/mirror_collector/src/migration.rs
+++ b/contracts/mirror_collector/src/migration.rs
@@ -19,8 +19,8 @@ pub struct LegacyConfig {
 }
 
 pub fn migrate_config(storage: &mut dyn Storage) -> StdResult<()> {
-    let legacty_store: ReadonlySingleton<LegacyConfig> = singleton_read(storage, KEY_CONFIG);
-    let legacy_config: LegacyConfig = legacty_store.load()?;
+    let legacy_store: ReadonlySingleton<LegacyConfig> = singleton_read(storage, KEY_CONFIG);
+    let legacy_config: LegacyConfig = legacy_store.load()?;
     let config = Config {
         owner: legacy_config.owner,
         distribution_contract: legacy_config.distribution_contract,

--- a/contracts/mirror_collector/src/state.rs
+++ b/contracts/mirror_collector/src/state.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use cosmwasm_std::{CanonicalAddr, StdResult, Storage};
 use cosmwasm_storage::{singleton, singleton_read};
 
-static KEY_CONFIG: &[u8] = b"config";
+pub static KEY_CONFIG: &[u8] = b"config";
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct Config {
@@ -19,6 +19,8 @@ pub struct Config {
     // bLuna params
     pub bluna_token: CanonicalAddr,
     pub bluna_swap_denom: String,
+    // when set, use this address instead of querying from terraswap
+    pub mir_ust_pair: Option<CanonicalAddr>,
 }
 
 pub fn store_config(storage: &mut dyn Storage, config: &Config) -> StdResult<()> {

--- a/contracts/mirror_factory/Cargo.toml
+++ b/contracts/mirror_factory/Cargo.toml
@@ -38,6 +38,7 @@ cw20 = { version = "0.8.0" }
 cosmwasm-std = { version = "0.16.0", features = ["iterator"] }
 cosmwasm-storage = { version = "0.16.0", features = ["iterator"] }
 mirror-protocol = { version = "2.1.1", path = "../../packages/mirror_protocol" }
+tefi-oracle = { version = "0.1.0", path = "../../packages/tefi_oracle" }
 protobuf = { version = "2", features = ["with-bytes"] }
 terraswap = "2.4.0"
 schemars = "0.8.1"

--- a/contracts/mirror_factory/schema/execute_msg.json
+++ b/contracts/mirror_factory/schema/execute_msg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "ExecuteMsg",
-  "anyOf": [
+  "oneOf": [
     {
       "description": "Owner Operations",
       "type": "object",
@@ -137,7 +137,7 @@
           "type": "object",
           "required": [
             "name",
-            "oracle_feeder",
+            "oracle_proxy",
             "params",
             "symbol"
           ],
@@ -146,8 +146,8 @@
               "description": "asset name used to create token contract",
               "type": "string"
             },
-            "oracle_feeder": {
-              "description": "authorized asset oracle feeder",
+            "oracle_proxy": {
+              "description": "oracle proxy that will provide prices for this asset",
               "type": "string"
             },
             "params": {
@@ -192,7 +192,7 @@
       "additionalProperties": false
     },
     {
-      "description": "Feeder Operations ////////////////// Revoke asset from MIR rewards pool and register end_price to mint contract Only feeder can set end_price",
+      "description": "Revoke asset from MIR rewards pool and register end_price to mint contract",
       "type": "object",
       "required": [
         "revoke_asset"
@@ -206,16 +206,6 @@
           "properties": {
             "asset_token": {
               "type": "string"
-            },
-            "end_price": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/Decimal"
-                },
-                {
-                  "type": "null"
-                }
-              ]
             }
           }
         }
@@ -232,19 +222,19 @@
         "migrate_asset": {
           "type": "object",
           "required": [
-            "end_price",
             "from_token",
             "name",
+            "oracle_proxy",
             "symbol"
           ],
           "properties": {
-            "end_price": {
-              "$ref": "#/definitions/Decimal"
-            },
             "from_token": {
               "type": "string"
             },
             "name": {
+              "type": "string"
+            },
+            "oracle_proxy": {
               "type": "string"
             },
             "symbol": {
@@ -291,6 +281,13 @@
             {
               "$ref": "#/definitions/Decimal"
             }
+          ]
+        },
+        "ipo_trigger_addr": {
+          "description": "For pre-IPO assets, address authorized to trigger the ipo event",
+          "type": [
+            "string",
+            "null"
           ]
         },
         "min_collateral_ratio": {

--- a/contracts/mirror_factory/schema/query_msg.json
+++ b/contracts/mirror_factory/schema/query_msg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "QueryMsg",
-  "anyOf": [
+  "oneOf": [
     {
       "type": "object",
       "required": [

--- a/contracts/mirror_factory/src/contract.rs
+++ b/contracts/mirror_factory/src/contract.rs
@@ -6,7 +6,7 @@ use cosmwasm_std::{
     Env, MessageInfo, Reply, ReplyOn, Response, StdError, StdResult, SubMsg, Uint128, WasmMsg,
 };
 
-use crate::querier::{load_mint_asset_config, load_oracle_feeder, query_last_price};
+use crate::querier::{load_mint_asset_config, query_last_price};
 use crate::response::MsgInstantiateContractResponse;
 use crate::state::{
     decrease_total_weight, increase_total_weight, read_all_weight, read_config,
@@ -20,9 +20,9 @@ use mirror_protocol::factory::{
     QueryMsg,
 };
 use mirror_protocol::mint::{ExecuteMsg as MintExecuteMsg, IPOParams};
-use mirror_protocol::oracle::ExecuteMsg as OracleExecuteMsg;
 use mirror_protocol::staking::Cw20HookMsg as StakingCw20HookMsg;
 use mirror_protocol::staking::ExecuteMsg as StakingExecuteMsg;
+use tefi_oracle::hub::HubExecuteMsg as TeFiOracleExecuteMsg;
 
 use protobuf::Message;
 
@@ -100,23 +100,20 @@ pub fn execute(deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg) -> S
         ExecuteMsg::Whitelist {
             name,
             symbol,
-            oracle_feeder,
+            oracle_proxy,
             params,
-        } => whitelist(deps, info, name, symbol, oracle_feeder, params),
+        } => whitelist(deps, info, name, symbol, oracle_proxy, params),
         ExecuteMsg::Distribute {} => distribute(deps, env),
         ExecuteMsg::PassCommand { contract_addr, msg } => {
             pass_command(deps, info, contract_addr, msg)
         }
-        ExecuteMsg::RevokeAsset {
-            asset_token,
-            end_price,
-        } => revoke_asset(deps, info, asset_token, end_price),
+        ExecuteMsg::RevokeAsset { asset_token } => revoke_asset(deps, info, asset_token),
         ExecuteMsg::MigrateAsset {
             name,
             symbol,
             from_token,
-            end_price,
-        } => migrate_asset(deps, info, name, symbol, from_token, end_price),
+            oracle_proxy,
+        } => migrate_asset(deps, info, name, symbol, from_token, oracle_proxy),
     }
 }
 
@@ -237,7 +234,7 @@ pub fn pass_command(
 /// 2. Call `TokenCreationHook`
 ///    2-1. Initialize distribution info
 ///    2-2. Register asset to mint contract
-///    2-3. Register asset and oracle feeder to oracle contract
+///    2-3. Register asset and oracle proxy to oracle contract
 ///    2-4. Create terraswap pair through terraswap factory
 /// 3. Call `TerraswapCreationHook`
 ///    3-1. Register asset to staking contract
@@ -246,7 +243,7 @@ pub fn whitelist(
     info: MessageInfo,
     name: String,
     symbol: String,
-    oracle_feeder: String,
+    oracle_proxy: String,
     params: Params,
 ) -> StdResult<Response> {
     let config: Config = read_config(deps.storage)?;
@@ -261,7 +258,7 @@ pub fn whitelist(
     store_params(deps.storage, &params)?;
 
     // store oracle in temp storage to use in reply callback
-    let oracle = deps.api.addr_validate(&oracle_feeder)?;
+    let oracle = deps.api.addr_validate(&oracle_proxy)?;
     store_tmp_oracle(deps.storage, &oracle)?;
 
     Ok(Response::new()
@@ -299,8 +296,8 @@ pub fn whitelist(
 pub fn reply(deps: DepsMut, env: Env, msg: Reply) -> StdResult<Response> {
     match msg.id {
         1 => {
-            // fetch saved oracle_feeder from temp state
-            let oracle_feeder = read_tmp_oracle(deps.storage)?;
+            // fetch saved oracle_proxy from temp state
+            let oracle_proxy = read_tmp_oracle(deps.storage)?;
 
             // get new token's contract address
             let res: MsgInstantiateContractResponse = Message::parse_from_bytes(
@@ -311,7 +308,7 @@ pub fn reply(deps: DepsMut, env: Env, msg: Reply) -> StdResult<Response> {
             })?;
             let asset_token = Addr::unchecked(res.get_contract_address());
 
-            token_creation_hook(deps, env, asset_token, oracle_feeder)
+            token_creation_hook(deps, env, asset_token, oracle_proxy)
         }
         2 => {
             // fetch saved asset_token from temp state
@@ -326,13 +323,13 @@ pub fn reply(deps: DepsMut, env: Env, msg: Reply) -> StdResult<Response> {
 /// TokenCreationHook
 /// 1. Initialize distribution info
 /// 2. Register asset to mint contract
-/// 3. Register asset and oracle feeder to oracle contract
+/// 3. Register asset and oracle proxy to oracle hub contract
 /// 4. Create terraswap pair through terraswap factory with `TerraswapCreationHook`
 pub fn token_creation_hook(
     deps: DepsMut,
     env: Env,
     asset_token: Addr,
-    oracle_feeder: Addr,
+    oracle_proxy: Addr,
 ) -> StdResult<Response> {
     let config: Config = read_config(deps.storage)?;
 
@@ -361,31 +358,38 @@ pub fn token_creation_hook(
     let mut attributes: Vec<Attribute> = vec![];
 
     // Check if all IPO params exist
-    let ipo_params: Option<IPOParams> =
-        if let (Some(mint_period), Some(min_collateral_ratio_after_ipo), Some(pre_ipo_price)) = (
-            params.mint_period,
-            params.min_collateral_ratio_after_ipo,
-            params.pre_ipo_price,
-        ) {
-            let mint_end: u64 = env.block.time.plus_seconds(mint_period).seconds();
-            attributes = vec![
-                attr("is_pre_ipo", "true"),
-                attr("mint_end", mint_end.to_string()),
-                attr(
-                    "min_collateral_ratio_after_ipo",
-                    min_collateral_ratio_after_ipo.to_string(),
-                ),
-                attr("pre_ipo_price", pre_ipo_price.to_string()),
-            ];
-            Some(IPOParams {
-                mint_end,
-                pre_ipo_price,
-                min_collateral_ratio_after_ipo,
-            })
-        } else {
-            attributes.push(attr("is_pre_ipo", "false"));
-            None
-        };
+    let ipo_params: Option<IPOParams> = if let (
+        Some(mint_period),
+        Some(min_collateral_ratio_after_ipo),
+        Some(pre_ipo_price),
+        Some(trigger_addr),
+    ) = (
+        params.mint_period,
+        params.min_collateral_ratio_after_ipo,
+        params.pre_ipo_price,
+        params.ipo_trigger_addr,
+    ) {
+        let mint_end: u64 = env.block.time.plus_seconds(mint_period).seconds();
+        attributes = vec![
+            attr("is_pre_ipo", "true"),
+            attr("mint_end", mint_end.to_string()),
+            attr(
+                "min_collateral_ratio_after_ipo",
+                min_collateral_ratio_after_ipo.to_string(),
+            ),
+            attr("pre_ipo_price", pre_ipo_price.to_string()),
+            attr("ipo_trigger_addr", trigger_addr.to_string()),
+        ];
+        Some(IPOParams {
+            mint_end,
+            pre_ipo_price,
+            min_collateral_ratio_after_ipo,
+            trigger_addr,
+        })
+    } else {
+        attributes.push(attr("is_pre_ipo", "false"));
+        None
+    };
 
     // store asset_token in temp storage to use in reply callback
     store_tmp_asset(deps.storage, &asset_token)?;
@@ -408,9 +412,10 @@ pub fn token_creation_hook(
             CosmosMsg::Wasm(WasmMsg::Execute {
                 contract_addr: deps.api.addr_humanize(&config.oracle_contract)?.to_string(),
                 funds: vec![],
-                msg: to_binary(&OracleExecuteMsg::RegisterAsset {
+                msg: to_binary(&TeFiOracleExecuteMsg::RegisterProxy {
                     asset_token: asset_token.to_string(),
-                    feeder: oracle_feeder.to_string(),
+                    proxy_addr: oracle_proxy.to_string(),
+                    priority: None, // default priority
                 })?,
             }),
         ])
@@ -543,7 +548,7 @@ pub fn distribute(deps: DepsMut, env: Env) -> StdResult<Response> {
     // store last distributed
     store_last_distributed(deps.storage, env.block.time.seconds())?;
 
-    // mint token to self and try send minted tokens to staking contract
+    // send token rewards to staking contract
     const SPLIT_UNIT: usize = 10;
     Ok(Response::new()
         .add_messages(
@@ -570,52 +575,25 @@ pub fn distribute(deps: DepsMut, env: Env) -> StdResult<Response> {
         ]))
 }
 
-pub fn revoke_asset(
-    deps: DepsMut,
-    info: MessageInfo,
-    asset_token: String,
-    end_price: Option<Decimal>,
-) -> StdResult<Response> {
+pub fn revoke_asset(deps: DepsMut, info: MessageInfo, asset_token: String) -> StdResult<Response> {
     let config: Config = read_config(deps.storage)?;
     let asset_token_raw: CanonicalAddr = deps.api.addr_canonicalize(&asset_token)?;
     let sender_raw: CanonicalAddr = deps.api.addr_canonicalize(info.sender.as_str())?;
     let mint: Addr = deps.api.addr_humanize(&config.mint_contract)?;
     let oracle: Addr = deps.api.addr_humanize(&config.oracle_contract)?;
 
-    let end_price: Decimal = match end_price {
-        Some(value) => {
-            // only feeder can revoke_asset with end_price
-            let oracle_feeder: Addr = deps.api.addr_humanize(&load_oracle_feeder(
-                &deps.querier,
-                deps.api.addr_humanize(&config.oracle_contract)?,
-                &asset_token_raw,
-            )?)?;
-            if oracle_feeder != info.sender {
-                return Err(StdError::generic_err("unauthorized"));
-            }
+    // only owner can revoke asset
+    if config.owner != sender_raw {
+        return Err(StdError::generic_err("unauthorized"));
+    }
 
-            value
-        }
-        None => {
-            // revoke asset without end_price can be called by owner
-            if config.owner != sender_raw {
-                return Err(StdError::generic_err("unauthorized"));
-            }
+    // check if the asset has a preIPO price
+    let (_, _, pre_ipo_price) = load_mint_asset_config(&deps.querier, mint, &asset_token_raw)?;
 
-            // check if the asset has a preIPO price
-            let (_, _, pre_ipo_price) =
-                load_mint_asset_config(&deps.querier, mint, &asset_token_raw)?;
-            pre_ipo_price.unwrap_or(
-                // if there is no pre_ipo_price, fetch last reported price from oracle
-                query_last_price(
-                    &deps.querier,
-                    oracle,
-                    asset_token.to_string(),
-                    config.base_denom,
-                )?,
-            )
-        }
-    };
+    let end_price: Decimal = pre_ipo_price.unwrap_or(
+        // if there is no pre_ipo_price, fetch last reported price from oracle
+        query_last_price(&deps.querier, oracle, asset_token.to_string())?,
+    );
 
     let weight = read_weight(deps.storage, &asset_token_raw)?;
     remove_weight(deps.storage, &asset_token_raw);
@@ -643,19 +621,27 @@ pub fn migrate_asset(
     name: String,
     symbol: String,
     asset_token: String,
-    end_price: Decimal,
+    oracle_proxy: String,
 ) -> StdResult<Response> {
     let config: Config = read_config(deps.storage)?;
     let asset_token_raw: CanonicalAddr = deps.api.addr_canonicalize(&asset_token)?;
-    let oracle_feeder: Addr = deps.api.addr_humanize(&load_oracle_feeder(
-        &deps.querier,
-        deps.api.addr_humanize(&config.oracle_contract)?,
-        &asset_token_raw,
-    )?)?;
+    let sender_raw: CanonicalAddr = deps.api.addr_canonicalize(info.sender.as_str())?;
+    let oracle_proxy_addr: Addr = deps.api.addr_validate(&oracle_proxy)?;
+    let mint: Addr = deps.api.addr_humanize(&config.mint_contract)?;
+    let oracle: Addr = deps.api.addr_humanize(&config.oracle_contract)?;
 
-    if oracle_feeder != info.sender {
+    if sender_raw != config.owner {
         return Err(StdError::generic_err("unauthorized"));
     }
+
+    // check if the asset has a preIPO price
+    let (_, _, pre_ipo_price) = load_mint_asset_config(&deps.querier, mint, &asset_token_raw)?;
+
+    if pre_ipo_price.is_some() {
+        return Err(StdError::generic_err("Can not migrate a preIPO asset"));
+    }
+
+    let end_price = query_last_price(&deps.querier, oracle, asset_token.to_string())?;
 
     let weight = read_weight(deps.storage, &asset_token_raw)?;
     remove_weight(deps.storage, &asset_token_raw);
@@ -674,11 +660,12 @@ pub fn migrate_asset(
             mint_period: None,
             min_collateral_ratio_after_ipo: None,
             pre_ipo_price: None,
+            ipo_trigger_addr: None,
         },
     )?;
 
     // store oracle in temp storage to use in reply callback
-    store_tmp_oracle(deps.storage, &oracle_feeder)?;
+    store_tmp_oracle(deps.storage, &oracle_proxy_addr)?;
 
     Ok(Response::new()
         .add_message(CosmosMsg::Wasm(WasmMsg::Execute {

--- a/contracts/mirror_factory/src/querier.rs
+++ b/contracts/mirror_factory/src/querier.rs
@@ -5,44 +5,20 @@ use cosmwasm_std::{
 
 use cosmwasm_storage::to_length_prefixed;
 use mirror_protocol::mint::IPOParams;
-use mirror_protocol::oracle::{PriceResponse, QueryMsg as OracleQueryMsg};
 use serde::{Deserialize, Serialize};
-
-pub fn load_oracle_feeder(
-    querier: &QuerierWrapper,
-    contract_addr: Addr,
-    asset_token: &CanonicalAddr,
-) -> StdResult<CanonicalAddr> {
-    let res: StdResult<CanonicalAddr> = querier.query(&QueryRequest::Wasm(WasmQuery::Raw {
-        contract_addr: contract_addr.to_string(),
-        key: Binary::from(concat(
-            &to_length_prefixed(b"feeder"),
-            asset_token.as_slice(),
-        )),
-    }));
-
-    let feeder: CanonicalAddr = match res {
-        Ok(v) => v,
-        Err(_) => {
-            return Err(StdError::generic_err("Failed to fetch the oracle feeder"));
-        }
-    };
-
-    Ok(feeder)
-}
+use tefi_oracle::hub::{HubQueryMsg as OracleQueryMsg, PriceResponse};
 
 /// Query asset price igonoring price age
 pub fn query_last_price(
     querier: &QuerierWrapper,
     oracle: Addr,
-    base_asset: String,
-    quote_asset: String,
+    asset: String,
 ) -> StdResult<Decimal> {
     let res: PriceResponse = querier.query(&QueryRequest::Wasm(WasmQuery::Smart {
         contract_addr: oracle.to_string(),
         msg: to_binary(&OracleQueryMsg::Price {
-            base_asset,
-            quote_asset,
+            asset_token: asset,
+            timeframe: None,
         })?,
     }))?;
 

--- a/contracts/mirror_factory/src/state.rs
+++ b/contracts/mirror_factory/src/state.rs
@@ -10,7 +10,7 @@ static KEY_CONFIG: &[u8] = b"config";
 static KEY_PARAMS: &[u8] = b"params";
 static KEY_TOTAL_WEIGHT: &[u8] = b"total_weight";
 static KEY_LAST_DISTRIBUTED: &[u8] = b"last_distributed";
-static KEY_TMP_ORACLE: &[u8] = b"tmp_oracle_feeder";
+static KEY_TMP_ORACLE: &[u8] = b"tmp_oracle_proxy";
 static KEY_TMP_ASSET: &[u8] = b"tmp_asset_token";
 
 static PREFIX_WEIGHT: &[u8] = b"weight";

--- a/contracts/mirror_factory/src/testing/mock_querier.rs
+++ b/contracts/mirror_factory/src/testing/mock_querier.rs
@@ -8,10 +8,9 @@ use cosmwasm_std::{
 };
 use cosmwasm_storage::to_length_prefixed;
 
-use crate::math::decimal_division;
 use crate::querier::MintAssetConfig;
-use mirror_protocol::oracle::PriceResponse;
 use std::collections::HashMap;
+use tefi_oracle::hub::PriceResponse;
 use terraswap::asset::{AssetInfo, PairInfo};
 
 /// mock_dependencies is a drop-in replacement for cosmwasm_std::testing::mock_dependencies
@@ -32,7 +31,6 @@ pub fn mock_dependencies(
 pub struct WasmMockQuerier {
     base: MockQuerier<Empty>,
     terraswap_factory_querier: TerraswapFactoryQuerier,
-    oracle_querier: OracleQuerier,
     oracle_price_querier: OraclePriceQuerier,
     mint_querier: MintQuerier,
 }
@@ -84,27 +82,6 @@ pub(crate) fn oracle_price_to_map(
 }
 
 #[derive(Clone, Default)]
-pub struct OracleQuerier {
-    feeders: HashMap<String, String>,
-}
-
-impl OracleQuerier {
-    pub fn new(feeders: &[(&String, &String)]) -> Self {
-        OracleQuerier {
-            feeders: address_pair_to_map(feeders),
-        }
-    }
-}
-
-pub(crate) fn address_pair_to_map(address_pair: &[(&String, &String)]) -> HashMap<String, String> {
-    let mut address_pair_map: HashMap<String, String> = HashMap::new();
-    for (addr1, addr2) in address_pair.iter() {
-        address_pair_map.insert(addr1.to_string(), addr2.to_string());
-    }
-    address_pair_map
-}
-
-#[derive(Clone, Default)]
 pub struct MintQuerier {
     configs: HashMap<String, (Decimal, Decimal)>,
 }
@@ -150,8 +127,8 @@ pub enum QueryMsg {
         asset_infos: [AssetInfo; 2],
     },
     Price {
-        base_asset: String,
-        quote_asset: String,
+        asset_token: String,
+        timeframe: Option<u64>,
     },
 }
 
@@ -184,23 +161,14 @@ impl WasmMockQuerier {
                     }
                 }
                 QueryMsg::Price {
-                    base_asset,
-                    quote_asset,
-                } => match self.oracle_price_querier.oracle_price.get(&base_asset) {
+                    asset_token,
+                    timeframe: _,
+                } => match self.oracle_price_querier.oracle_price.get(&asset_token) {
                     Some(base_price) => {
-                        match self.oracle_price_querier.oracle_price.get(&quote_asset) {
-                            Some(quote_price) => {
-                                SystemResult::Ok(ContractResult::from(to_binary(&PriceResponse {
-                                    rate: decimal_division(*base_price, *quote_price),
-                                    last_updated_base: 1000u64,
-                                    last_updated_quote: 1000u64,
-                                })))
-                            }
-                            None => SystemResult::Err(SystemError::InvalidRequest {
-                                error: "No oracle price exists".to_string(),
-                                request: msg.as_slice().into(),
-                            }),
-                        }
+                        SystemResult::Ok(ContractResult::from(to_binary(&PriceResponse {
+                            rate: *base_price,
+                            last_updated: 1000u64,
+                        })))
                     }
                     None => SystemResult::Err(SystemError::InvalidRequest {
                         error: "No oracle price exists".to_string(),
@@ -208,44 +176,15 @@ impl WasmMockQuerier {
                     }),
                 },
             },
-            QueryRequest::Wasm(WasmQuery::Raw { contract_addr, key }) => {
+            QueryRequest::Wasm(WasmQuery::Raw {
+                contract_addr: _,
+                key,
+            }) => {
                 let key: &[u8] = key.as_slice();
                 let prefix_asset_config = to_length_prefixed(b"asset_config").to_vec();
-                let prefix_feeder = to_length_prefixed(b"feeder").to_vec();
 
                 let api: MockApi = MockApi::default();
-                if key.len() > prefix_feeder.len()
-                    && key[..prefix_feeder.len()].to_vec() == prefix_feeder
-                {
-                    let api: MockApi = MockApi::default();
-                    let rest_key: &[u8] = &key[prefix_feeder.len()..];
-
-                    if contract_addr == "oracle0000" {
-                        let asset_token: String = api
-                            .addr_humanize(&(CanonicalAddr::from(rest_key.to_vec())))
-                            .unwrap()
-                            .to_string();
-
-                        let feeder = match self.oracle_querier.feeders.get(&asset_token) {
-                            Some(v) => v,
-                            None => {
-                                return SystemResult::Err(SystemError::InvalidRequest {
-                                    error: format!(
-                                        "Oracle Feeder is not found for {}",
-                                        asset_token
-                                    ),
-                                    request: key.into(),
-                                })
-                            }
-                        };
-
-                        SystemResult::Ok(ContractResult::from(to_binary(
-                            &api.addr_canonicalize(feeder).unwrap(),
-                        )))
-                    } else {
-                        panic!("DO NOT ENTER HERE")
-                    }
-                } else if key.len() > prefix_asset_config.len()
+                if key.len() > prefix_asset_config.len()
                     && key[..prefix_asset_config.len()].to_vec() == prefix_asset_config
                 {
                     let rest_key: &[u8] = &key[prefix_asset_config.len()..];
@@ -285,7 +224,6 @@ impl WasmMockQuerier {
             base,
             terraswap_factory_querier: TerraswapFactoryQuerier::default(),
             mint_querier: MintQuerier::default(),
-            oracle_querier: OracleQuerier::default(),
             oracle_price_querier: OraclePriceQuerier::default(),
         }
     }
@@ -293,10 +231,6 @@ impl WasmMockQuerier {
     // configure the terraswap pair
     pub fn with_terraswap_pairs(&mut self, pairs: &[(&String, &String)]) {
         self.terraswap_factory_querier = TerraswapFactoryQuerier::new(pairs);
-    }
-
-    pub fn with_oracle_feeders(&mut self, feeders: &[(&String, &String)]) {
-        self.oracle_querier = OracleQuerier::new(feeders);
     }
 
     pub fn with_mint_configs(&mut self, configs: &[(&String, &(Decimal, Decimal))]) {

--- a/contracts/mirror_factory/src/testing/tests.rs
+++ b/contracts/mirror_factory/src/testing/tests.rs
@@ -18,9 +18,9 @@ use mirror_protocol::factory::{
     ConfigResponse, DistributionInfoResponse, ExecuteMsg, InstantiateMsg, Params, QueryMsg,
 };
 use mirror_protocol::mint::{ExecuteMsg as MintExecuteMsg, IPOParams};
-use mirror_protocol::oracle::ExecuteMsg as OracleExecuteMsg;
 use mirror_protocol::staking::Cw20HookMsg as StakingCw20HookMsg;
 use mirror_protocol::staking::ExecuteMsg as StakingExecuteMsg;
+use tefi_oracle::hub::HubExecuteMsg as TeFiOracleExecuteMsg;
 
 use protobuf::Message;
 
@@ -294,7 +294,7 @@ fn test_whitelist() {
     let msg = ExecuteMsg::Whitelist {
         name: "apple derivative".to_string(),
         symbol: "mAPPL".to_string(),
-        oracle_feeder: "feeder0000".to_string(),
+        oracle_proxy: "oracleproxy0000".to_string(),
         params: Params {
             auction_discount: Decimal::percent(5),
             min_collateral_ratio: Decimal::percent(150),
@@ -302,6 +302,7 @@ fn test_whitelist() {
             mint_period: None,
             min_collateral_ratio_after_ipo: None,
             pre_ipo_price: None,
+            ipo_trigger_addr: None,
         },
     };
     let info = mock_info("owner0000", &[]);
@@ -354,6 +355,7 @@ fn test_whitelist() {
             mint_period: None,
             min_collateral_ratio_after_ipo: None,
             pre_ipo_price: None,
+            ipo_trigger_addr: None,
         }
     );
 
@@ -372,7 +374,7 @@ fn test_whitelist() {
 
     //ensure temp oracle was stored
     let tmp_oracle = read_tmp_oracle(&deps.storage).unwrap();
-    assert_eq!(tmp_oracle.to_string(), "feeder0000");
+    assert_eq!(tmp_oracle.to_string(), "oracleproxy0000");
 }
 
 #[test]
@@ -404,7 +406,7 @@ fn test_token_creation_hook() {
     let msg = ExecuteMsg::Whitelist {
         name: "apple derivative".to_string(),
         symbol: "mAPPL".to_string(),
-        oracle_feeder: "feeder0000".to_string(),
+        oracle_proxy: "oracleproxy0000".to_string(),
         params: Params {
             auction_discount: Decimal::percent(5),
             min_collateral_ratio: Decimal::percent(150),
@@ -412,6 +414,7 @@ fn test_token_creation_hook() {
             mint_period: None,
             min_collateral_ratio_after_ipo: None,
             pre_ipo_price: None,
+            ipo_trigger_addr: None,
         },
     };
     let info = mock_info("owner0000", &[]);
@@ -419,7 +422,7 @@ fn test_token_creation_hook() {
 
     //ensure temp oracle was stored
     let tmp_oracle = read_tmp_oracle(&deps.storage).unwrap();
-    assert_eq!(tmp_oracle.to_string(), "feeder0000");
+    assert_eq!(tmp_oracle.to_string(), "oracleproxy0000");
 
     let mut token_inst_res = MsgInstantiateContractResponse::new();
     token_inst_res.set_contract_address("asset0000".to_string());
@@ -455,9 +458,10 @@ fn test_token_creation_hook() {
             SubMsg::new(CosmosMsg::Wasm(WasmMsg::Execute {
                 contract_addr: "oracle0000".to_string(),
                 funds: vec![],
-                msg: to_binary(&OracleExecuteMsg::RegisterAsset {
+                msg: to_binary(&TeFiOracleExecuteMsg::RegisterProxy {
                     asset_token: "asset0000".to_string(),
-                    feeder: "feeder0000".to_string(),
+                    proxy_addr: "oracleproxy0000".to_string(),
+                    priority: None,
                 })
                 .unwrap(),
             })),
@@ -536,7 +540,7 @@ fn test_token_creation_hook_without_weight() {
     let msg = ExecuteMsg::Whitelist {
         name: "apple derivative".to_string(),
         symbol: "mAPPL".to_string(),
-        oracle_feeder: "feeder0000".to_string(),
+        oracle_proxy: "oracleproxy0000".to_string(),
         params: Params {
             auction_discount: Decimal::percent(5),
             min_collateral_ratio: Decimal::percent(150),
@@ -544,6 +548,7 @@ fn test_token_creation_hook_without_weight() {
             mint_period: None,
             min_collateral_ratio_after_ipo: None,
             pre_ipo_price: None,
+            ipo_trigger_addr: None,
         },
     };
     let info = mock_info("owner0000", &[]);
@@ -551,7 +556,7 @@ fn test_token_creation_hook_without_weight() {
 
     //ensure temp oracle was stored
     let tmp_oracle = read_tmp_oracle(&deps.storage).unwrap();
-    assert_eq!(tmp_oracle.to_string(), "feeder0000");
+    assert_eq!(tmp_oracle.to_string(), "oracleproxy0000");
 
     let mut token_inst_res = MsgInstantiateContractResponse::new();
     token_inst_res.set_contract_address("asset0000".to_string());
@@ -587,9 +592,10 @@ fn test_token_creation_hook_without_weight() {
             SubMsg::new(CosmosMsg::Wasm(WasmMsg::Execute {
                 contract_addr: "oracle0000".to_string(),
                 funds: vec![],
-                msg: to_binary(&OracleExecuteMsg::RegisterAsset {
+                msg: to_binary(&TeFiOracleExecuteMsg::RegisterProxy {
                     asset_token: "asset0000".to_string(),
-                    feeder: "feeder0000".to_string(),
+                    proxy_addr: "oracleproxy0000".to_string(),
+                    priority: None,
                 })
                 .unwrap(),
             })),
@@ -662,7 +668,7 @@ fn test_terraswap_creation_hook() {
     let msg = ExecuteMsg::Whitelist {
         name: "apple derivative".to_string(),
         symbol: "mAPPL".to_string(),
-        oracle_feeder: "feeder0000".to_string(),
+        oracle_proxy: "oracleproxy0000".to_string(),
         params: Params {
             auction_discount: Decimal::percent(5),
             min_collateral_ratio: Decimal::percent(150),
@@ -670,6 +676,7 @@ fn test_terraswap_creation_hook() {
             mint_period: None,
             min_collateral_ratio_after_ipo: None,
             pre_ipo_price: None,
+            ipo_trigger_addr: None,
         },
     };
     let info = mock_info("owner0000", &[]);
@@ -677,7 +684,7 @@ fn test_terraswap_creation_hook() {
 
     //ensure temp oracle was stored
     let tmp_oracle = read_tmp_oracle(&deps.storage).unwrap();
-    assert_eq!(tmp_oracle.to_string(), "feeder0000");
+    assert_eq!(tmp_oracle.to_string(), "oracleproxy0000");
 
     let mut token_inst_res = MsgInstantiateContractResponse::new();
     token_inst_res.set_contract_address("asset0000".to_string());
@@ -756,7 +763,7 @@ fn test_distribute() {
     let msg = ExecuteMsg::Whitelist {
         name: "apple derivative".to_string(),
         symbol: "mAPPL".to_string(),
-        oracle_feeder: "feeder0000".to_string(),
+        oracle_proxy: "oracleproxy0000".to_string(),
         params: Params {
             auction_discount: Decimal::percent(5),
             min_collateral_ratio: Decimal::percent(150),
@@ -764,6 +771,7 @@ fn test_distribute() {
             mint_period: None,
             min_collateral_ratio_after_ipo: None,
             pre_ipo_price: None,
+            ipo_trigger_addr: None,
         },
     };
     let info = mock_info("owner0000", &[]);
@@ -771,7 +779,7 @@ fn test_distribute() {
 
     //ensure temp oracle was stored
     let tmp_oracle = read_tmp_oracle(&deps.storage).unwrap();
-    assert_eq!(tmp_oracle.to_string(), "feeder0000");
+    assert_eq!(tmp_oracle.to_string(), "oracleproxy0000");
 
     let mut token_inst_res = MsgInstantiateContractResponse::new();
     token_inst_res.set_contract_address("asset0000".to_string());
@@ -804,7 +812,7 @@ fn test_distribute() {
     let msg = ExecuteMsg::Whitelist {
         name: "google derivative".to_string(),
         symbol: "mGOGL".to_string(),
-        oracle_feeder: "feeder0000".to_string(),
+        oracle_proxy: "oracleproxy0000".to_string(),
         params: Params {
             auction_discount: Decimal::percent(5),
             min_collateral_ratio: Decimal::percent(150),
@@ -812,6 +820,7 @@ fn test_distribute() {
             mint_period: None,
             min_collateral_ratio_after_ipo: None,
             pre_ipo_price: None,
+            ipo_trigger_addr: None,
         },
     };
     let info = mock_info("owner0000", &[]);
@@ -919,7 +928,7 @@ fn whitelist_token(
     let msg = ExecuteMsg::Whitelist {
         name: name.to_string(),
         symbol: symbol.to_string(),
-        oracle_feeder: "feeder0000".to_string(),
+        oracle_proxy: "oracleproxy0000".to_string(),
         params: Params {
             auction_discount: Decimal::percent(5),
             min_collateral_ratio: Decimal::percent(150),
@@ -927,6 +936,7 @@ fn whitelist_token(
             mint_period: None,
             min_collateral_ratio_after_ipo: None,
             pre_ipo_price: None,
+            ipo_trigger_addr: None,
         },
     };
     let info = mock_info("owner0000", &[]);
@@ -934,7 +944,7 @@ fn whitelist_token(
 
     //ensure temp oracle was stored
     let tmp_oracle = read_tmp_oracle(&deps.storage).unwrap();
-    assert_eq!(tmp_oracle.to_string(), "feeder0000");
+    assert_eq!(tmp_oracle.to_string(), "oracleproxy0000");
 
     // callback 1
     let mut token_inst_res = MsgInstantiateContractResponse::new();
@@ -1205,13 +1215,19 @@ fn test_revocation() {
         (&"uusdmirror0000".to_string(), &"MIRLP000".to_string()),
     ]);
     deps.querier.with_oracle_price(&[
-        (&"uusd".to_string(), &Decimal::one()),
+        (&"asset0000".to_string(), &Decimal::percent(100)),
         (&"asset0001".to_string(), &Decimal::percent(200)),
     ]);
-    deps.querier.with_mint_configs(&[(
-        &"asset0001".to_string(),
-        &(Decimal::percent(1), Decimal::percent(1)),
-    )]);
+    deps.querier.with_mint_configs(&[
+        (
+            &"asset0000".to_string(),
+            &(Decimal::percent(1), Decimal::percent(1)),
+        ),
+        (
+            &"asset0001".to_string(),
+            &(Decimal::percent(1), Decimal::percent(1)),
+        ),
+    ]);
 
     let msg = InstantiateMsg {
         base_denom: BASE_DENOM.to_string(),
@@ -1236,16 +1252,9 @@ fn test_revocation() {
     whitelist_token(&mut deps, "tesla derivative", "mTSLA", "asset0000", 100u32);
     whitelist_token(&mut deps, "apple derivative", "mAPPL", "asset0001", 100u32);
 
-    // register queriers
-    deps.querier.with_oracle_feeders(&[
-        (&"asset0000".to_string(), &"feeder0000".to_string()),
-        (&"asset0001".to_string(), &"feeder0000".to_string()),
-    ]);
-
     // unauthorized revoke attempt
     let msg = ExecuteMsg::RevokeAsset {
         asset_token: "asset0000".to_string(),
-        end_price: Some(Decimal::from_ratio(2u128, 3u128)),
     };
     let info = mock_info("address0000", &[]);
     let err = execute(deps.as_mut(), mock_env(), info, msg.clone()).unwrap_err();
@@ -1254,16 +1263,8 @@ fn test_revocation() {
         _ => panic!("DO NOT ENTER HERE"),
     }
 
-    // unatuthorized attemt 2, only owner can fix set price
-    let info = mock_info("addr0000", &[]);
-    let err = execute(deps.as_mut(), mock_env(), info, msg.clone()).unwrap_err();
-    match err {
-        StdError::GenericErr { msg, .. } => assert_eq!(msg, "unauthorized"),
-        _ => panic!("DO NOT ENTER HERE"),
-    }
-
-    // SUCCESS - the feeder revokes item 1
-    let info = mock_info("feeder0000", &[]);
+    // SUCCESS - revoke item 1
+    let info = mock_info("owner0000", &[]);
     let res = execute(deps.as_mut(), mock_env(), info, msg).unwrap();
     assert_eq!(
         res.messages,
@@ -1272,7 +1273,7 @@ fn test_revocation() {
             funds: vec![],
             msg: to_binary(&MintExecuteMsg::RegisterMigration {
                 asset_token: "asset0000".to_string(),
-                end_price: Decimal::from_ratio(2u128, 3u128),
+                end_price: Decimal::percent(100), // last price feed
             })
             .unwrap(),
         }))]
@@ -1280,9 +1281,8 @@ fn test_revocation() {
 
     let msg = ExecuteMsg::RevokeAsset {
         asset_token: "asset0001".to_string(),
-        end_price: None, // owner can revoke without price feed
     };
-    // SUCCESS - the owner revokes item 2
+    // SUCCESS - revoke item 2
     let info = mock_info("owner0000", &[]);
     let res = execute(deps.as_mut(), mock_env(), info, msg).unwrap();
     assert_eq!(
@@ -1335,16 +1335,16 @@ fn test_migration() {
         &(Decimal::percent(1), Decimal::percent(1)),
     )]);
     deps.querier
-        .with_oracle_feeders(&[(&"asset0000".to_string(), &"feeder0000".to_string())]);
+        .with_oracle_price(&[(&"asset0000".to_string(), &Decimal::percent(300))]);
 
     // unauthorized migrate attempt
     let msg = ExecuteMsg::MigrateAsset {
         name: "apple migration".to_string(),
         symbol: "mAPPL2".to_string(),
         from_token: "asset0000".to_string(),
-        end_price: Decimal::from_ratio(2u128, 1u128),
+        oracle_proxy: "oracleproxy0000".to_string(),
     };
-    let info = mock_info("owner0000", &[]);
+    let info = mock_info("addr0000", &[]);
     let res = execute(deps.as_mut(), mock_env(), info, msg.clone()).unwrap_err();
 
     match res {
@@ -1352,7 +1352,7 @@ fn test_migration() {
         _ => panic!("DO NOT ENTER HERE"),
     }
 
-    let info = mock_info("feeder0000", &[]);
+    let info = mock_info("owner0000", &[]);
     let res = execute(deps.as_mut(), mock_env(), info, msg).unwrap();
     assert_eq!(
         res.messages,
@@ -1362,7 +1362,7 @@ fn test_migration() {
                 funds: vec![],
                 msg: to_binary(&MintExecuteMsg::RegisterMigration {
                     asset_token: "asset0000".to_string(),
-                    end_price: Decimal::from_ratio(2u128, 1u128),
+                    end_price: Decimal::percent(300),
                 })
                 .unwrap(),
             })),
@@ -1422,7 +1422,7 @@ fn test_whitelist_pre_ipo_asset() {
     let msg = ExecuteMsg::Whitelist {
         name: "pre-IPO asset".to_string(),
         symbol: "mPreIPO".to_string(),
-        oracle_feeder: "feeder0000".to_string(),
+        oracle_proxy: "oracleproxy0000".to_string(),
         params: Params {
             auction_discount: Decimal::percent(5),
             min_collateral_ratio: Decimal::percent(1000),
@@ -1430,6 +1430,7 @@ fn test_whitelist_pre_ipo_asset() {
             mint_period: Some(10000u64),
             min_collateral_ratio_after_ipo: Some(Decimal::percent(150)),
             pre_ipo_price: Some(Decimal::percent(1)),
+            ipo_trigger_addr: Some("trigger0000".to_string()),
         },
     };
     let info = mock_info("owner0000", &[]);
@@ -1473,12 +1474,13 @@ fn test_whitelist_pre_ipo_asset() {
             mint_period: Some(10000u64),
             min_collateral_ratio_after_ipo: Some(Decimal::percent(150)),
             pre_ipo_price: Some(Decimal::percent(1)),
+            ipo_trigger_addr: Some("trigger0000".to_string())
         }
     );
 
     //ensure temp oracle was stored
     let tmp_oracle = read_tmp_oracle(&deps.storage).unwrap();
-    assert_eq!(tmp_oracle.to_string(), "feeder0000");
+    assert_eq!(tmp_oracle.to_string(), "oracleproxy0000");
 
     // callback 1
     let mut token_inst_res = MsgInstantiateContractResponse::new();
@@ -1513,6 +1515,7 @@ fn test_whitelist_pre_ipo_asset() {
                             / 1_000_000_000,
                         min_collateral_ratio_after_ipo: Decimal::percent(150),
                         pre_ipo_price: Decimal::percent(1),
+                        trigger_addr: "trigger0000".to_string()
                     }),
                 })
                 .unwrap(),
@@ -1520,9 +1523,10 @@ fn test_whitelist_pre_ipo_asset() {
             SubMsg::new(CosmosMsg::Wasm(WasmMsg::Execute {
                 contract_addr: "oracle0000".to_string(),
                 funds: vec![],
-                msg: to_binary(&OracleExecuteMsg::RegisterAsset {
+                msg: to_binary(&TeFiOracleExecuteMsg::RegisterProxy {
                     asset_token: "asset0000".to_string(),
-                    feeder: "feeder0000".to_string(),
+                    proxy_addr: "oracleproxy0000".to_string(),
+                    priority: None,
                 })
                 .unwrap(),
             })),
@@ -1561,6 +1565,7 @@ fn test_whitelist_pre_ipo_asset() {
             ),
             attr("min_collateral_ratio_after_ipo", "1.5"),
             attr("pre_ipo_price", "0.01"),
+            attr("ipo_trigger_addr", "trigger0000"),
         ]
     );
 }

--- a/contracts/mirror_gov/schema/config_response.json
+++ b/contracts/mirror_gov/schema/config_response.json
@@ -10,6 +10,7 @@
     "migration_poll_config",
     "mirror_token",
     "owner",
+    "poll_gas_limit",
     "snapshot_period",
     "voter_weight"
   ],
@@ -36,6 +37,11 @@
     },
     "owner": {
       "type": "string"
+    },
+    "poll_gas_limit": {
+      "type": "integer",
+      "format": "uint64",
+      "minimum": 0.0
     },
     "snapshot_period": {
       "type": "integer",

--- a/contracts/mirror_gov/schema/config_response.json
+++ b/contracts/mirror_gov/schema/config_response.json
@@ -3,21 +3,33 @@
   "title": "ConfigResponse",
   "type": "object",
   "required": [
+    "admin_manager",
+    "auth_admin_poll_config",
+    "default_poll_config",
     "effective_delay",
+    "migration_poll_config",
     "mirror_token",
     "owner",
-    "proposal_deposit",
-    "quorum",
     "snapshot_period",
-    "threshold",
-    "voter_weight",
-    "voting_period"
+    "voter_weight"
   ],
   "properties": {
+    "admin_manager": {
+      "type": "string"
+    },
+    "auth_admin_poll_config": {
+      "$ref": "#/definitions/PollConfig"
+    },
+    "default_poll_config": {
+      "$ref": "#/definitions/PollConfig"
+    },
     "effective_delay": {
       "type": "integer",
       "format": "uint64",
       "minimum": 0.0
+    },
+    "migration_poll_config": {
+      "$ref": "#/definitions/PollConfig"
     },
     "mirror_token": {
       "type": "string"
@@ -25,33 +37,44 @@
     "owner": {
       "type": "string"
     },
-    "proposal_deposit": {
-      "$ref": "#/definitions/Uint128"
-    },
-    "quorum": {
-      "$ref": "#/definitions/Decimal"
-    },
     "snapshot_period": {
       "type": "integer",
       "format": "uint64",
       "minimum": 0.0
     },
-    "threshold": {
-      "$ref": "#/definitions/Decimal"
-    },
     "voter_weight": {
       "$ref": "#/definitions/Decimal"
-    },
-    "voting_period": {
-      "type": "integer",
-      "format": "uint64",
-      "minimum": 0.0
     }
   },
   "definitions": {
     "Decimal": {
       "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
       "type": "string"
+    },
+    "PollConfig": {
+      "type": "object",
+      "required": [
+        "proposal_deposit",
+        "quorum",
+        "threshold",
+        "voting_period"
+      ],
+      "properties": {
+        "proposal_deposit": {
+          "$ref": "#/definitions/Uint128"
+        },
+        "quorum": {
+          "$ref": "#/definitions/Decimal"
+        },
+        "threshold": {
+          "$ref": "#/definitions/Decimal"
+        },
+        "voting_period": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        }
+      }
     },
     "Uint128": {
       "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",

--- a/contracts/mirror_gov/schema/cw20_hook_msg.json
+++ b/contracts/mirror_gov/schema/cw20_hook_msg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Cw20HookMsg",
-  "anyOf": [
+  "oneOf": [
     {
       "description": "StakeVotingTokens a user can stake their mirror token to receive rewards or do vote on polls",
       "type": "object",
@@ -29,6 +29,16 @@
             "title"
           ],
           "properties": {
+            "admin_action": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/PollAdminAction"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
             "description": {
               "type": "string"
             },
@@ -75,6 +85,203 @@
       "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>",
       "type": "string"
     },
+    "Decimal": {
+      "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
+      "type": "string"
+    },
+    "PollAdminAction": {
+      "oneOf": [
+        {
+          "description": "Updates migration manager owner",
+          "type": "object",
+          "required": [
+            "update_owner"
+          ],
+          "properties": {
+            "update_owner": {
+              "type": "object",
+              "required": [
+                "owner"
+              ],
+              "properties": {
+                "owner": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "Executes a set of migrations. The poll can be executes as soon as it reaches the quorum and threshold",
+          "type": "object",
+          "required": [
+            "execute_migrations"
+          ],
+          "properties": {
+            "execute_migrations": {
+              "type": "object",
+              "required": [
+                "migrations"
+              ],
+              "properties": {
+                "migrations": {
+                  "type": "array",
+                  "items": {
+                    "type": "array",
+                    "items": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "integer",
+                        "format": "uint64",
+                        "minimum": 0.0
+                      },
+                      {
+                        "$ref": "#/definitions/Binary"
+                      }
+                    ],
+                    "maxItems": 3,
+                    "minItems": 3
+                  }
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "Transfer admin privileges over Mirror contracts to the authorized_addr",
+          "type": "object",
+          "required": [
+            "authorize_claim"
+          ],
+          "properties": {
+            "authorize_claim": {
+              "type": "object",
+              "required": [
+                "authorized_addr"
+              ],
+              "properties": {
+                "authorized_addr": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "Updates Governace contract configuration",
+          "type": "object",
+          "required": [
+            "update_config"
+          ],
+          "properties": {
+            "update_config": {
+              "type": "object",
+              "properties": {
+                "admin_manager": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "auth_admin_poll_config": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/PollConfig"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "default_poll_config": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/PollConfig"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "effective_delay": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ],
+                  "format": "uint64",
+                  "minimum": 0.0
+                },
+                "migration_poll_config": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/PollConfig"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "owner": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "snapshot_period": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ],
+                  "format": "uint64",
+                  "minimum": 0.0
+                },
+                "voter_weight": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/Decimal"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "PollConfig": {
+      "type": "object",
+      "required": [
+        "proposal_deposit",
+        "quorum",
+        "threshold",
+        "voting_period"
+      ],
+      "properties": {
+        "proposal_deposit": {
+          "$ref": "#/definitions/Uint128"
+        },
+        "quorum": {
+          "$ref": "#/definitions/Decimal"
+        },
+        "threshold": {
+          "$ref": "#/definitions/Decimal"
+        },
+        "voting_period": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        }
+      }
+    },
     "PollExecuteMsg": {
       "type": "object",
       "required": [
@@ -89,6 +296,10 @@
           "$ref": "#/definitions/Binary"
         }
       }
+    },
+    "Uint128": {
+      "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+      "type": "string"
     }
   }
 }

--- a/contracts/mirror_gov/schema/execute_msg.json
+++ b/contracts/mirror_gov/schema/execute_msg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "ExecuteMsg",
-  "anyOf": [
+  "oneOf": [
     {
       "type": "object",
       "required": [
@@ -23,6 +23,32 @@
         "update_config": {
           "type": "object",
           "properties": {
+            "admin_manager": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "auth_admin_poll_config": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/PollConfig"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "default_poll_config": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/PollConfig"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
             "effective_delay": {
               "type": [
                 "integer",
@@ -31,30 +57,20 @@
               "format": "uint64",
               "minimum": 0.0
             },
+            "migration_poll_config": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/PollConfig"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
             "owner": {
               "type": [
                 "string",
                 "null"
-              ]
-            },
-            "proposal_deposit": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/Uint128"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            },
-            "quorum": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/Decimal"
-                },
-                {
-                  "type": "null"
-                }
               ]
             },
             "snapshot_period": {
@@ -65,16 +81,6 @@
               "format": "uint64",
               "minimum": 0.0
             },
-            "threshold": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/Decimal"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            },
             "voter_weight": {
               "anyOf": [
                 {
@@ -84,14 +90,6 @@
                   "type": "null"
                 }
               ]
-            },
-            "voting_period": {
-              "type": [
-                "integer",
-                "null"
-              ],
-              "format": "uint64",
-              "minimum": 0.0
             }
           }
         }
@@ -291,6 +289,31 @@
     "Decimal": {
       "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
       "type": "string"
+    },
+    "PollConfig": {
+      "type": "object",
+      "required": [
+        "proposal_deposit",
+        "quorum",
+        "threshold",
+        "voting_period"
+      ],
+      "properties": {
+        "proposal_deposit": {
+          "$ref": "#/definitions/Uint128"
+        },
+        "quorum": {
+          "$ref": "#/definitions/Decimal"
+        },
+        "threshold": {
+          "$ref": "#/definitions/Decimal"
+        },
+        "voting_period": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        }
+      }
     },
     "Uint128": {
       "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",

--- a/contracts/mirror_gov/schema/execute_msg.json
+++ b/contracts/mirror_gov/schema/execute_msg.json
@@ -73,6 +73,14 @@
                 "null"
               ]
             },
+            "poll_gas_limit": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint64",
+              "minimum": 0.0
+            },
             "snapshot_period": {
               "type": [
                 "integer",

--- a/contracts/mirror_gov/schema/instantiate_msg.json
+++ b/contracts/mirror_gov/schema/instantiate_msg.json
@@ -3,51 +3,74 @@
   "title": "InstantiateMsg",
   "type": "object",
   "required": [
+    "admin_manager",
+    "auth_admin_poll_config",
+    "default_poll_config",
     "effective_delay",
+    "migration_poll_config",
     "mirror_token",
-    "proposal_deposit",
-    "quorum",
     "snapshot_period",
-    "threshold",
-    "voter_weight",
-    "voting_period"
+    "voter_weight"
   ],
   "properties": {
+    "admin_manager": {
+      "type": "string"
+    },
+    "auth_admin_poll_config": {
+      "$ref": "#/definitions/PollConfig"
+    },
+    "default_poll_config": {
+      "$ref": "#/definitions/PollConfig"
+    },
     "effective_delay": {
       "type": "integer",
       "format": "uint64",
       "minimum": 0.0
     },
+    "migration_poll_config": {
+      "$ref": "#/definitions/PollConfig"
+    },
     "mirror_token": {
       "type": "string"
-    },
-    "proposal_deposit": {
-      "$ref": "#/definitions/Uint128"
-    },
-    "quorum": {
-      "$ref": "#/definitions/Decimal"
     },
     "snapshot_period": {
       "type": "integer",
       "format": "uint64",
       "minimum": 0.0
     },
-    "threshold": {
-      "$ref": "#/definitions/Decimal"
-    },
     "voter_weight": {
       "$ref": "#/definitions/Decimal"
-    },
-    "voting_period": {
-      "type": "integer",
-      "format": "uint64",
-      "minimum": 0.0
     }
   },
   "definitions": {
     "Decimal": {
       "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
       "type": "string"
+    },
+    "PollConfig": {
+      "type": "object",
+      "required": [
+        "proposal_deposit",
+        "quorum",
+        "threshold",
+        "voting_period"
+      ],
+      "properties": {
+        "proposal_deposit": {
+          "$ref": "#/definitions/Uint128"
+        },
+        "quorum": {
+          "$ref": "#/definitions/Decimal"
+        },
+        "threshold": {
+          "$ref": "#/definitions/Decimal"
+        },
+        "voting_period": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        }
+      }
     },
     "Uint128": {
       "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",

--- a/contracts/mirror_gov/schema/instantiate_msg.json
+++ b/contracts/mirror_gov/schema/instantiate_msg.json
@@ -9,6 +9,7 @@
     "effective_delay",
     "migration_poll_config",
     "mirror_token",
+    "poll_gas_limit",
     "snapshot_period",
     "voter_weight"
   ],
@@ -32,6 +33,11 @@
     },
     "mirror_token": {
       "type": "string"
+    },
+    "poll_gas_limit": {
+      "type": "integer",
+      "format": "uint64",
+      "minimum": 0.0
     },
     "snapshot_period": {
       "type": "integer",

--- a/contracts/mirror_gov/schema/migrate_msg.json
+++ b/contracts/mirror_gov/schema/migrate_msg.json
@@ -1,5 +1,56 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "MigrateMsg",
-  "type": "object"
+  "type": "object",
+  "required": [
+    "admin_manager",
+    "auth_admin_poll_config",
+    "migration_poll_config"
+  ],
+  "properties": {
+    "admin_manager": {
+      "type": "string"
+    },
+    "auth_admin_poll_config": {
+      "$ref": "#/definitions/PollConfig"
+    },
+    "migration_poll_config": {
+      "$ref": "#/definitions/PollConfig"
+    }
+  },
+  "definitions": {
+    "Decimal": {
+      "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
+      "type": "string"
+    },
+    "PollConfig": {
+      "type": "object",
+      "required": [
+        "proposal_deposit",
+        "quorum",
+        "threshold",
+        "voting_period"
+      ],
+      "properties": {
+        "proposal_deposit": {
+          "$ref": "#/definitions/Uint128"
+        },
+        "quorum": {
+          "$ref": "#/definitions/Decimal"
+        },
+        "threshold": {
+          "$ref": "#/definitions/Decimal"
+        },
+        "voting_period": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        }
+      }
+    },
+    "Uint128": {
+      "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+      "type": "string"
+    }
+  }
 }

--- a/contracts/mirror_gov/schema/migrate_msg.json
+++ b/contracts/mirror_gov/schema/migrate_msg.json
@@ -5,7 +5,8 @@
   "required": [
     "admin_manager",
     "auth_admin_poll_config",
-    "migration_poll_config"
+    "migration_poll_config",
+    "poll_gas_limit"
   ],
   "properties": {
     "admin_manager": {
@@ -16,6 +17,11 @@
     },
     "migration_poll_config": {
       "$ref": "#/definitions/PollConfig"
+    },
+    "poll_gas_limit": {
+      "type": "integer",
+      "format": "uint64",
+      "minimum": 0.0
     }
   },
   "definitions": {

--- a/contracts/mirror_gov/schema/query_msg.json
+++ b/contracts/mirror_gov/schema/query_msg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "QueryMsg",
-  "anyOf": [
+  "oneOf": [
     {
       "type": "object",
       "required": [

--- a/contracts/mirror_gov/src/lib.rs
+++ b/contracts/mirror_gov/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod contract;
+mod migrate;
 mod querier;
 mod staking;
 pub mod state;

--- a/contracts/mirror_gov/src/migrate.rs
+++ b/contracts/mirror_gov/src/migrate.rs
@@ -25,6 +25,7 @@ pub fn migrate_config(
     migration_poll_config: PollConfig,
     auth_admin_poll_config: PollConfig,
     admin_manager: String,
+    poll_gas_limit: u64,
 ) -> StdResult<()> {
     let legacty_store: ReadonlySingleton<LegacyConfig> = singleton_read(deps.storage, KEY_CONFIG);
     let legacy_config: LegacyConfig = legacty_store.load()?;
@@ -43,6 +44,7 @@ pub fn migrate_config(
         migration_poll_config,
         auth_admin_poll_config,
         admin_manager: deps.api.addr_canonicalize(&admin_manager)?,
+        poll_gas_limit,
     };
     let mut store: Singleton<Config> = singleton(deps.storage, KEY_CONFIG);
     store.save(&config)?;
@@ -96,6 +98,7 @@ mod migrate_tests {
             migration_poll_config.clone(),
             auth_admin_poll_config.clone(),
             "admin_manager".to_string(),
+            4_000_000u64,
         )
         .unwrap();
 
@@ -117,6 +120,7 @@ mod migrate_tests {
                 voter_weight: Decimal::percent(50u64),
                 snapshot_period: 20u64,
                 admin_manager: deps.api.addr_canonicalize("admin_manager").unwrap(),
+                poll_gas_limit: 4_000_000u64,
             }
         )
     }

--- a/contracts/mirror_gov/src/migrate.rs
+++ b/contracts/mirror_gov/src/migrate.rs
@@ -1,0 +1,123 @@
+use cosmwasm_std::{CanonicalAddr, Decimal, DepsMut, StdResult, Uint128};
+use cosmwasm_storage::{singleton, singleton_read, ReadonlySingleton, Singleton};
+use mirror_protocol::gov::PollConfig;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::state::{Config, KEY_CONFIG};
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct LegacyConfig {
+    pub owner: CanonicalAddr,
+    pub mirror_token: CanonicalAddr,
+    pub quorum: Decimal,
+    pub threshold: Decimal,
+    pub voting_period: u64,
+    pub effective_delay: u64,
+    pub expiration_period: u64, // deprecated, to remove on next state migration
+    pub proposal_deposit: Uint128,
+    pub voter_weight: Decimal,
+    pub snapshot_period: u64,
+}
+
+pub fn migrate_config(
+    deps: DepsMut,
+    migration_poll_config: PollConfig,
+    auth_admin_poll_config: PollConfig,
+    admin_manager: String,
+) -> StdResult<()> {
+    let legacty_store: ReadonlySingleton<LegacyConfig> = singleton_read(deps.storage, KEY_CONFIG);
+    let legacy_config: LegacyConfig = legacty_store.load()?;
+    let config = Config {
+        mirror_token: legacy_config.mirror_token,
+        owner: legacy_config.owner,
+        effective_delay: legacy_config.effective_delay,
+        voter_weight: legacy_config.voter_weight,
+        snapshot_period: legacy_config.snapshot_period,
+        default_poll_config: PollConfig {
+            proposal_deposit: legacy_config.proposal_deposit,
+            voting_period: legacy_config.voting_period,
+            quorum: legacy_config.quorum,
+            threshold: legacy_config.threshold,
+        },
+        migration_poll_config,
+        auth_admin_poll_config,
+        admin_manager: deps.api.addr_canonicalize(&admin_manager)?,
+    };
+    let mut store: Singleton<Config> = singleton(deps.storage, KEY_CONFIG);
+    store.save(&config)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod migrate_tests {
+    use crate::state::config_read;
+
+    use super::*;
+    use cosmwasm_std::{testing::mock_dependencies, Api, Storage};
+
+    pub fn config_old_store(storage: &mut dyn Storage) -> Singleton<LegacyConfig> {
+        Singleton::new(storage, KEY_CONFIG)
+    }
+
+    #[test]
+    fn test_config_migration() {
+        let mut deps = mock_dependencies(&[]);
+        let mut legacy_config_store = config_old_store(&mut deps.storage);
+        legacy_config_store
+            .save(&LegacyConfig {
+                mirror_token: deps.api.addr_canonicalize("mir0000").unwrap(),
+                owner: deps.api.addr_canonicalize("owner0000").unwrap(),
+                quorum: Decimal::one(),
+                threshold: Decimal::one(),
+                voting_period: 100u64,
+                effective_delay: 100u64,
+                expiration_period: 100u64,
+                proposal_deposit: Uint128::from(100000u128),
+                voter_weight: Decimal::percent(50),
+                snapshot_period: 20u64,
+            })
+            .unwrap();
+
+        let migration_poll_config = PollConfig {
+            quorum: Decimal::percent(60),
+            threshold: Decimal::percent(60),
+            proposal_deposit: Uint128::from(99999u128),
+            voting_period: 888u64,
+        };
+        let auth_admin_poll_config = PollConfig {
+            quorum: Decimal::percent(70),
+            threshold: Decimal::percent(70),
+            proposal_deposit: Uint128::from(99999000u128),
+            voting_period: 88800u64,
+        };
+        migrate_config(
+            deps.as_mut(),
+            migration_poll_config.clone(),
+            auth_admin_poll_config.clone(),
+            "admin_manager".to_string(),
+        )
+        .unwrap();
+
+        let config: Config = config_read(&deps.storage).load().unwrap();
+        assert_eq!(
+            config,
+            Config {
+                mirror_token: deps.api.addr_canonicalize("mir0000").unwrap(),
+                owner: deps.api.addr_canonicalize("owner0000").unwrap(),
+                default_poll_config: PollConfig {
+                    quorum: Decimal::one(),
+                    threshold: Decimal::one(),
+                    voting_period: 100u64,
+                    proposal_deposit: Uint128::from(100000u128),
+                },
+                migration_poll_config,
+                auth_admin_poll_config,
+                effective_delay: 100u64,
+                voter_weight: Decimal::percent(50u64),
+                snapshot_period: 20u64,
+                admin_manager: deps.api.addr_canonicalize("admin_manager").unwrap(),
+            }
+        )
+    }
+}

--- a/contracts/mirror_gov/src/state.rs
+++ b/contracts/mirror_gov/src/state.rs
@@ -33,6 +33,7 @@ pub struct Config {
     pub voter_weight: Decimal,
     pub snapshot_period: u64,
     pub admin_manager: CanonicalAddr,
+    pub poll_gas_limit: u64,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/contracts/mirror_gov/src/state.rs
+++ b/contracts/mirror_gov/src/state.rs
@@ -7,9 +7,9 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use mirror_protocol::common::OrderBy;
-use mirror_protocol::gov::{PollStatus, VoterInfo};
+use mirror_protocol::gov::{PollAdminAction, PollConfig, PollStatus, VoterInfo};
 
-static KEY_CONFIG: &[u8] = b"config";
+pub static KEY_CONFIG: &[u8] = b"config";
 static KEY_STATE: &[u8] = b"state";
 static KEY_TMP_POLL_ID: &[u8] = b"tmp_poll_id";
 
@@ -17,6 +17,7 @@ static PREFIX_POLL_INDEXER: &[u8] = b"poll_indexer";
 static PREFIX_POLL_VOTER: &[u8] = b"poll_voter";
 static PREFIX_POLL: &[u8] = b"poll";
 static PREFIX_BANK: &[u8] = b"bank";
+static PREFIX_POLL_ADDITIONAL_PARAMS: &[u8] = b"poll_additional_params";
 
 const MAX_LIMIT: u32 = 30;
 const DEFAULT_LIMIT: u32 = 10;
@@ -25,14 +26,13 @@ const DEFAULT_LIMIT: u32 = 10;
 pub struct Config {
     pub owner: CanonicalAddr,
     pub mirror_token: CanonicalAddr,
-    pub quorum: Decimal,
-    pub threshold: Decimal,
-    pub voting_period: u64,
     pub effective_delay: u64,
-    pub expiration_period: u64, // deprecated, to remove on next state migration
-    pub proposal_deposit: Uint128,
+    pub default_poll_config: PollConfig,
+    pub migration_poll_config: PollConfig,
+    pub auth_admin_poll_config: PollConfig,
     pub voter_weight: Decimal,
     pub snapshot_period: u64,
+    pub admin_manager: CanonicalAddr,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
@@ -72,6 +72,11 @@ pub struct Poll {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct PollAdditionalParams {
+    pub admin_action: Option<PollAdminAction>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct ExecuteData {
     pub contract: CanonicalAddr,
     pub msg: Binary,
@@ -107,6 +112,14 @@ pub fn poll_store(storage: &mut dyn Storage) -> Bucket<Poll> {
 
 pub fn poll_read(storage: &dyn Storage) -> ReadonlyBucket<Poll> {
     bucket_read(storage, PREFIX_POLL)
+}
+
+pub fn poll_additional_params_store(storage: &mut dyn Storage) -> Bucket<PollAdditionalParams> {
+    bucket(storage, PREFIX_POLL_ADDITIONAL_PARAMS)
+}
+
+pub fn poll_additional_params_read(storage: &dyn Storage) -> ReadonlyBucket<PollAdditionalParams> {
+    bucket_read(storage, PREFIX_POLL_ADDITIONAL_PARAMS)
 }
 
 pub fn poll_indexer_store<'a>(

--- a/contracts/mirror_gov/src/testing/tests.rs
+++ b/contracts/mirror_gov/src/testing/tests.rs
@@ -42,6 +42,7 @@ const DEFAULT_MIGRATION_PROPOSAL_DEPOSIT: u128 = 20000000000u128;
 const DEFAULT_AUTH_ADMIN_PROPOSAL_DEPOSIT: u128 = 30000000000u128;
 const DEFAULT_VOTER_WEIGHT: Decimal = Decimal::zero();
 const DEFAULT_SNAPSHOT_PERIOD: u64 = 10u64;
+const DEFAULT_POLL_GAS_LIMIT: u64 = 4_000_000u64;
 
 fn mock_instantiate(deps: DepsMut) {
     let msg = init_msg();
@@ -83,6 +84,7 @@ fn init_msg() -> InstantiateMsg {
         voter_weight: DEFAULT_VOTER_WEIGHT,
         snapshot_period: DEFAULT_SNAPSHOT_PERIOD,
         admin_manager: TEST_ADMIN_MANAGER.to_string(),
+        poll_gas_limit: DEFAULT_POLL_GAS_LIMIT,
     }
 }
 
@@ -123,6 +125,7 @@ fn proper_initialization() {
             voter_weight: DEFAULT_VOTER_WEIGHT,
             snapshot_period: DEFAULT_SNAPSHOT_PERIOD,
             admin_manager: deps.api.addr_canonicalize(TEST_ADMIN_MANAGER).unwrap(),
+            poll_gas_limit: DEFAULT_POLL_GAS_LIMIT,
         }
     );
 
@@ -757,7 +760,7 @@ fn happy_days_end_poll() {
                 msg: exec_msg_bz,
                 funds: vec![],
             }),
-            gas_limit: None,
+            gas_limit: Some(DEFAULT_POLL_GAS_LIMIT),
             id: 1u64,
             reply_on: ReplyOn::Error,
         }]
@@ -966,7 +969,7 @@ fn failed_execute_poll() {
                 msg: exec_msg_bz,
                 funds: vec![],
             }),
-            gas_limit: None,
+            gas_limit: Some(DEFAULT_POLL_GAS_LIMIT),
             id: 1u64,
             reply_on: ReplyOn::Error,
         }]
@@ -2381,6 +2384,7 @@ fn update_config() {
         voter_weight: None,
         snapshot_period: None,
         admin_manager: None,
+        poll_gas_limit: None,
     };
 
     let res = execute(deps.as_mut(), mock_env(), info, msg).unwrap();
@@ -2421,6 +2425,7 @@ fn update_config() {
         voter_weight: Some(Decimal::percent(1)),
         snapshot_period: Some(60u64),
         admin_manager: Some("new_admin_mgr0000".to_string()),
+        poll_gas_limit: Some(1_000_000u64),
     };
 
     let res = execute(deps.as_mut(), mock_env(), info, msg).unwrap();
@@ -2437,6 +2442,7 @@ fn update_config() {
     assert_eq!(Decimal::percent(1), config.voter_weight);
     assert_eq!(60u64, config.snapshot_period);
     assert_eq!("new_admin_mgr0000", config.admin_manager.as_str());
+    assert_eq!(1_000_000u64, config.poll_gas_limit);
 
     // Unauthorzied err
     let info = mock_info(TEST_CREATOR, &[]);
@@ -2449,6 +2455,7 @@ fn update_config() {
         voter_weight: None,
         snapshot_period: None,
         admin_manager: None,
+        poll_gas_limit: None,
     };
 
     let res = execute(deps.as_mut(), mock_env(), info, msg);

--- a/contracts/mirror_gov/src/testing/tests.rs
+++ b/contracts/mirror_gov/src/testing/tests.rs
@@ -15,9 +15,9 @@ use cosmwasm_std::{
 use cw20::{Cw20ExecuteMsg, Cw20ReceiveMsg};
 use mirror_protocol::common::OrderBy;
 use mirror_protocol::gov::{
-    ConfigResponse, Cw20HookMsg, ExecuteMsg, InstantiateMsg, PollExecuteMsg, PollResponse,
-    PollStatus, PollsResponse, QueryMsg, SharesResponse, SharesResponseItem, StakerResponse,
-    StateResponse, VoteOption, VoterInfo, VotersResponse, VotersResponseItem,
+    ConfigResponse, Cw20HookMsg, ExecuteMsg, InstantiateMsg, PollConfig, PollExecuteMsg,
+    PollResponse, PollStatus, PollsResponse, QueryMsg, SharesResponse, SharesResponseItem,
+    StakerResponse, StateResponse, VoteOption, VoterInfo, VotersResponse, VotersResponseItem,
 };
 
 const VOTING_TOKEN: &str = "voting_token";
@@ -26,25 +26,25 @@ const TEST_VOTER: &str = "voter1";
 const TEST_VOTER_2: &str = "voter2";
 const TEST_VOTER_3: &str = "voter3";
 const TEST_COLLECTOR: &str = "collector";
+const TEST_ADMIN_MANAGER: &str = "admin_manager";
 const DEFAULT_QUORUM: u64 = 30u64;
 const DEFAULT_THRESHOLD: u64 = 50u64;
 const DEFAULT_VOTING_PERIOD: u64 = 10000u64;
+const DEFAULT_MIGRATION_QUORUM: u64 = 40u64;
+const DEFAULT_MIGRATION_THRESHOLD: u64 = 60u64;
+const DEFAULT_MIGRATION_VOTING_PERIOD: u64 = 20000u64;
+const DEFAULT_AUTH_ADMIN_QUORUM: u64 = 50u64;
+const DEFAULT_AUTH_ADMIN_THRESHOLD: u64 = 70u64;
+const DEFAULT_AUTH_ADMIN_VOTING_PERIOD: u64 = 30000u64;
 const DEFAULT_EFFECTIVE_DELAY: u64 = 10000u64;
 const DEFAULT_PROPOSAL_DEPOSIT: u128 = 10000000000u128;
+const DEFAULT_MIGRATION_PROPOSAL_DEPOSIT: u128 = 20000000000u128;
+const DEFAULT_AUTH_ADMIN_PROPOSAL_DEPOSIT: u128 = 30000000000u128;
 const DEFAULT_VOTER_WEIGHT: Decimal = Decimal::zero();
 const DEFAULT_SNAPSHOT_PERIOD: u64 = 10u64;
 
 fn mock_instantiate(deps: DepsMut) {
-    let msg = InstantiateMsg {
-        mirror_token: VOTING_TOKEN.to_string(),
-        quorum: Decimal::percent(DEFAULT_QUORUM),
-        threshold: Decimal::percent(DEFAULT_THRESHOLD),
-        voting_period: DEFAULT_VOTING_PERIOD,
-        effective_delay: DEFAULT_EFFECTIVE_DELAY,
-        proposal_deposit: Uint128::new(DEFAULT_PROPOSAL_DEPOSIT),
-        voter_weight: DEFAULT_VOTER_WEIGHT,
-        snapshot_period: DEFAULT_SNAPSHOT_PERIOD,
-    };
+    let msg = init_msg();
 
     let info = mock_info(TEST_CREATOR, &[]);
     let _res = instantiate(deps, mock_env(), info, msg)
@@ -61,13 +61,28 @@ fn mock_env_height(height: u64, time: u64) -> Env {
 fn init_msg() -> InstantiateMsg {
     InstantiateMsg {
         mirror_token: VOTING_TOKEN.to_string(),
-        quorum: Decimal::percent(DEFAULT_QUORUM),
-        threshold: Decimal::percent(DEFAULT_THRESHOLD),
-        voting_period: DEFAULT_VOTING_PERIOD,
+        default_poll_config: PollConfig {
+            proposal_deposit: Uint128::new(DEFAULT_PROPOSAL_DEPOSIT),
+            voting_period: DEFAULT_VOTING_PERIOD,
+            quorum: Decimal::percent(DEFAULT_QUORUM),
+            threshold: Decimal::percent(DEFAULT_THRESHOLD),
+        },
+        migration_poll_config: PollConfig {
+            proposal_deposit: Uint128::new(DEFAULT_MIGRATION_PROPOSAL_DEPOSIT),
+            voting_period: DEFAULT_MIGRATION_VOTING_PERIOD,
+            quorum: Decimal::percent(DEFAULT_MIGRATION_QUORUM),
+            threshold: Decimal::percent(DEFAULT_MIGRATION_THRESHOLD),
+        },
+        auth_admin_poll_config: PollConfig {
+            proposal_deposit: Uint128::new(DEFAULT_AUTH_ADMIN_PROPOSAL_DEPOSIT),
+            voting_period: DEFAULT_AUTH_ADMIN_VOTING_PERIOD,
+            quorum: Decimal::percent(DEFAULT_AUTH_ADMIN_QUORUM),
+            threshold: Decimal::percent(DEFAULT_AUTH_ADMIN_THRESHOLD),
+        },
         effective_delay: DEFAULT_EFFECTIVE_DELAY,
-        proposal_deposit: Uint128::new(DEFAULT_PROPOSAL_DEPOSIT),
         voter_weight: DEFAULT_VOTER_WEIGHT,
         snapshot_period: DEFAULT_SNAPSHOT_PERIOD,
+        admin_manager: TEST_ADMIN_MANAGER.to_string(),
     }
 }
 
@@ -86,14 +101,28 @@ fn proper_initialization() {
         Config {
             mirror_token: deps.api.addr_canonicalize(VOTING_TOKEN).unwrap(),
             owner: deps.api.addr_canonicalize(TEST_CREATOR).unwrap(),
-            quorum: Decimal::percent(DEFAULT_QUORUM),
-            threshold: Decimal::percent(DEFAULT_THRESHOLD),
-            voting_period: DEFAULT_VOTING_PERIOD,
+            default_poll_config: PollConfig {
+                proposal_deposit: Uint128::new(DEFAULT_PROPOSAL_DEPOSIT),
+                voting_period: DEFAULT_VOTING_PERIOD,
+                quorum: Decimal::percent(DEFAULT_QUORUM),
+                threshold: Decimal::percent(DEFAULT_THRESHOLD),
+            },
+            migration_poll_config: PollConfig {
+                proposal_deposit: Uint128::new(DEFAULT_MIGRATION_PROPOSAL_DEPOSIT),
+                voting_period: DEFAULT_MIGRATION_VOTING_PERIOD,
+                quorum: Decimal::percent(DEFAULT_MIGRATION_QUORUM),
+                threshold: Decimal::percent(DEFAULT_MIGRATION_THRESHOLD),
+            },
+            auth_admin_poll_config: PollConfig {
+                proposal_deposit: Uint128::new(DEFAULT_AUTH_ADMIN_PROPOSAL_DEPOSIT),
+                voting_period: DEFAULT_AUTH_ADMIN_VOTING_PERIOD,
+                quorum: Decimal::percent(DEFAULT_AUTH_ADMIN_QUORUM),
+                threshold: Decimal::percent(DEFAULT_AUTH_ADMIN_THRESHOLD),
+            },
             effective_delay: DEFAULT_EFFECTIVE_DELAY,
-            proposal_deposit: Uint128::new(DEFAULT_PROPOSAL_DEPOSIT),
             voter_weight: DEFAULT_VOTER_WEIGHT,
             snapshot_period: DEFAULT_SNAPSHOT_PERIOD,
-            expiration_period: 0u64, // depcrecated
+            admin_manager: deps.api.addr_canonicalize(TEST_ADMIN_MANAGER).unwrap(),
         }
     );
 
@@ -129,14 +158,11 @@ fn fails_create_poll_invalid_quorum() {
     let mut deps = mock_dependencies(&[]);
     let info = mock_info("voter", &coins(11, VOTING_TOKEN));
     let msg = InstantiateMsg {
-        mirror_token: VOTING_TOKEN.to_string(),
-        quorum: Decimal::percent(101),
-        threshold: Decimal::percent(DEFAULT_THRESHOLD),
-        voting_period: DEFAULT_VOTING_PERIOD,
-        effective_delay: DEFAULT_EFFECTIVE_DELAY,
-        proposal_deposit: Uint128::new(DEFAULT_PROPOSAL_DEPOSIT),
-        voter_weight: DEFAULT_VOTER_WEIGHT,
-        snapshot_period: DEFAULT_SNAPSHOT_PERIOD,
+        default_poll_config: PollConfig {
+            quorum: Decimal::percent(101),
+            ..init_msg().default_poll_config
+        },
+        ..init_msg()
     };
 
     let res = instantiate(deps.as_mut(), mock_env(), info, msg);
@@ -153,14 +179,11 @@ fn fails_create_poll_invalid_threshold() {
     let mut deps = mock_dependencies(&[]);
     let info = mock_info("voter", &coins(11, VOTING_TOKEN));
     let msg = InstantiateMsg {
-        mirror_token: VOTING_TOKEN.to_string(),
-        quorum: Decimal::percent(DEFAULT_QUORUM),
-        threshold: Decimal::percent(101),
-        voting_period: DEFAULT_VOTING_PERIOD,
-        effective_delay: DEFAULT_EFFECTIVE_DELAY,
-        proposal_deposit: Uint128::new(DEFAULT_PROPOSAL_DEPOSIT),
-        voter_weight: DEFAULT_VOTER_WEIGHT,
-        snapshot_period: DEFAULT_SNAPSHOT_PERIOD,
+        default_poll_config: PollConfig {
+            threshold: Decimal::percent(101),
+            ..init_msg().default_poll_config
+        },
+        ..init_msg()
     };
 
     let res = instantiate(deps.as_mut(), mock_env(), info, msg);
@@ -271,6 +294,7 @@ fn fails_create_poll_invalid_deposit() {
             description: "TESTTEST".to_string(),
             link: None,
             execute_msg: None,
+            admin_action: None,
         })
         .unwrap(),
     });
@@ -299,6 +323,7 @@ fn create_poll_msg(
             description,
             link,
             execute_msg,
+            admin_action: None,
         })
         .unwrap(),
     })
@@ -2139,14 +2164,8 @@ fn share_calculation_with_voter_rewards() {
 
     // initialize the store
     let msg = InstantiateMsg {
-        mirror_token: VOTING_TOKEN.to_string(),
-        quorum: Decimal::percent(DEFAULT_QUORUM),
-        threshold: Decimal::percent(DEFAULT_THRESHOLD),
-        voting_period: DEFAULT_VOTING_PERIOD,
-        effective_delay: DEFAULT_EFFECTIVE_DELAY,
-        proposal_deposit: Uint128::new(DEFAULT_PROPOSAL_DEPOSIT),
         voter_weight: Decimal::percent(50), // distribute 50% rewards to voters
-        snapshot_period: DEFAULT_SNAPSHOT_PERIOD,
+        ..init_msg()
     };
     let info = mock_info(TEST_VOTER, &coins(2, VOTING_TOKEN));
     let init_res = instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
@@ -2355,13 +2374,13 @@ fn update_config() {
     let info = mock_info(TEST_CREATOR, &[]);
     let msg = ExecuteMsg::UpdateConfig {
         owner: Some("addr0001".to_string()),
-        quorum: None,
-        threshold: None,
-        voting_period: None,
+        default_poll_config: None,
+        migration_poll_config: None,
+        auth_admin_poll_config: None,
         effective_delay: None,
-        proposal_deposit: None,
         voter_weight: None,
         snapshot_period: None,
+        admin_manager: None,
     };
 
     let res = execute(deps.as_mut(), mock_env(), info, msg).unwrap();
@@ -2371,23 +2390,37 @@ fn update_config() {
     let res = query(deps.as_ref(), mock_env(), QueryMsg::Config {}).unwrap();
     let config: ConfigResponse = from_binary(&res).unwrap();
     assert_eq!("addr0001", config.owner.as_str());
-    assert_eq!(Decimal::percent(DEFAULT_QUORUM), config.quorum);
-    assert_eq!(Decimal::percent(DEFAULT_THRESHOLD), config.threshold);
-    assert_eq!(DEFAULT_VOTING_PERIOD, config.voting_period);
-    assert_eq!(DEFAULT_EFFECTIVE_DELAY, config.effective_delay);
-    assert_eq!(DEFAULT_PROPOSAL_DEPOSIT, config.proposal_deposit.u128());
 
-    // update left items
+    // update all items
+    let new_default_poll_config = PollConfig {
+        proposal_deposit: Uint128::new(DEFAULT_PROPOSAL_DEPOSIT + 1),
+        voting_period: DEFAULT_VOTING_PERIOD + 2,
+        quorum: Decimal::percent(DEFAULT_QUORUM + 3),
+        threshold: Decimal::percent(DEFAULT_THRESHOLD + 4),
+    };
+    let new_migration_poll_config = PollConfig {
+        proposal_deposit: Uint128::new(DEFAULT_PROPOSAL_DEPOSIT + 5),
+        voting_period: DEFAULT_VOTING_PERIOD + 6,
+        quorum: Decimal::percent(DEFAULT_QUORUM + 7),
+        threshold: Decimal::percent(DEFAULT_THRESHOLD + 8),
+    };
+    let new_auth_admin_poll_config = PollConfig {
+        proposal_deposit: Uint128::new(DEFAULT_PROPOSAL_DEPOSIT + 9),
+        voting_period: DEFAULT_VOTING_PERIOD + 10,
+        quorum: Decimal::percent(DEFAULT_QUORUM + 11),
+        threshold: Decimal::percent(DEFAULT_THRESHOLD + 12),
+    };
+
     let info = mock_info("addr0001", &[]);
     let msg = ExecuteMsg::UpdateConfig {
         owner: None,
-        quorum: Some(Decimal::percent(20)),
-        threshold: Some(Decimal::percent(75)),
-        voting_period: Some(20000u64),
+        default_poll_config: Some(new_default_poll_config.clone()),
+        migration_poll_config: Some(new_migration_poll_config.clone()),
+        auth_admin_poll_config: Some(new_auth_admin_poll_config.clone()),
         effective_delay: Some(20000u64),
-        proposal_deposit: Some(Uint128::new(123u128)),
         voter_weight: Some(Decimal::percent(1)),
         snapshot_period: Some(60u64),
+        admin_manager: Some("new_admin_mgr0000".to_string()),
     };
 
     let res = execute(deps.as_mut(), mock_env(), info, msg).unwrap();
@@ -2397,25 +2430,25 @@ fn update_config() {
     let res = query(deps.as_ref(), mock_env(), QueryMsg::Config {}).unwrap();
     let config: ConfigResponse = from_binary(&res).unwrap();
     assert_eq!("addr0001", config.owner.as_str());
-    assert_eq!(Decimal::percent(20), config.quorum);
-    assert_eq!(Decimal::percent(75), config.threshold);
-    assert_eq!(20000u64, config.voting_period);
+    assert_eq!(new_default_poll_config, config.default_poll_config);
+    assert_eq!(new_migration_poll_config, config.migration_poll_config);
+    assert_eq!(new_auth_admin_poll_config, config.auth_admin_poll_config);
     assert_eq!(20000u64, config.effective_delay);
-    assert_eq!(123u128, config.proposal_deposit.u128());
     assert_eq!(Decimal::percent(1), config.voter_weight);
     assert_eq!(60u64, config.snapshot_period);
+    assert_eq!("new_admin_mgr0000", config.admin_manager.as_str());
 
     // Unauthorzied err
     let info = mock_info(TEST_CREATOR, &[]);
     let msg = ExecuteMsg::UpdateConfig {
         owner: None,
-        quorum: None,
-        threshold: None,
-        voting_period: None,
+        default_poll_config: None,
+        migration_poll_config: None,
+        auth_admin_poll_config: None,
         effective_delay: None,
-        proposal_deposit: None,
         voter_weight: None,
         snapshot_period: None,
+        admin_manager: None,
     };
 
     let res = execute(deps.as_mut(), mock_env(), info, msg);
@@ -2429,14 +2462,8 @@ fn update_config() {
 fn distribute_voting_rewards() {
     let mut deps = mock_dependencies(&[]);
     let msg = InstantiateMsg {
-        mirror_token: VOTING_TOKEN.to_string(),
-        quorum: Decimal::percent(DEFAULT_QUORUM),
-        threshold: Decimal::percent(DEFAULT_THRESHOLD),
-        voting_period: DEFAULT_VOTING_PERIOD,
-        effective_delay: DEFAULT_EFFECTIVE_DELAY,
-        proposal_deposit: Uint128::new(DEFAULT_PROPOSAL_DEPOSIT),
         voter_weight: Decimal::percent(50), // distribute 50% rewards to voters
-        snapshot_period: DEFAULT_SNAPSHOT_PERIOD,
+        ..init_msg()
     };
 
     let info = mock_info(TEST_CREATOR, &[]);
@@ -2557,14 +2584,8 @@ fn distribute_voting_rewards() {
 fn stake_voting_rewards() {
     let mut deps = mock_dependencies(&[]);
     let msg = InstantiateMsg {
-        mirror_token: VOTING_TOKEN.to_string(),
-        quorum: Decimal::percent(DEFAULT_QUORUM),
-        threshold: Decimal::percent(DEFAULT_THRESHOLD),
-        voting_period: DEFAULT_VOTING_PERIOD,
-        effective_delay: DEFAULT_EFFECTIVE_DELAY,
-        proposal_deposit: Uint128::new(DEFAULT_PROPOSAL_DEPOSIT),
         voter_weight: Decimal::percent(50), // distribute 50% rewards to voters
-        snapshot_period: DEFAULT_SNAPSHOT_PERIOD,
+        ..init_msg()
     };
 
     let info = mock_info(TEST_CREATOR, &[]);
@@ -2710,14 +2731,8 @@ fn stake_voting_rewards() {
 fn distribute_voting_rewards_with_multiple_active_polls_and_voters() {
     let mut deps = mock_dependencies(&[]);
     let msg = InstantiateMsg {
-        mirror_token: VOTING_TOKEN.to_string(),
-        quorum: Decimal::percent(DEFAULT_QUORUM),
-        threshold: Decimal::percent(DEFAULT_THRESHOLD),
-        voting_period: DEFAULT_VOTING_PERIOD,
-        effective_delay: DEFAULT_EFFECTIVE_DELAY,
-        proposal_deposit: Uint128::new(DEFAULT_PROPOSAL_DEPOSIT),
         voter_weight: Decimal::percent(50), // distribute 50% rewards to voters
-        snapshot_period: DEFAULT_SNAPSHOT_PERIOD,
+        ..init_msg()
     };
     let info = mock_info(TEST_CREATOR, &[]);
     let _res = instantiate(deps.as_mut(), mock_env(), info, msg)
@@ -2899,14 +2914,8 @@ fn distribute_voting_rewards_with_multiple_active_polls_and_voters() {
 fn distribute_voting_rewards_only_to_polls_in_progress() {
     let mut deps = mock_dependencies(&[]);
     let msg = InstantiateMsg {
-        mirror_token: VOTING_TOKEN.to_string(),
-        quorum: Decimal::percent(DEFAULT_QUORUM),
-        threshold: Decimal::percent(DEFAULT_THRESHOLD),
-        voting_period: DEFAULT_VOTING_PERIOD,
-        effective_delay: DEFAULT_EFFECTIVE_DELAY,
-        proposal_deposit: Uint128::new(DEFAULT_PROPOSAL_DEPOSIT),
         voter_weight: Decimal::percent(50), // distribute 50% rewards to voters
-        snapshot_period: DEFAULT_SNAPSHOT_PERIOD,
+        ..init_msg()
     };
     let info = mock_info(TEST_CREATOR, &[]);
     let _res = instantiate(deps.as_mut(), mock_env(), info, msg)
@@ -3033,14 +3042,8 @@ fn distribute_voting_rewards_only_to_polls_in_progress() {
 fn test_staking_and_voting_rewards() {
     let mut deps = mock_dependencies(&[]);
     let msg = InstantiateMsg {
-        mirror_token: VOTING_TOKEN.to_string(),
-        quorum: Decimal::percent(DEFAULT_QUORUM),
-        threshold: Decimal::percent(DEFAULT_THRESHOLD),
-        voting_period: DEFAULT_VOTING_PERIOD,
-        effective_delay: DEFAULT_EFFECTIVE_DELAY,
-        proposal_deposit: Uint128::new(DEFAULT_PROPOSAL_DEPOSIT),
         voter_weight: Decimal::percent(50), // distribute 50% rewards to voters
-        snapshot_period: DEFAULT_SNAPSHOT_PERIOD,
+        ..init_msg()
     };
     let info = mock_info(TEST_CREATOR, &[]);
     let _res = instantiate(deps.as_mut(), mock_env(), info, msg)
@@ -3261,16 +3264,7 @@ fn test_staking_and_voting_rewards() {
 #[test]
 fn test_abstain_votes_theshold() {
     let mut deps = mock_dependencies(&[]);
-    let msg = InstantiateMsg {
-        mirror_token: VOTING_TOKEN.to_string(),
-        quorum: Decimal::percent(DEFAULT_QUORUM),
-        threshold: Decimal::percent(DEFAULT_THRESHOLD),
-        voting_period: DEFAULT_VOTING_PERIOD,
-        effective_delay: DEFAULT_EFFECTIVE_DELAY,
-        proposal_deposit: Uint128::new(DEFAULT_PROPOSAL_DEPOSIT),
-        voter_weight: Decimal::percent(50), // distribute 50% rewards to voters
-        snapshot_period: DEFAULT_SNAPSHOT_PERIOD,
-    };
+    let msg = init_msg();
 
     let info = mock_info(TEST_CREATOR, &[]);
     let _res = instantiate(deps.as_mut(), mock_env(), info, msg)
@@ -3383,16 +3377,7 @@ fn test_abstain_votes_theshold() {
 #[test]
 fn test_abstain_votes_quorum() {
     let mut deps = mock_dependencies(&[]);
-    let msg = InstantiateMsg {
-        mirror_token: VOTING_TOKEN.to_string(),
-        quorum: Decimal::percent(DEFAULT_QUORUM),
-        threshold: Decimal::percent(DEFAULT_THRESHOLD),
-        voting_period: DEFAULT_VOTING_PERIOD,
-        effective_delay: DEFAULT_EFFECTIVE_DELAY,
-        proposal_deposit: Uint128::new(DEFAULT_PROPOSAL_DEPOSIT),
-        voter_weight: Decimal::percent(50), // distribute 50% rewards to voters
-        snapshot_period: DEFAULT_SNAPSHOT_PERIOD,
-    };
+    let msg = init_msg();
 
     let info = mock_info(TEST_CREATOR, &[]);
     let _res = instantiate(deps.as_mut(), mock_env(), info, msg)
@@ -3758,7 +3743,7 @@ fn snapshot_poll() {
     )
     .unwrap_err();
     assert_eq!(
-        StdError::generic_err("Cannot snapshot at this height",),
+        StdError::generic_err("Cannot snapshot at this time",),
         snapshot_err
     );
 
@@ -4327,14 +4312,8 @@ fn happy_days_end_poll_with_controlled_quorum() {
 fn test_unstake_before_claiming_voting_rewards() {
     let mut deps = mock_dependencies(&[]);
     let msg = InstantiateMsg {
-        mirror_token: VOTING_TOKEN.to_string(),
-        quorum: Decimal::percent(DEFAULT_QUORUM),
-        threshold: Decimal::percent(DEFAULT_THRESHOLD),
-        voting_period: DEFAULT_VOTING_PERIOD,
-        effective_delay: DEFAULT_EFFECTIVE_DELAY,
-        proposal_deposit: Uint128::new(DEFAULT_PROPOSAL_DEPOSIT),
         voter_weight: Decimal::percent(50),
-        snapshot_period: DEFAULT_SNAPSHOT_PERIOD,
+        ..init_msg()
     };
 
     let info = mock_info(TEST_CREATOR, &[]);

--- a/contracts/mirror_mint/Cargo.toml
+++ b/contracts/mirror_mint/Cargo.toml
@@ -38,6 +38,7 @@ cw20 = { version = "0.8.0" }
 cosmwasm-std = { version = "0.16.0", features = ["iterator"] }
 cosmwasm-storage = { version = "0.16.0", features = ["iterator"] }
 mirror-protocol = { version = "2.1.1", path = "../../packages/mirror_protocol" }
+tefi-oracle = { version = "0.1.0", path = "../../packages/tefi_oracle" }
 terraswap = "2.4.0"
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/contracts/mirror_mint/schema/asset_config_response.json
+++ b/contracts/mirror_mint/schema/asset_config_response.json
@@ -48,7 +48,8 @@
       "required": [
         "min_collateral_ratio_after_ipo",
         "mint_end",
-        "pre_ipo_price"
+        "pre_ipo_price",
+        "trigger_addr"
       ],
       "properties": {
         "min_collateral_ratio_after_ipo": {
@@ -61,6 +62,9 @@
         },
         "pre_ipo_price": {
           "$ref": "#/definitions/Decimal"
+        },
+        "trigger_addr": {
+          "type": "string"
         }
       }
     }

--- a/contracts/mirror_mint/schema/cw20_hook_msg.json
+++ b/contracts/mirror_mint/schema/cw20_hook_msg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Cw20HookMsg",
-  "anyOf": [
+  "oneOf": [
     {
       "type": "object",
       "required": [
@@ -103,7 +103,7 @@
   "definitions": {
     "AssetInfo": {
       "description": "AssetInfo contract_addr is usually passed from the cw20 hook so we can trust the contract_addr is properly validated.",
-      "anyOf": [
+      "oneOf": [
         {
           "type": "object",
           "required": [

--- a/contracts/mirror_mint/schema/execute_msg.json
+++ b/contracts/mirror_mint/schema/execute_msg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "ExecuteMsg",
-  "anyOf": [
+  "oneOf": [
     {
       "type": "object",
       "required": [
@@ -373,7 +373,7 @@
     },
     "AssetInfo": {
       "description": "AssetInfo contract_addr is usually passed from the cw20 hook so we can trust the contract_addr is properly validated.",
-      "anyOf": [
+      "oneOf": [
         {
           "type": "object",
           "required": [
@@ -449,7 +449,8 @@
       "required": [
         "min_collateral_ratio_after_ipo",
         "mint_end",
-        "pre_ipo_price"
+        "pre_ipo_price",
+        "trigger_addr"
       ],
       "properties": {
         "min_collateral_ratio_after_ipo": {
@@ -462,6 +463,9 @@
         },
         "pre_ipo_price": {
           "$ref": "#/definitions/Decimal"
+        },
+        "trigger_addr": {
+          "type": "string"
         }
       }
     },

--- a/contracts/mirror_mint/schema/position_response.json
+++ b/contracts/mirror_mint/schema/position_response.json
@@ -44,7 +44,7 @@
     },
     "AssetInfo": {
       "description": "AssetInfo contract_addr is usually passed from the cw20 hook so we can trust the contract_addr is properly validated.",
-      "anyOf": [
+      "oneOf": [
         {
           "type": "object",
           "required": [

--- a/contracts/mirror_mint/schema/positions_response.json
+++ b/contracts/mirror_mint/schema/positions_response.json
@@ -31,7 +31,7 @@
     },
     "AssetInfo": {
       "description": "AssetInfo contract_addr is usually passed from the cw20 hook so we can trust the contract_addr is properly validated.",
-      "anyOf": [
+      "oneOf": [
         {
           "type": "object",
           "required": [

--- a/contracts/mirror_mint/schema/query_msg.json
+++ b/contracts/mirror_mint/schema/query_msg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "QueryMsg",
-  "anyOf": [
+  "oneOf": [
     {
       "type": "object",
       "required": [

--- a/contracts/mirror_mint/src/lib.rs
+++ b/contracts/mirror_mint/src/lib.rs
@@ -1,6 +1,7 @@
 mod asserts;
 pub mod contract;
 mod math;
+mod migration;
 mod positions;
 mod querier;
 mod state;

--- a/contracts/mirror_mint/src/migration.rs
+++ b/contracts/mirror_mint/src/migration.rs
@@ -1,0 +1,104 @@
+use cosmwasm_storage::Bucket;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use cosmwasm_std::{CanonicalAddr, Decimal, Order, StdError, StdResult, Storage};
+
+use crate::state::{AssetConfig, PREFIX_ASSET_CONFIG};
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct LegacyAssetConfig {
+    pub token: CanonicalAddr,
+    pub auction_discount: Decimal,
+    pub min_collateral_ratio: Decimal,
+    pub end_price: Option<Decimal>,
+    pub ipo_params: Option<LegacyIPOParams>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct LegacyIPOParams {
+    pub mint_end: u64,
+    pub pre_ipo_price: Decimal,
+    pub min_collateral_ratio_after_ipo: Decimal,
+}
+
+pub fn migrate_asset_configs(storage: &mut dyn Storage) -> StdResult<()> {
+    let mut legacy_asset_configs_bucket: Bucket<LegacyAssetConfig> =
+        Bucket::new(storage, PREFIX_ASSET_CONFIG);
+
+    let mut asset_configs: Vec<(CanonicalAddr, LegacyAssetConfig)> = vec![];
+    for item in legacy_asset_configs_bucket.range(None, None, Order::Ascending) {
+        let (k, p) = item?;
+        asset_configs.push((CanonicalAddr::from(k), p));
+    }
+
+    for (asset, _) in asset_configs.clone().into_iter() {
+        legacy_asset_configs_bucket.remove(asset.as_slice());
+    }
+
+    let mut new_asset_configs_bucket: Bucket<AssetConfig> =
+        Bucket::new(storage, PREFIX_ASSET_CONFIG);
+
+    for (asset, asset_config) in asset_configs.into_iter() {
+        if asset_config.ipo_params.is_some() {
+            return Err(StdError::generic_err(
+                "can not exeucte migration while there is an ipo event",
+            ));
+        }
+        let new_asset_config = &AssetConfig {
+            token: asset_config.token,
+            auction_discount: asset_config.auction_discount,
+            min_collateral_ratio: asset_config.min_collateral_ratio,
+            end_price: asset_config.end_price,
+            ipo_params: None,
+        };
+        new_asset_configs_bucket.save(asset.as_slice(), new_asset_config)?;
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod migrate_tests {
+    use crate::state::read_asset_config;
+
+    use super::*;
+    use cosmwasm_std::{testing::mock_dependencies, Api};
+
+    pub fn asset_configs_old_store(storage: &mut dyn Storage) -> Bucket<LegacyAssetConfig> {
+        Bucket::new(storage, PREFIX_ASSET_CONFIG)
+    }
+
+    #[test]
+    fn test_asset_configs_migration() {
+        let mut deps = mock_dependencies(&[]);
+        let mut legacy_store = asset_configs_old_store(&mut deps.storage);
+
+        let asset_config = LegacyAssetConfig {
+            token: deps.api.addr_canonicalize("mAPPL").unwrap(),
+            auction_discount: Decimal::percent(20),
+            min_collateral_ratio: Decimal::percent(150),
+            end_price: None,
+            ipo_params: None,
+        };
+
+        legacy_store
+            .save(asset_config.token.as_slice(), &asset_config)
+            .unwrap();
+
+        migrate_asset_configs(deps.as_mut().storage).unwrap();
+
+        let new_asset_config: AssetConfig =
+            read_asset_config(deps.as_mut().storage, &asset_config.token).unwrap();
+
+        assert_eq!(
+            new_asset_config,
+            AssetConfig {
+                token: asset_config.token,
+                auction_discount: asset_config.auction_discount,
+                min_collateral_ratio: asset_config.min_collateral_ratio,
+                end_price: asset_config.end_price,
+                ipo_params: None,
+            }
+        );
+    }
+}

--- a/contracts/mirror_mint/src/positions.rs
+++ b/contracts/mirror_mint/src/positions.rs
@@ -48,14 +48,9 @@ pub fn open_position(
     // assert the collateral is listed and has not been migrated/revoked
     let collateral_info_raw: AssetInfoRaw = collateral.info.to_raw(deps.api)?;
     let collateral_oracle: Addr = deps.api.addr_humanize(&config.collateral_oracle)?;
-    let (collateral_price, collateral_multiplier) =
-        assert_revoked_collateral(load_collateral_info(
-            deps.as_ref(),
-            collateral_oracle,
-            &collateral_info_raw,
-            Some(env.block.time.seconds()),
-            Some(env.block.height),
-        )?)?;
+    let (collateral_price, collateral_multiplier) = assert_revoked_collateral(
+        load_collateral_info(deps.as_ref(), collateral_oracle, &collateral_info_raw, true)?,
+    )?;
 
     // assert asset migrated
     let asset_info_raw: AssetInfoRaw = asset_info.to_raw(deps.api)?;
@@ -80,12 +75,7 @@ pub fn open_position(
     }
 
     let oracle: Addr = deps.api.addr_humanize(&config.oracle)?;
-    let asset_price: Decimal = load_asset_price(
-        deps.as_ref(),
-        oracle,
-        &asset_info_raw,
-        Some(env.block.time.seconds()),
-    )?;
+    let asset_price: Decimal = load_asset_price(deps.as_ref(), oracle, &asset_info_raw, true)?;
 
     let asset_price_in_collateral_asset = decimal_division(collateral_price, asset_price);
 
@@ -234,8 +224,7 @@ pub fn deposit(
         deps.as_ref(),
         collateral_oracle,
         &position.collateral.info,
-        None,
-        None,
+        false,
     )?)?;
 
     // assert asset migrated
@@ -259,7 +248,6 @@ pub fn deposit(
 
 pub fn withdraw(
     deps: DepsMut,
-    env: Env,
     sender: Addr,
     position_idx: Uint128,
     collateral: Option<Asset>,
@@ -296,12 +284,7 @@ pub fn withdraw(
 
     let asset_config: AssetConfig = read_asset_config(deps.storage, &asset_token_raw)?;
     let oracle: Addr = deps.api.addr_humanize(&config.oracle)?;
-    let asset_price: Decimal = load_asset_price(
-        deps.as_ref(),
-        oracle,
-        &position.asset.info,
-        Some(env.block.time.seconds()),
-    )?;
+    let asset_price: Decimal = load_asset_price(deps.as_ref(), oracle, &position.asset.info, true)?;
 
     // Fetch collateral info from collateral oracle
     let collateral_oracle: Addr = deps.api.addr_humanize(&config.collateral_oracle)?;
@@ -310,8 +293,7 @@ pub fn withdraw(
             deps.as_ref(),
             collateral_oracle,
             &position.collateral.info,
-            Some(env.block.time.seconds()),
-            Some(env.block.height),
+            true,
         )?;
 
     // ignore multiplier for delisted assets
@@ -409,20 +391,14 @@ pub fn mint(
             deps.as_ref(),
             collateral_oracle,
             &position.collateral.info,
-            Some(env.block.time.seconds()),
-            Some(env.block.height),
+            true,
         )?)?;
 
     // for assets with limited minting period (preIPO assets), assert minting phase
     assert_mint_period(&env, &asset_config)?;
 
     let oracle: Addr = deps.api.addr_humanize(&config.oracle)?;
-    let asset_price: Decimal = load_asset_price(
-        deps.as_ref(),
-        oracle,
-        &position.asset.info,
-        Some(env.block.time.seconds()),
-    )?;
+    let asset_price: Decimal = load_asset_price(deps.as_ref(), oracle, &position.asset.info, true)?;
 
     // Compute new asset amount
     let asset_amount: Uint128 = mint_amount + position.asset.amount;
@@ -583,8 +559,7 @@ pub fn burn(
         deps.as_ref(),
         collateral_oracle,
         &position.collateral.info,
-        Some(env.block.time.seconds()),
-        Some(env.block.height),
+        true,
     )?;
 
     // If the collateral is default denom asset and the asset is deprecated,
@@ -655,12 +630,8 @@ pub fn burn(
             return Err(StdError::generic_err("unauthorized"));
         }
         let oracle = deps.api.addr_humanize(&config.oracle)?;
-        let asset_price: Decimal = load_asset_price(
-            deps.as_ref(),
-            oracle,
-            &asset.info.to_raw(deps.api)?,
-            Some(env.block.time.seconds()),
-        )?;
+        let asset_price: Decimal =
+            load_asset_price(deps.as_ref(), oracle, &asset.info.to_raw(deps.api)?, true)?;
         let collateral_price_in_asset: Decimal = decimal_division(asset_price, collateral_price);
 
         // Subtract the protocol fee from the position's collateral
@@ -738,7 +709,6 @@ pub fn burn(
 
 pub fn auction(
     deps: DepsMut,
-    env: Env,
     sender: Addr,
     position_idx: Uint128,
     asset: Asset,
@@ -766,12 +736,7 @@ pub fn auction(
     }
 
     let oracle: Addr = deps.api.addr_humanize(&config.oracle)?;
-    let asset_price: Decimal = load_asset_price(
-        deps.as_ref(),
-        oracle,
-        &position.asset.info,
-        Some(env.block.time.seconds()),
-    )?;
+    let asset_price: Decimal = load_asset_price(deps.as_ref(), oracle, &position.asset.info, true)?;
 
     // fetch collateral info from collateral oracle
     let collateral_oracle: Addr = deps.api.addr_humanize(&config.collateral_oracle)?;
@@ -779,8 +744,7 @@ pub fn auction(
         deps.as_ref(),
         collateral_oracle,
         &position.collateral.info,
-        Some(env.block.time.seconds()),
-        Some(env.block.height),
+        true,
     )?;
 
     // Compute collateral price in asset unit

--- a/contracts/mirror_mint/src/querier.rs
+++ b/contracts/mirror_mint/src/querier.rs
@@ -1,40 +1,24 @@
 use cosmwasm_std::{
-    to_binary, Addr, Decimal, Deps, QuerierWrapper, QueryRequest, StdError, StdResult, WasmQuery,
+    to_binary, Addr, Decimal, Deps, QuerierWrapper, QueryRequest, StdResult, WasmQuery,
 };
 
-use crate::state::{read_config, read_fixed_price, Config};
-use mirror_protocol::collateral_oracle::{
-    CollateralPriceResponse, QueryMsg as CollateralOracleQueryMsg,
+use crate::{
+    math::decimal_division,
+    state::{read_config, read_fixed_price, Config},
 };
-use mirror_protocol::oracle::{FeederResponse, PriceResponse, QueryMsg as OracleQueryMsg};
+use mirror_protocol::collateral_oracle::{
+    CollateralInfoResponse, CollateralPriceResponse, QueryMsg as CollateralOracleQueryMsg,
+};
+use tefi_oracle::hub::{HubQueryMsg as OracleQueryMsg, PriceResponse};
 use terraswap::asset::AssetInfoRaw;
 
 const PRICE_EXPIRE_TIME: u64 = 60;
-
-pub fn load_oracle_feeder(deps: Deps, contract_addr: Addr, asset_token: Addr) -> StdResult<Addr> {
-    let res: StdResult<FeederResponse> =
-        deps.querier.query(&QueryRequest::Wasm(WasmQuery::Smart {
-            contract_addr: contract_addr.to_string(),
-            msg: to_binary(&OracleQueryMsg::Feeder {
-                asset_token: asset_token.to_string(),
-            })?,
-        }));
-
-    let feeder: Addr = match res {
-        Ok(v) => deps.api.addr_validate(v.feeder.as_str())?,
-        Err(_) => {
-            return Err(StdError::generic_err("Failed to fetch the oracle feeder"));
-        }
-    };
-
-    Ok(feeder)
-}
 
 pub fn load_asset_price(
     deps: Deps,
     oracle: Addr,
     asset: &AssetInfoRaw,
-    block_time: Option<u64>,
+    check_expire: bool,
 ) -> StdResult<Decimal> {
     let config: Config = read_config(deps.storage)?;
 
@@ -49,13 +33,7 @@ pub fn load_asset_price(
             Decimal::one()
         } else {
             // fetch price from oracle
-            query_price(
-                &deps.querier,
-                oracle,
-                asset_denom,
-                config.base_denom,
-                block_time,
-            )?
+            query_price(&deps.querier, oracle, asset_denom, None, check_expire)?
         }
     };
 
@@ -66,8 +44,7 @@ pub fn load_collateral_info(
     deps: Deps,
     collateral_oracle: Addr,
     collateral: &AssetInfoRaw,
-    block_time: Option<u64>,
-    block_height: Option<u64>,
+    check_expire: bool,
 ) -> StdResult<(Decimal, Decimal, bool)> {
     let config: Config = read_config(deps.storage)?;
     let collateral_denom: String = (collateral.to_normal(deps.api)?).to_string();
@@ -84,13 +61,8 @@ pub fn load_collateral_info(
     if let Some(end_price) = end_price {
         // load collateral_multiplier from collateral oracle
         // if asset is revoked, no need to check for old price
-        let (_, collateral_multiplier, _) = query_collateral(
-            &deps.querier,
-            collateral_oracle,
-            collateral_denom,
-            None,
-            block_height,
-        )?;
+        let (collateral_multiplier, _) =
+            query_collateral_info(&deps.querier, collateral_oracle, collateral_denom)?;
 
         Ok((end_price, collateral_multiplier, true))
     } else {
@@ -99,8 +71,7 @@ pub fn load_collateral_info(
             &deps.querier,
             collateral_oracle,
             collateral_denom,
-            block_time,
-            block_height,
+            check_expire,
         )?;
 
         Ok((collateral_oracle_price, collateral_multiplier, is_revoked))
@@ -111,26 +82,37 @@ pub fn query_price(
     querier: &QuerierWrapper,
     oracle: Addr,
     base_asset: String,
-    quote_asset: String,
-    block_time: Option<u64>,
+    quote_asset: Option<String>,
+    check_expire: bool,
 ) -> StdResult<Decimal> {
-    let res: PriceResponse = querier.query(&QueryRequest::Wasm(WasmQuery::Smart {
+    let timeframe: Option<u64> = if check_expire {
+        Some(PRICE_EXPIRE_TIME)
+    } else {
+        None
+    };
+    let base_res: PriceResponse = querier.query(&QueryRequest::Wasm(WasmQuery::Smart {
         contract_addr: oracle.to_string(),
         msg: to_binary(&OracleQueryMsg::Price {
-            base_asset,
-            quote_asset,
+            asset_token: base_asset,
+            timeframe,
         })?,
     }))?;
 
-    if let Some(block_time) = block_time {
-        if res.last_updated_base < (block_time - PRICE_EXPIRE_TIME)
-            || res.last_updated_quote < (block_time - PRICE_EXPIRE_TIME)
-        {
-            return Err(StdError::generic_err("Price is too old"));
-        }
-    }
+    let rate = if let Some(quote_asset) = quote_asset {
+        let quote_res: PriceResponse = querier.query(&QueryRequest::Wasm(WasmQuery::Smart {
+            contract_addr: oracle.to_string(),
+            msg: to_binary(&OracleQueryMsg::Price {
+                asset_token: quote_asset,
+                timeframe,
+            })?,
+        }))?;
 
-    Ok(res.rate)
+        decimal_division(base_res.rate, quote_res.rate)
+    } else {
+        base_res.rate
+    };
+
+    Ok(rate)
 }
 
 // queries the collateral oracle to get the asset rate and multiplier
@@ -138,22 +120,31 @@ pub fn query_collateral(
     querier: &QuerierWrapper,
     collateral_oracle: Addr,
     asset: String,
-    block_time: Option<u64>,
-    block_height: Option<u64>,
+    check_expire: bool,
 ) -> StdResult<(Decimal, Decimal, bool)> {
+    let timeframe: Option<u64> = if check_expire {
+        Some(PRICE_EXPIRE_TIME)
+    } else {
+        None
+    };
     let res: CollateralPriceResponse = querier.query(&QueryRequest::Wasm(WasmQuery::Smart {
         contract_addr: collateral_oracle.to_string(),
-        msg: to_binary(&CollateralOracleQueryMsg::CollateralPrice {
-            asset,
-            block_height,
-        })?,
+        msg: to_binary(&CollateralOracleQueryMsg::CollateralPrice { asset, timeframe })?,
     }))?;
 
-    if let Some(block_time) = block_time {
-        if res.last_updated < (block_time - PRICE_EXPIRE_TIME) {
-            return Err(StdError::generic_err("Collateral price is too old"));
-        }
-    }
-
     Ok((res.rate, res.multiplier, res.is_revoked))
+}
+
+// queries only collateral information (multiplier and is_revoked), without price
+pub fn query_collateral_info(
+    querier: &QuerierWrapper,
+    collateral_oracle: Addr,
+    asset: String,
+) -> StdResult<(Decimal, bool)> {
+    let res: CollateralInfoResponse = querier.query(&QueryRequest::Wasm(WasmQuery::Smart {
+        contract_addr: collateral_oracle.to_string(),
+        msg: to_binary(&CollateralOracleQueryMsg::CollateralAssetInfo { asset })?,
+    }))?;
+
+    Ok((res.multiplier, res.is_revoked))
 }

--- a/contracts/mirror_mint/src/state.rs
+++ b/contracts/mirror_mint/src/state.rs
@@ -9,7 +9,7 @@ use mirror_protocol::mint::IPOParams;
 use std::convert::TryInto;
 use terraswap::asset::{AssetInfoRaw, AssetRaw};
 
-static PREFIX_ASSET_CONFIG: &[u8] = b"asset_config";
+pub static PREFIX_ASSET_CONFIG: &[u8] = b"asset_config";
 static PREFIX_POSITION: &[u8] = b"position";
 static PREFIX_INDEX_BY_USER: &[u8] = b"by_user";
 static PREFIX_INDEX_BY_ASSET: &[u8] = b"by_asset";

--- a/contracts/mirror_mint/src/testing/contract_test.rs
+++ b/contracts/mirror_mint/src/testing/contract_test.rs
@@ -133,7 +133,9 @@ fn register_asset() {
                     contract_addr: "asset0000".to_string(),
                 },
                 multiplier: Decimal::one(),
-                price_source: SourceType::MirrorOracle {},
+                price_source: SourceType::TeFiOracle {
+                    oracle_addr: "oracle0000".to_string(),
+                },
             })
             .unwrap(),
         }))]
@@ -249,6 +251,7 @@ fn update_asset() {
             min_collateral_ratio_after_ipo: Decimal::percent(150),
             mint_end: 10000u64,
             pre_ipo_price: Decimal::percent(1),
+            trigger_addr: "ipotrigger0000".to_string(),
         }),
     };
     let info = mock_info("owner0000", &[]);
@@ -272,7 +275,8 @@ fn update_asset() {
             ipo_params: Some(IPOParams {
                 min_collateral_ratio_after_ipo: Decimal::percent(150),
                 mint_end: 10000u64,
-                pre_ipo_price: Decimal::percent(1)
+                pre_ipo_price: Decimal::percent(1),
+                trigger_addr: "ipotrigger0000".to_string(),
             }),
         }
     );

--- a/contracts/mirror_mint/src/testing/mock_querier.rs
+++ b/contracts/mirror_mint/src/testing/mock_querier.rs
@@ -7,9 +7,8 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-use crate::math::decimal_division;
 use mirror_protocol::collateral_oracle::CollateralPriceResponse;
-use mirror_protocol::oracle::{FeederResponse, PriceResponse};
+use tefi_oracle::hub::PriceResponse;
 use terra_cosmwasm::{TaxCapResponse, TaxRateResponse, TerraQuery, TerraQueryWrapper, TerraRoute};
 use terraswap::{asset::AssetInfo, asset::PairInfo};
 
@@ -34,7 +33,6 @@ pub struct WasmMockQuerier {
     oracle_price_querier: OraclePriceQuerier,
     collateral_oracle_querier: CollateralOracleQuerier,
     terraswap_pair_querier: TerraswapPairQuerier,
-    oracle_querier: OracleQuerier,
 }
 
 #[derive(Clone, Default)]
@@ -141,27 +139,6 @@ pub(crate) fn paris_to_map(pairs: &[(&String, &String, &String)]) -> HashMap<Str
     pairs_map
 }
 
-#[derive(Clone, Default)]
-pub struct OracleQuerier {
-    feeders: HashMap<String, String>,
-}
-
-impl OracleQuerier {
-    pub fn new(feeders: &[(&String, &String)]) -> Self {
-        OracleQuerier {
-            feeders: address_pair_to_map(feeders),
-        }
-    }
-}
-
-pub(crate) fn address_pair_to_map(address_pair: &[(&String, &String)]) -> HashMap<String, String> {
-    let mut address_pair_map: HashMap<String, String> = HashMap::new();
-    for (addr1, addr2) in address_pair.iter() {
-        address_pair_map.insert(addr1.to_string(), addr2.to_string());
-    }
-    address_pair_map
-}
-
 impl Querier for WasmMockQuerier {
     fn raw_query(&self, bin_request: &[u8]) -> QuerierResult {
         // MockQuerier doesn't support Custom, so we ignore it completely here
@@ -182,17 +159,14 @@ impl Querier for WasmMockQuerier {
 #[serde(rename_all = "snake_case")]
 pub enum MockQueryMsg {
     Price {
-        base_asset: String,
-        quote_asset: String,
+        asset_token: String,
+        timeframe: Option<u64>,
     },
     CollateralPrice {
         asset: String,
     },
     Pair {
         asset_infos: [AssetInfo; 2],
-    },
-    Feeder {
-        asset_token: String,
     },
 }
 
@@ -229,23 +203,14 @@ impl WasmMockQuerier {
                 msg,
             }) => match from_binary(msg).unwrap() {
                 MockQueryMsg::Price {
-                    base_asset,
-                    quote_asset,
-                } => match self.oracle_price_querier.oracle_price.get(&base_asset) {
+                    asset_token,
+                    timeframe: _,
+                } => match self.oracle_price_querier.oracle_price.get(&asset_token) {
                     Some(base_price) => {
-                        match self.oracle_price_querier.oracle_price.get(&quote_asset) {
-                            Some(quote_price) => {
-                                SystemResult::Ok(ContractResult::from(to_binary(&PriceResponse {
-                                    rate: decimal_division(*base_price, *quote_price),
-                                    last_updated_base: 1000u64,
-                                    last_updated_quote: 1000u64,
-                                })))
-                            }
-                            None => SystemResult::Err(SystemError::InvalidRequest {
-                                error: "No oracle price exists".to_string(),
-                                request: msg.as_slice().into(),
-                            }),
-                        }
+                        SystemResult::Ok(ContractResult::from(to_binary(&PriceResponse {
+                            rate: *base_price,
+                            last_updated: 1000u64,
+                        })))
                     }
                     None => SystemResult::Err(SystemError::InvalidRequest {
                         error: "No oracle price exists".to_string(),
@@ -288,22 +253,6 @@ impl WasmMockQuerier {
                         }),
                     }
                 }
-                MockQueryMsg::Feeder { asset_token } => {
-                    match self.oracle_querier.feeders.get(&asset_token) {
-                        Some(v) => {
-                            SystemResult::Ok(ContractResult::from(to_binary(&FeederResponse {
-                                asset_token,
-                                feeder: v.to_string(),
-                            })))
-                        }
-                        None => {
-                            return SystemResult::Err(SystemError::InvalidRequest {
-                                error: format!("Oracle Feeder is not found for {}", asset_token),
-                                request: msg.as_slice().into(),
-                            })
-                        }
-                    }
-                }
             },
             _ => self.base.handle_query(request),
         }
@@ -318,7 +267,6 @@ impl WasmMockQuerier {
             oracle_price_querier: OraclePriceQuerier::default(),
             collateral_oracle_querier: CollateralOracleQuerier::default(),
             terraswap_pair_querier: TerraswapPairQuerier::default(),
-            oracle_querier: OracleQuerier::default(),
         }
     }
 
@@ -343,9 +291,5 @@ impl WasmMockQuerier {
     // configure the terraswap factory pair mock querier
     pub fn with_terraswap_pair(&mut self, pairs: &[(&String, &String, &String)]) {
         self.terraswap_pair_querier = TerraswapPairQuerier::new(pairs);
-    }
-
-    pub fn with_oracle_feeders(&mut self, feeders: &[(&String, &String)]) {
-        self.oracle_querier = OracleQuerier::new(feeders);
     }
 }

--- a/contracts/mirror_mint/src/testing/pre_ipo_test.rs
+++ b/contracts/mirror_mint/src/testing/pre_ipo_test.rs
@@ -36,8 +36,6 @@ fn pre_ipo_assets() {
             &Decimal::from_ratio(10u128, 1u128),
         ),
     ]);
-    deps.querier
-        .with_oracle_feeders(&[(&"preIPOAsset0000".to_string(), &"feeder0000".to_string())]);
 
     let base_denom = "uusd".to_string();
 
@@ -67,6 +65,7 @@ fn pre_ipo_assets() {
             mint_end,
             min_collateral_ratio_after_ipo: Decimal::percent(150),
             pre_ipo_price: Decimal::percent(100),
+            trigger_addr: "ipotrigger0000".to_string(),
         }),
     };
 
@@ -226,7 +225,7 @@ fn pre_ipo_assets() {
     ///////////////////
     current_time = creator_env.block.time.plus_seconds(20).seconds();
 
-    // register migration initiated by the feeder
+    // register migration initiated by the trigger address
     let msg = ExecuteMsg::TriggerIPO {
         asset_token: "preIPOAsset0000".to_string(),
     };
@@ -238,7 +237,7 @@ fn pre_ipo_assets() {
 
     // succesfull attempt
     let env = mock_env_with_block_time(current_time);
-    let info = mock_info("feeder0000", &[]);
+    let info = mock_info("ipotrigger0000", &[]);
     let res = execute(deps.as_mut(), env, info, msg).unwrap();
 
     assert_eq!(
@@ -258,7 +257,9 @@ fn pre_ipo_assets() {
                     contract_addr: "preIPOAsset0000".to_string(),
                 },
                 multiplier: Decimal::one(),
-                price_source: SourceType::MirrorOracle {},
+                price_source: SourceType::TeFiOracle {
+                    oracle_addr: "oracle0000".to_string(),
+                },
             })
             .unwrap(),
         }))]
@@ -273,7 +274,7 @@ fn pre_ipo_assets() {
     )
     .unwrap();
     let asset_config_res: AssetConfigResponse = from_binary(&res).unwrap();
-    // traditional asset configuration, feeder feeds real price
+    // traditional asset configuration, price is obtained from the oracle
     assert_eq!(
         asset_config_res,
         AssetConfigResponse {

--- a/contracts/mirror_staking/schema/config_response.json
+++ b/contracts/mirror_staking/schema/config_response.json
@@ -34,7 +34,7 @@
       "minimum": 0.0
     },
     "short_reward_contract": {
-      "$ref": "#/definitions/HumanAddr"
+      "type": "string"
     },
     "terraswap_factory": {
       "type": "string"

--- a/contracts/mirror_staking/schema/cw20_hook_msg.json
+++ b/contracts/mirror_staking/schema/cw20_hook_msg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Cw20HookMsg",
-  "anyOf": [
+  "oneOf": [
     {
       "type": "object",
       "required": [

--- a/contracts/mirror_staking/schema/execute_msg.json
+++ b/contracts/mirror_staking/schema/execute_msg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "ExecuteMsg",
-  "anyOf": [
+  "oneOf": [
     {
       "type": "object",
       "required": [
@@ -39,13 +39,9 @@
               "minimum": 0.0
             },
             "short_reward_contract": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/HumanAddr"
-                },
-                {
-                  "type": "null"
-                }
+              "type": [
+                "string",
+                "null"
               ]
             }
           }
@@ -70,6 +66,30 @@
               "type": "string"
             },
             "staking_token": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "deprecate_staking_token"
+      ],
+      "properties": {
+        "deprecate_staking_token": {
+          "type": "object",
+          "required": [
+            "asset_token",
+            "new_staking_token"
+          ],
+          "properties": {
+            "asset_token": {
+              "type": "string"
+            },
+            "new_staking_token": {
               "type": "string"
             }
           }
@@ -275,10 +295,6 @@
     }
   ],
   "definitions": {
-    "Addr": {
-      "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
-      "type": "string"
-    },
     "Asset": {
       "type": "object",
       "required": [
@@ -296,7 +312,7 @@
     },
     "AssetInfo": {
       "description": "AssetInfo contract_addr is usually passed from the cw20 hook so we can trust the contract_addr is properly validated.",
-      "anyOf": [
+      "oneOf": [
         {
           "type": "object",
           "required": [
@@ -310,7 +326,7 @@
               ],
               "properties": {
                 "contract_addr": {
-                  "$ref": "#/definitions/Addr"
+                  "type": "string"
                 }
               }
             }

--- a/contracts/mirror_staking/schema/instantiate_msg.json
+++ b/contracts/mirror_staking/schema/instantiate_msg.json
@@ -34,7 +34,7 @@
       "minimum": 0.0
     },
     "short_reward_contract": {
-      "$ref": "#/definitions/HumanAddr"
+      "type": "string"
     },
     "terraswap_factory": {
       "type": "string"

--- a/contracts/mirror_staking/schema/migrate_msg.json
+++ b/contracts/mirror_staking/schema/migrate_msg.json
@@ -4,15 +4,15 @@
   "description": "We currently take no arguments for migrations",
   "type": "object",
   "required": [
-    "network",
-    "short_reward_contract"
+    "base_denom",
+    "mint_contract",
+    "oracle_contract",
+    "premium_min_update_interval",
+    "terraswap_factory"
   ],
   "properties": {
     "base_denom": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": "string"
     },
     "mint_contract": {
       "type": "string"
@@ -21,22 +21,12 @@
       "type": "string"
     },
     "premium_min_update_interval": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": "integer",
       "format": "uint64",
       "minimum": 0.0
     },
     "terraswap_factory": {
       "type": "string"
-    },
-    "Network": {
-      "type": "string",
-      "enum": [
-        "mainnet",
-        "test_net"
-      ]
     }
   }
 }

--- a/contracts/mirror_staking/schema/migrate_msg.json
+++ b/contracts/mirror_staking/schema/migrate_msg.json
@@ -4,28 +4,14 @@
   "description": "We currently take no arguments for migrations",
   "type": "object",
   "required": [
-    "base_denom",
-    "mint_contract",
-    "oracle_contract",
-    "premium_min_update_interval",
-    "terraswap_factory"
+    "asset_token_to_deprecate",
+    "new_staking_token"
   ],
   "properties": {
-    "base_denom": {
+    "asset_token_to_deprecate": {
       "type": "string"
     },
-    "mint_contract": {
-      "type": "string"
-    },
-    "oracle_contract": {
-      "type": "string"
-    },
-    "premium_min_update_interval": {
-      "type": "integer",
-      "format": "uint64",
-      "minimum": 0.0
-    },
-    "terraswap_factory": {
+    "new_staking_token": {
       "type": "string"
     }
   }

--- a/contracts/mirror_staking/schema/pool_info_response.json
+++ b/contracts/mirror_staking/schema/pool_info_response.json
@@ -19,6 +19,22 @@
     "asset_token": {
       "type": "string"
     },
+    "migration_deprecated_staking_token": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "migration_index_snapshot": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/Decimal"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "pending_reward": {
       "$ref": "#/definitions/Uint128"
     },

--- a/contracts/mirror_staking/schema/query_msg.json
+++ b/contracts/mirror_staking/schema/query_msg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "QueryMsg",
-  "anyOf": [
+  "oneOf": [
     {
       "type": "object",
       "required": [

--- a/contracts/mirror_staking/schema/reward_info_response.json
+++ b/contracts/mirror_staking/schema/reward_info_response.json
@@ -38,6 +38,12 @@
         },
         "pending_reward": {
           "$ref": "#/definitions/Uint128"
+        },
+        "should_migrate": {
+          "type": [
+            "boolean",
+            "null"
+          ]
         }
       }
     },

--- a/contracts/mirror_staking/src/contract.rs
+++ b/contracts/mirror_staking/src/contract.rs
@@ -1,8 +1,11 @@
+use crate::migration::migrate_pool_infos;
 use crate::rewards::{adjust_premium, deposit_reward, query_reward_info, withdraw_reward};
 use crate::staking::{
     auto_stake, auto_stake_hook, bond, decrease_short_token, increase_short_token, unbond,
 };
-use crate::state::{read_config, read_pool_info, store_config, store_pool_info, Config, PoolInfo};
+use crate::state::{
+    read_config, read_pool_info, store_config, store_pool_info, Config, MigrationParams, PoolInfo,
+};
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
@@ -77,6 +80,18 @@ pub fn execute(deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg) -> S
                 info,
                 api.addr_validate(&asset_token)?,
                 api.addr_validate(&staking_token)?,
+            )
+        }
+        ExecuteMsg::DeprecateStakingToken {
+            asset_token,
+            new_staking_token,
+        } => {
+            let api = deps.api;
+            deprecate_staking_token(
+                deps,
+                info,
+                api.addr_validate(&asset_token)?,
+                api.addr_validate(&new_staking_token)?,
             )
         }
         ExecuteMsg::Unbond {
@@ -254,12 +269,56 @@ fn register_asset(
             premium_rate: Decimal::zero(),
             short_reward_weight: Decimal::zero(),
             premium_updated_time: 0,
+            migration_params: None,
         },
     )?;
 
     Ok(Response::new().add_attributes(vec![
         attr("action", "register_asset"),
         attr("asset_token", asset_token.as_str()),
+    ]))
+}
+
+fn deprecate_staking_token(
+    deps: DepsMut,
+    info: MessageInfo,
+    asset_token: Addr,
+    new_staking_token: Addr,
+) -> StdResult<Response> {
+    let config: Config = read_config(deps.storage)?;
+    let asset_token_raw = deps.api.addr_canonicalize(asset_token.as_str())?;
+
+    if config.owner != deps.api.addr_canonicalize(info.sender.as_str())? {
+        return Err(StdError::generic_err("unauthorized"));
+    }
+
+    let mut pool_info: PoolInfo = read_pool_info(deps.storage, &asset_token_raw)?;
+
+    if pool_info.migration_params.is_some() {
+        return Err(StdError::generic_err(
+            "This asset LP token has already been migrated",
+        ));
+    }
+
+    let depcrecated_token_addr: Addr = deps.api.addr_humanize(&pool_info.staking_token)?;
+
+    pool_info.total_bond_amount = Uint128::zero();
+    pool_info.migration_params = Some(MigrationParams {
+        index_snapshot: pool_info.reward_index,
+        deprecated_staking_token: pool_info.staking_token,
+    });
+    pool_info.staking_token = deps.api.addr_canonicalize(new_staking_token.as_str())?;
+
+    store_pool_info(deps.storage, &asset_token_raw, &pool_info)?;
+
+    Ok(Response::new().add_attributes(vec![
+        attr("action", "depcrecate_staking_token"),
+        attr("asset_token", asset_token.to_string()),
+        attr(
+            "deprecated_staking_token",
+            depcrecated_token_addr.to_string(),
+        ),
+        attr("new_staking_token", new_staking_token.to_string()),
     ]))
 }
 
@@ -315,10 +374,21 @@ pub fn query_pool_info(deps: Deps, asset_token: String) -> StdResult<PoolInfoRes
         premium_rate: pool_info.premium_rate,
         short_reward_weight: pool_info.short_reward_weight,
         premium_updated_time: pool_info.premium_updated_time,
+        migration_deprecated_staking_token: pool_info.migration_params.clone().map(|params| {
+            deps.api
+                .addr_humanize(&params.deprecated_staking_token)
+                .unwrap()
+                .to_string()
+        }),
+        migration_index_snapshot: pool_info
+            .migration_params
+            .map(|params| params.index_snapshot),
     })
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]
-pub fn migrate(_deps: DepsMut, _env: Env, _msg: MigrateMsg) -> StdResult<Response> {
+pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> StdResult<Response> {
+    migrate_pool_infos(deps.storage)?;
+
     Ok(Response::default())
 }

--- a/contracts/mirror_staking/src/contract.rs
+++ b/contracts/mirror_staking/src/contract.rs
@@ -300,7 +300,7 @@ fn deprecate_staking_token(
         ));
     }
 
-    let depcrecated_token_addr: Addr = deps.api.addr_humanize(&pool_info.staking_token)?;
+    let deprecated_token_addr: Addr = deps.api.addr_humanize(&pool_info.staking_token)?;
 
     pool_info.total_bond_amount = Uint128::zero();
     pool_info.migration_params = Some(MigrationParams {
@@ -316,7 +316,7 @@ fn deprecate_staking_token(
         attr("asset_token", asset_token.to_string()),
         attr(
             "deprecated_staking_token",
-            depcrecated_token_addr.to_string(),
+            deprecated_token_addr.to_string(),
         ),
         attr("new_staking_token", new_staking_token.to_string()),
     ]))

--- a/contracts/mirror_staking/src/lib.rs
+++ b/contracts/mirror_staking/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod contract;
 mod math;
+mod migration;
 mod querier;
 mod rewards;
 mod staking;

--- a/contracts/mirror_staking/src/migration.rs
+++ b/contracts/mirror_staking/src/migration.rs
@@ -1,0 +1,142 @@
+use cosmwasm_std::{CanonicalAddr, Decimal, Order, StdResult, Storage, Uint128};
+use cosmwasm_storage::Bucket;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::state::{PoolInfo, PREFIX_POOL_INFO};
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct LegacyPoolInfo {
+    pub staking_token: CanonicalAddr,
+    pub pending_reward: Uint128,
+    pub short_pending_reward: Uint128,
+    pub total_bond_amount: Uint128,
+    pub total_short_amount: Uint128,
+    pub reward_index: Decimal,
+    pub short_reward_index: Decimal,
+    pub premium_rate: Decimal,
+    pub short_reward_weight: Decimal,
+    pub premium_updated_time: u64,
+}
+
+pub fn migrate_pool_infos(storage: &mut dyn Storage) -> StdResult<()> {
+    let mut legacy_pool_infos_bucket: Bucket<LegacyPoolInfo> =
+        Bucket::new(storage, PREFIX_POOL_INFO);
+
+    let mut pools: Vec<(CanonicalAddr, LegacyPoolInfo)> = vec![];
+    for item in legacy_pool_infos_bucket.range(None, None, Order::Ascending) {
+        let (k, p) = item?;
+        pools.push((CanonicalAddr::from(k), p));
+    }
+
+    for (asset, _) in pools.clone().into_iter() {
+        legacy_pool_infos_bucket.remove(asset.as_slice());
+    }
+
+    let mut new_pool_infos_bucket: Bucket<PoolInfo> = Bucket::new(storage, PREFIX_POOL_INFO);
+
+    for (asset, legacy_pool_info) in pools.into_iter() {
+        let new_pool_info = &PoolInfo {
+            staking_token: legacy_pool_info.staking_token,
+            total_bond_amount: legacy_pool_info.total_bond_amount,
+            total_short_amount: legacy_pool_info.total_short_amount,
+            reward_index: legacy_pool_info.reward_index,
+            short_reward_index: legacy_pool_info.short_reward_index,
+            pending_reward: legacy_pool_info.pending_reward,
+            short_pending_reward: legacy_pool_info.short_pending_reward,
+            premium_rate: legacy_pool_info.premium_rate,
+            short_reward_weight: legacy_pool_info.short_reward_weight,
+            premium_updated_time: legacy_pool_info.premium_updated_time,
+            migration_params: None,
+        };
+        new_pool_infos_bucket.save(asset.as_slice(), new_pool_info)?;
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod migrate_tests {
+    use crate::state::read_pool_info;
+
+    use super::*;
+    use cosmwasm_std::{testing::mock_dependencies, Api};
+
+    pub fn pool_infos_old_store(storage: &mut dyn Storage) -> Bucket<LegacyPoolInfo> {
+        Bucket::new(storage, PREFIX_POOL_INFO)
+    }
+
+    #[test]
+    fn test_pool_infos_migration() {
+        let mut deps = mock_dependencies(&[]);
+        let mut legacy_store = pool_infos_old_store(&mut deps.storage);
+
+        let asset_1 = deps.api.addr_canonicalize("asset1").unwrap();
+        let pool_info_1 = LegacyPoolInfo {
+            staking_token: deps.api.addr_canonicalize("staking1").unwrap(),
+            total_bond_amount: Uint128::from(1u128),
+            total_short_amount: Uint128::from(1u128),
+            reward_index: Decimal::percent(1),
+            short_reward_index: Decimal::percent(1),
+            pending_reward: Uint128::from(1u128),
+            short_pending_reward: Uint128::from(1u128),
+            premium_rate: Decimal::percent(1),
+            short_reward_weight: Decimal::percent(1),
+            premium_updated_time: 1,
+        };
+        let asset_2 = deps.api.addr_canonicalize("asset2").unwrap();
+        let pool_info_2 = LegacyPoolInfo {
+            staking_token: deps.api.addr_canonicalize("staking2").unwrap(),
+            total_bond_amount: Uint128::from(2u128),
+            total_short_amount: Uint128::from(2u128),
+            reward_index: Decimal::percent(2),
+            short_reward_index: Decimal::percent(2),
+            pending_reward: Uint128::from(2u128),
+            short_pending_reward: Uint128::from(2u128),
+            premium_rate: Decimal::percent(2),
+            short_reward_weight: Decimal::percent(2),
+            premium_updated_time: 2,
+        };
+
+        legacy_store.save(asset_1.as_slice(), &pool_info_1).unwrap();
+        legacy_store.save(asset_2.as_slice(), &pool_info_2).unwrap();
+
+        migrate_pool_infos(deps.as_mut().storage).unwrap();
+
+        let new_pool_info_1: PoolInfo = read_pool_info(deps.as_mut().storage, &asset_1).unwrap();
+        let new_pool_info_2: PoolInfo = read_pool_info(deps.as_mut().storage, &asset_2).unwrap();
+
+        assert_eq!(
+            new_pool_info_1,
+            PoolInfo {
+                staking_token: deps.api.addr_canonicalize("staking1").unwrap(),
+                total_bond_amount: Uint128::from(1u128),
+                total_short_amount: Uint128::from(1u128),
+                reward_index: Decimal::percent(1),
+                short_reward_index: Decimal::percent(1),
+                pending_reward: Uint128::from(1u128),
+                short_pending_reward: Uint128::from(1u128),
+                premium_rate: Decimal::percent(1),
+                short_reward_weight: Decimal::percent(1),
+                premium_updated_time: 1,
+                migration_params: None,
+            }
+        );
+        assert_eq!(
+            new_pool_info_2,
+            PoolInfo {
+                staking_token: deps.api.addr_canonicalize("staking2").unwrap(),
+                total_bond_amount: Uint128::from(2u128),
+                total_short_amount: Uint128::from(2u128),
+                reward_index: Decimal::percent(2),
+                short_reward_index: Decimal::percent(2),
+                pending_reward: Uint128::from(2u128),
+                short_pending_reward: Uint128::from(2u128),
+                premium_rate: Decimal::percent(2),
+                short_reward_weight: Decimal::percent(2),
+                premium_updated_time: 2,
+                migration_params: None,
+            }
+        )
+    }
+}

--- a/contracts/mirror_staking/src/staking.rs
+++ b/contracts/mirror_staking/src/staking.rs
@@ -5,8 +5,8 @@ use cosmwasm_std::{
 
 use crate::rewards::before_share_change;
 use crate::state::{
-    read_config, read_pool_info, rewards_read, rewards_store, store_pool_info, Config, PoolInfo,
-    RewardInfo,
+    read_config, read_is_migrated, read_pool_info, rewards_read, rewards_store, store_is_migrated,
+    store_pool_info, Config, PoolInfo, RewardInfo,
 };
 
 use cw20::Cw20ExecuteMsg;
@@ -54,6 +54,7 @@ pub fn unbond(
         amount,
         false,
     )?;
+    let staking_token_addr: Addr = deps.api.addr_humanize(&staking_token)?;
 
     Ok(Response::new()
         .add_message(CosmosMsg::Wasm(WasmMsg::Execute {
@@ -69,6 +70,7 @@ pub fn unbond(
             attr("staker_addr", staker_addr.as_str()),
             attr("asset_token", asset_token.as_str()),
             attr("amount", amount.to_string()),
+            attr("staking_token", staking_token_addr.as_str()),
         ]))
 }
 
@@ -302,8 +304,21 @@ fn _increase_bond_amount(
             pending_reward: Uint128::zero(),
         });
 
+    if !is_short
+        && pool_info.migration_params.is_some()
+        && !read_is_migrated(storage, asset_token, staker_addr)
+    {
+        return Err(StdError::generic_err("The LP token for this asset has been deprecated, withdraw all your deprecated tokens to migrate your position"));
+    }
+
+    let pool_index = if is_short {
+        pool_info.short_reward_index
+    } else {
+        pool_info.reward_index
+    };
+
     // Withdraw reward to pending reward; before changing share
-    before_share_change(&pool_info, &mut reward_info, is_short)?;
+    before_share_change(pool_index, &mut reward_info)?;
 
     // Increase total short or bond amount
     if is_short {
@@ -313,6 +328,7 @@ fn _increase_bond_amount(
     }
 
     reward_info.bond_amount += amount;
+
     rewards_store(storage, staker_addr, is_short).save(asset_token.as_slice(), &reward_info)?;
     store_pool_info(storage, asset_token, &pool_info)?;
 
@@ -334,19 +350,43 @@ fn _decrease_bond_amount(
         return Err(StdError::generic_err("Cannot unbond more than bond amount"));
     }
 
+    // if the lp token was migrated, and the user did not close their position yet, cap the reward at the snapshot
+    let should_migrate = !read_is_migrated(storage, asset_token, staker_addr)
+        && !is_short
+        && pool_info.migration_params.is_some();
+    let (pool_index, staking_token) = if is_short {
+        (
+            pool_info.short_reward_index,
+            pool_info.staking_token.clone(),
+        ) // actually not used later
+    } else if should_migrate {
+        let migraton_params = pool_info.migration_params.clone().unwrap();
+        (
+            migraton_params.index_snapshot,
+            migraton_params.deprecated_staking_token,
+        )
+    } else {
+        (pool_info.reward_index, pool_info.staking_token.clone())
+    };
+
     // Distribute reward to pending reward; before changing share
-    before_share_change(&pool_info, &mut reward_info, is_short)?;
+    before_share_change(pool_index, &mut reward_info)?;
 
     // Decrease total short or bond amount
     if is_short {
         pool_info.total_short_amount = pool_info.total_short_amount.checked_sub(amount)?;
-    } else {
+    } else if !should_migrate {
+        // if it should migrate, we dont need to decrease from the current total bond amount
         pool_info.total_bond_amount = pool_info.total_bond_amount.checked_sub(amount)?;
     }
 
+    // Update rewards info
     reward_info.bond_amount = reward_info.bond_amount.checked_sub(amount)?;
 
-    // Update rewards info
+    if reward_info.bond_amount.is_zero() && should_migrate {
+        store_is_migrated(storage, asset_token, staker_addr)?;
+    }
+
     if reward_info.pending_reward.is_zero() && reward_info.bond_amount.is_zero() {
         rewards_store(storage, staker_addr, is_short).remove(asset_token.as_slice());
     } else {
@@ -356,5 +396,5 @@ fn _decrease_bond_amount(
     // Update pool info
     store_pool_info(storage, asset_token, &pool_info)?;
 
-    Ok(pool_info.staking_token)
+    Ok(staking_token)
 }

--- a/contracts/mirror_staking/src/testing/contract_test.rs
+++ b/contracts/mirror_staking/src/testing/contract_test.rs
@@ -170,7 +170,8 @@ fn test_register() {
             premium_rate: Decimal::zero(),
             short_reward_weight: Decimal::zero(),
             premium_updated_time: 0,
+            migration_deprecated_staking_token: None,
+            migration_index_snapshot: None,
         }
     );
 }
-

--- a/contracts/mirror_staking/src/testing/deprecate_test.rs
+++ b/contracts/mirror_staking/src/testing/deprecate_test.rs
@@ -234,7 +234,10 @@ fn test_deprecate() {
     });
     let info = mock_info("staking", &[]);
     let err = execute(deps.as_mut(), mock_env(), info, msg.clone()).unwrap_err();
-    assert_eq!(err, StdError::generic_err("unauthorized"));
+    assert_eq!(
+        err,
+        StdError::generic_err("The staking token for this asset has been migrated to new_staking")
+    );
     let info = mock_info("new_staking", &[]);
     let err = execute(deps.as_mut(), mock_env(), info, msg).unwrap_err();
     assert_eq!(

--- a/contracts/mirror_staking/src/testing/deprecate_test.rs
+++ b/contracts/mirror_staking/src/testing/deprecate_test.rs
@@ -1,0 +1,357 @@
+use crate::contract::{execute, instantiate, query};
+use crate::state::{read_pool_info, store_pool_info, PoolInfo};
+use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
+use cosmwasm_std::{
+    from_binary, to_binary, Api, CosmosMsg, Decimal, StdError, SubMsg, Uint128, WasmMsg,
+};
+use cw20::{Cw20ExecuteMsg, Cw20ReceiveMsg};
+use mirror_protocol::staking::{
+    Cw20HookMsg, ExecuteMsg, InstantiateMsg, PoolInfoResponse, QueryMsg, RewardInfoResponse,
+    RewardInfoResponseItem,
+};
+
+#[test]
+fn test_deprecate() {
+    let mut deps = mock_dependencies(&[]);
+
+    let msg = InstantiateMsg {
+        owner: "owner".to_string(),
+        mirror_token: "reward".to_string(),
+        mint_contract: "mint".to_string(),
+        oracle_contract: "oracle".to_string(),
+        terraswap_factory: "terraswap_factory".to_string(),
+        base_denom: "uusd".to_string(),
+        premium_min_update_interval: 3600,
+        short_reward_contract: "short_reward".to_string(),
+    };
+
+    let info = mock_info("addr", &[]);
+    let _res = instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
+
+    let msg = ExecuteMsg::RegisterAsset {
+        asset_token: "asset".to_string(),
+        staking_token: "staking".to_string(),
+    };
+
+    let info = mock_info("owner", &[]);
+    let _res = execute(deps.as_mut(), mock_env(), info, msg).unwrap();
+
+    let token_raw = deps.api.addr_canonicalize("asset").unwrap();
+    let pool_info = read_pool_info(&deps.storage, &token_raw).unwrap();
+    store_pool_info(
+        &mut deps.storage,
+        &token_raw,
+        &PoolInfo {
+            premium_rate: Decimal::percent(2),
+            short_reward_weight: Decimal::percent(20),
+            ..pool_info
+        },
+    )
+    .unwrap();
+
+    // bond 100 tokens
+    let msg = ExecuteMsg::Receive(Cw20ReceiveMsg {
+        sender: "addr".to_string(),
+        amount: Uint128::new(100u128),
+        msg: to_binary(&Cw20HookMsg::Bond {
+            asset_token: "asset".to_string(),
+        })
+        .unwrap(),
+    });
+    let info = mock_info("staking", &[]);
+    let _res = execute(deps.as_mut(), mock_env(), info, msg).unwrap();
+
+    // bond 200 short token
+    let msg = ExecuteMsg::IncreaseShortToken {
+        asset_token: "asset".to_string(),
+        staker_addr: "addr".to_string(),
+        amount: Uint128::new(200u128),
+    };
+    let info = mock_info("mint", &[]);
+    let _res = execute(deps.as_mut(), mock_env(), info, msg).unwrap();
+
+    // factory deposit 100 reward tokens
+    // distribute weight => 80:20
+    let msg = ExecuteMsg::Receive(Cw20ReceiveMsg {
+        sender: "factory".to_string(),
+        amount: Uint128::new(100u128),
+        msg: to_binary(&Cw20HookMsg::DepositReward {
+            rewards: vec![("asset".to_string(), Uint128::new(100u128))],
+        })
+        .unwrap(),
+    });
+    let info = mock_info("reward", &[]);
+    let _res = execute(deps.as_mut(), mock_env(), info, msg).unwrap();
+
+    // query pool and reward info
+    let res: PoolInfoResponse = from_binary(
+        &query(
+            deps.as_ref(),
+            mock_env(),
+            QueryMsg::PoolInfo {
+                asset_token: "asset".to_string(),
+            },
+        )
+        .unwrap(),
+    )
+    .unwrap();
+    let res_cmp = res.clone();
+    assert_eq!(
+        res_cmp,
+        PoolInfoResponse {
+            total_bond_amount: Uint128::new(100u128),
+            total_short_amount: Uint128::new(200u128),
+            reward_index: Decimal::from_ratio(80u128, 100u128),
+            short_reward_index: Decimal::from_ratio(20u128, 200u128),
+            short_pending_reward: Uint128::zero(),
+            migration_index_snapshot: None,
+            migration_deprecated_staking_token: None,
+            ..res
+        }
+    );
+    let data = query(
+        deps.as_ref(),
+        mock_env(),
+        QueryMsg::RewardInfo {
+            asset_token: None,
+            staker_addr: "addr".to_string(),
+        },
+    )
+    .unwrap();
+    let res: RewardInfoResponse = from_binary(&data).unwrap();
+    assert_eq!(
+        res,
+        RewardInfoResponse {
+            staker_addr: "addr".to_string(),
+            reward_infos: vec![
+                RewardInfoResponseItem {
+                    asset_token: "asset".to_string(),
+                    bond_amount: Uint128::new(100u128),
+                    pending_reward: Uint128::new(80u128),
+                    is_short: false,
+                    should_migrate: None,
+                },
+                RewardInfoResponseItem {
+                    asset_token: "asset".to_string(),
+                    bond_amount: Uint128::new(200u128),
+                    pending_reward: Uint128::new(20u128),
+                    is_short: true,
+                    should_migrate: None,
+                },
+            ],
+        }
+    );
+
+    // execute deprecate
+    let msg = ExecuteMsg::DeprecateStakingToken {
+        asset_token: "asset".to_string(),
+        new_staking_token: "new_staking".to_string(),
+    };
+    let info = mock_info("owner", &[]);
+    execute(deps.as_mut(), mock_env(), info, msg).unwrap();
+
+    // deposit more rewards
+    let msg = ExecuteMsg::Receive(Cw20ReceiveMsg {
+        sender: "factory".to_string(),
+        amount: Uint128::new(100u128),
+        msg: to_binary(&Cw20HookMsg::DepositReward {
+            rewards: vec![("asset".to_string(), Uint128::new(100u128))],
+        })
+        .unwrap(),
+    });
+    let info = mock_info("reward", &[]);
+    let _res = execute(deps.as_mut(), mock_env(), info, msg).unwrap();
+
+    // query again
+    let res: PoolInfoResponse = from_binary(
+        &query(
+            deps.as_ref(),
+            mock_env(),
+            QueryMsg::PoolInfo {
+                asset_token: "asset".to_string(),
+            },
+        )
+        .unwrap(),
+    )
+    .unwrap();
+    let res_cmp = res.clone();
+    assert_eq!(
+        res_cmp,
+        PoolInfoResponse {
+            staking_token: "new_staking".to_string(),
+            total_bond_amount: Uint128::zero(), // reset
+            total_short_amount: Uint128::new(200u128),
+            reward_index: Decimal::from_ratio(80u128, 100u128), // stays the same
+            short_reward_index: Decimal::from_ratio(40u128, 200u128), // increased 20
+            short_pending_reward: Uint128::zero(),
+            migration_index_snapshot: Some(Decimal::from_ratio(80u128, 100u128)),
+            migration_deprecated_staking_token: Some("staking".to_string()),
+            pending_reward: Uint128::new(80u128), // new reward waiting here
+            ..res
+        }
+    );
+    let data = query(
+        deps.as_ref(),
+        mock_env(),
+        QueryMsg::RewardInfo {
+            asset_token: None,
+            staker_addr: "addr".to_string(),
+        },
+    )
+    .unwrap();
+    let res: RewardInfoResponse = from_binary(&data).unwrap();
+    assert_eq!(
+        res,
+        RewardInfoResponse {
+            staker_addr: "addr".to_string(),
+            reward_infos: vec![
+                RewardInfoResponseItem {
+                    asset_token: "asset".to_string(),
+                    bond_amount: Uint128::new(100u128),
+                    pending_reward: Uint128::new(80u128), // did not change
+                    is_short: false,
+                    should_migrate: Some(true), // non-short pos should migrate
+                },
+                RewardInfoResponseItem {
+                    asset_token: "asset".to_string(),
+                    bond_amount: Uint128::new(200u128),
+                    pending_reward: Uint128::new(40u128), // more rewards here
+                    is_short: true,
+                    should_migrate: None,
+                },
+            ],
+        }
+    );
+
+    // try to bond new or old staking token, should fail both
+    let msg = ExecuteMsg::Receive(Cw20ReceiveMsg {
+        sender: "addr".to_string(),
+        amount: Uint128::new(100u128),
+        msg: to_binary(&Cw20HookMsg::Bond {
+            asset_token: "asset".to_string(),
+        })
+        .unwrap(),
+    });
+    let info = mock_info("staking", &[]);
+    let err = execute(deps.as_mut(), mock_env(), info, msg.clone()).unwrap_err();
+    assert_eq!(err, StdError::generic_err("unauthorized"));
+    let info = mock_info("new_staking", &[]);
+    let err = execute(deps.as_mut(), mock_env(), info, msg).unwrap_err();
+    assert_eq!(
+        err,
+        StdError::generic_err("The LP token for this asset has been deprecated, withdraw all your deprecated tokens to migrate your position")
+    );
+
+    // unbond all the old tokens
+    let msg = ExecuteMsg::Unbond {
+        asset_token: "asset".to_string(),
+        amount: Uint128::new(100u128),
+    };
+    let info = mock_info("addr", &[]);
+    let res = execute(deps.as_mut(), mock_env(), info, msg).unwrap();
+    // make sure that we are receiving deprecated lp tokens tokens
+    assert_eq!(
+        res.messages,
+        vec![SubMsg::new(CosmosMsg::Wasm(WasmMsg::Execute {
+            contract_addr: "staking".to_string(),
+            msg: to_binary(&Cw20ExecuteMsg::Transfer {
+                recipient: "addr".to_string(),
+                amount: Uint128::new(100u128),
+            })
+            .unwrap(),
+            funds: vec![],
+        }))]
+    );
+    let data = query(
+        deps.as_ref(),
+        mock_env(),
+        QueryMsg::RewardInfo {
+            asset_token: None,
+            staker_addr: "addr".to_string(),
+        },
+    )
+    .unwrap();
+    let res: RewardInfoResponse = from_binary(&data).unwrap();
+    assert_eq!(
+        res,
+        RewardInfoResponse {
+            staker_addr: "addr".to_string(),
+            reward_infos: vec![
+                RewardInfoResponseItem {
+                    asset_token: "asset".to_string(),
+                    bond_amount: Uint128::zero(),
+                    pending_reward: Uint128::new(80u128), // still the same
+                    is_short: false,
+                    should_migrate: None, // now its back to empty
+                },
+                RewardInfoResponseItem {
+                    asset_token: "asset".to_string(),
+                    bond_amount: Uint128::new(200u128),
+                    pending_reward: Uint128::new(40u128),
+                    is_short: true,
+                    should_migrate: None,
+                },
+            ],
+        }
+    );
+
+    // now can bond the new staking token
+    let msg = ExecuteMsg::Receive(Cw20ReceiveMsg {
+        sender: "addr".to_string(),
+        amount: Uint128::new(100u128),
+        msg: to_binary(&Cw20HookMsg::Bond {
+            asset_token: "asset".to_string(),
+        })
+        .unwrap(),
+    });
+    let info = mock_info("new_staking", &[]);
+    let _res = execute(deps.as_mut(), mock_env(), info, msg).unwrap();
+
+    // deposit new rewards
+    // will also add to the index the pending rewards from before the migration
+    let msg = ExecuteMsg::Receive(Cw20ReceiveMsg {
+        sender: "factory".to_string(),
+        amount: Uint128::new(100u128),
+        msg: to_binary(&Cw20HookMsg::DepositReward {
+            rewards: vec![("asset".to_string(), Uint128::new(100u128))],
+        })
+        .unwrap(),
+    });
+    let info = mock_info("reward", &[]);
+    let _res = execute(deps.as_mut(), mock_env(), info, msg).unwrap();
+
+    // expect to have 80 * 3 rewards
+    // initial + deposit after deprecation + deposit after bonding again
+    let data = query(
+        deps.as_ref(),
+        mock_env(),
+        QueryMsg::RewardInfo {
+            asset_token: None,
+            staker_addr: "addr".to_string(),
+        },
+    )
+    .unwrap();
+    let res: RewardInfoResponse = from_binary(&data).unwrap();
+    assert_eq!(
+        res,
+        RewardInfoResponse {
+            staker_addr: "addr".to_string(),
+            reward_infos: vec![
+                RewardInfoResponseItem {
+                    asset_token: "asset".to_string(),
+                    bond_amount: Uint128::new(100u128),
+                    pending_reward: Uint128::new(240u128), // 80 * 3
+                    is_short: false,
+                    should_migrate: None,
+                },
+                RewardInfoResponseItem {
+                    asset_token: "asset".to_string(),
+                    bond_amount: Uint128::new(200u128),
+                    pending_reward: Uint128::new(60u128), // 40 + 20
+                    is_short: true,
+                    should_migrate: None,
+                },
+            ],
+        }
+    );
+}

--- a/contracts/mirror_staking/src/testing/mod.rs
+++ b/contracts/mirror_staking/src/testing/mod.rs
@@ -1,1 +1,5 @@
-
+mod contract_test;
+mod deprecate_test;
+mod mock_querier;
+mod reward_test;
+mod staking_test;

--- a/contracts/mirror_staking/src/testing/reward_test.rs
+++ b/contracts/mirror_staking/src/testing/reward_test.rs
@@ -1,6 +1,6 @@
 use crate::contract::{execute, instantiate, query};
-use crate::testing::mock_querier::mock_dependencies_with_querier;
 use crate::state::{read_pool_info, rewards_read, store_pool_info, PoolInfo, RewardInfo};
+use crate::testing::mock_querier::mock_dependencies_with_querier;
 use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
 use cosmwasm_std::{
     from_binary, to_binary, Addr, Api, CosmosMsg, Decimal, StdError, SubMsg, Uint128, WasmMsg,
@@ -629,18 +629,21 @@ fn withdraw_multiple_rewards() {
                     bond_amount: Uint128::new(100u128),
                     pending_reward: Uint128::new(80u128),
                     is_short: false,
+                    should_migrate: None,
                 },
                 RewardInfoResponseItem {
                     asset_token: "asset2".to_string(),
                     bond_amount: Uint128::new(1000u128),
                     pending_reward: Uint128::new(160u128),
                     is_short: false,
+                    should_migrate: None,
                 },
                 RewardInfoResponseItem {
                     asset_token: "asset".to_string(),
                     bond_amount: Uint128::new(50u128),
                     pending_reward: Uint128::new(20u128),
                     is_short: true,
+                    should_migrate: None,
                 },
             ],
         }
@@ -684,18 +687,21 @@ fn withdraw_multiple_rewards() {
                     bond_amount: Uint128::new(100u128),
                     pending_reward: Uint128::zero(),
                     is_short: false,
+                    should_migrate: None,
                 },
                 RewardInfoResponseItem {
                     asset_token: "asset2".to_string(),
                     bond_amount: Uint128::new(1000u128),
                     pending_reward: Uint128::zero(),
                     is_short: false,
+                    should_migrate: None,
                 },
                 RewardInfoResponseItem {
                     asset_token: "asset".to_string(),
                     bond_amount: Uint128::new(50u128),
                     pending_reward: Uint128::zero(),
                     is_short: true,
+                    should_migrate: None,
                 },
             ],
         }
@@ -769,10 +775,7 @@ fn test_adjust_premium() {
     )
     .unwrap();
     assert_eq!(res.premium_rate, Decimal::zero());
-    assert_eq!(
-        res.premium_updated_time,
-        env.block.time.seconds()
-    );
+    assert_eq!(res.premium_updated_time, env.block.time.seconds());
 
     // terraswap price = 90
     // premium rate = 0
@@ -817,10 +820,7 @@ fn test_adjust_premium() {
     )
     .unwrap();
     assert_eq!(res.premium_rate, Decimal::zero());
-    assert_eq!(
-        res.premium_updated_time,
-        env.block.time.seconds()
-    );
+    assert_eq!(res.premium_updated_time, env.block.time.seconds());
 
     // terraswap price = 105
     // premium rate = 5%
@@ -855,9 +855,5 @@ fn test_adjust_premium() {
     )
     .unwrap();
     assert_eq!(res.premium_rate, Decimal::percent(5));
-    assert_eq!(
-        res.premium_updated_time,
-        env.block.time.seconds()
-    );
+    assert_eq!(res.premium_updated_time, env.block.time.seconds());
 }
-

--- a/contracts/mirror_staking/src/testing/staking_test.rs
+++ b/contracts/mirror_staking/src/testing/staking_test.rs
@@ -69,6 +69,7 @@ fn test_bond_tokens() {
                 pending_reward: Uint128::zero(),
                 bond_amount: Uint128::new(100u128),
                 is_short: false,
+                should_migrate: None,
             }],
         }
     );
@@ -97,6 +98,8 @@ fn test_bond_tokens() {
             premium_rate: Decimal::zero(),
             short_reward_weight: Decimal::zero(),
             premium_updated_time: 0,
+            migration_deprecated_staking_token: None,
+            migration_index_snapshot: None,
         }
     );
 
@@ -135,6 +138,8 @@ fn test_bond_tokens() {
             premium_rate: Decimal::zero(),
             short_reward_weight: Decimal::zero(),
             premium_updated_time: 0,
+            migration_deprecated_staking_token: None,
+            migration_index_snapshot: None,
         }
     );
 
@@ -254,6 +259,8 @@ fn test_unbond() {
             premium_rate: Decimal::zero(),
             short_reward_weight: Decimal::zero(),
             premium_updated_time: 0,
+            migration_deprecated_staking_token: None,
+            migration_index_snapshot: None,
         }
     );
 
@@ -351,6 +358,8 @@ fn test_increase_short_token() {
             premium_rate: Decimal::zero(),
             short_reward_weight: Decimal::zero(),
             premium_updated_time: 0,
+            migration_deprecated_staking_token: None,
+            migration_index_snapshot: None,
         }
     );
 
@@ -373,6 +382,7 @@ fn test_increase_short_token() {
                 pending_reward: Uint128::zero(),
                 bond_amount: Uint128::new(100u128),
                 is_short: true,
+                should_migrate: None,
             }],
         }
     );
@@ -453,6 +463,8 @@ fn test_decrease_short_token() {
             premium_rate: Decimal::zero(),
             short_reward_weight: Decimal::zero(),
             premium_updated_time: 0,
+            migration_deprecated_staking_token: None,
+            migration_index_snapshot: None,
         }
     );
 
@@ -726,7 +738,8 @@ fn test_auto_stake() {
             premium_rate: Decimal::zero(),
             short_reward_weight: Decimal::zero(),
             premium_updated_time: 0,
+            migration_deprecated_staking_token: None,
+            migration_index_snapshot: None,
         }
     );
 }
-

--- a/packages/mirror_protocol/src/admin_manager.rs
+++ b/packages/mirror_protocol/src/admin_manager.rs
@@ -1,0 +1,78 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use cosmwasm_std::Binary;
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct InstantiateMsg {
+    pub owner: String,
+    pub admin_claim_period: u64,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ExecuteMsg {
+    UpdateOwner {
+        owner: String,
+    },
+    ExecuteMigrations {
+        migrations: Vec<(String, u64, Binary)>,
+    },
+    AuthorizeClaim {
+        authorized_addr: String,
+    },
+    ClaimAdmin {
+        contract: String,
+    },
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum QueryMsg {
+    Config {},
+    MigrationRecords {
+        start_after: Option<u64>, // timestamp (seconds)
+        limit: Option<u32>,
+    },
+    AuthRecords {
+        start_after: Option<u64>, // timestamp (seconds)
+        limit: Option<u32>,
+    },
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct ConfigResponse {
+    pub owner: String,
+    pub admin_claim_period: u64,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct AuthRecordResponse {
+    pub address: String,
+    pub start_time: u64,
+    pub end_time: u64,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct AuthRecordsResponse {
+    pub records: Vec<AuthRecordResponse>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct MigrationRecordResponse {
+    pub executor: String,
+    pub time: u64,
+    pub migrations: Vec<MigrationItem>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct MigrationItem {
+    pub contract: String,
+    pub new_code_id: u64,
+    pub msg: Binary,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct MigrationRecordsResponse {
+    pub records: Vec<MigrationRecordResponse>,
+}

--- a/packages/mirror_protocol/src/collateral_oracle.rs
+++ b/packages/mirror_protocol/src/collateral_oracle.rs
@@ -9,9 +9,6 @@ pub struct InstantiateMsg {
     pub owner: String,
     pub mint_contract: String,
     pub base_denom: String,
-    pub mirror_oracle: String,
-    pub anchor_oracle: String,
-    pub band_oracle: String,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
@@ -21,9 +18,6 @@ pub enum ExecuteMsg {
         owner: Option<String>,
         mint_contract: Option<String>,
         base_denom: Option<String>,
-        mirror_oracle: Option<String>,
-        anchor_oracle: Option<String>,
-        band_oracle: Option<String>,
     },
     RegisterCollateralAsset {
         asset: AssetInfo,
@@ -49,7 +43,7 @@ pub enum QueryMsg {
     Config {},
     CollateralPrice {
         asset: String,
-        block_height: Option<u64>,
+        timeframe: Option<u64>,
     },
     CollateralAssetInfo {
         asset: String,
@@ -62,9 +56,6 @@ pub struct ConfigResponse {
     pub owner: String,
     pub mint_contract: String,
     pub base_denom: String,
-    pub mirror_oracle: String,
-    pub anchor_oracle: String,
-    pub band_oracle: String,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
@@ -89,21 +80,23 @@ pub struct CollateralInfosResponse {
     pub collaterals: Vec<CollateralInfoResponse>,
 }
 
-/// We currently take no arguments for migrations
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-pub struct MigrateMsg {}
+pub struct MigrateMsg {
+    pub mirror_tefi_oracle_addr: String,
+    pub anchor_tefi_oracle_addr: String,
+}
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum SourceType {
-    MirrorOracle {},
-    AnchorOracle {},
-    BandOracle {},
+    TeFiOracle {
+        oracle_addr: String,
+    },
     FixedPrice {
         price: Decimal,
     },
-    Terraswap {
-        terraswap_pair_addr: String,
+    AMMPair {
+        pair_addr: String,
         intermediate_denom: Option<String>,
     },
     AnchorMarket {
@@ -117,11 +110,9 @@ pub enum SourceType {
 impl fmt::Display for SourceType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            SourceType::MirrorOracle { .. } => write!(f, "mirror_oracle"),
-            SourceType::AnchorOracle { .. } => write!(f, "anchor_oracle"),
-            SourceType::BandOracle { .. } => write!(f, "band_oracle"),
+            SourceType::TeFiOracle { .. } => write!(f, "tefi_oracle"),
             SourceType::FixedPrice { .. } => write!(f, "fixed_price"),
-            SourceType::Terraswap { .. } => write!(f, "terraswap"),
+            SourceType::AMMPair { .. } => write!(f, "amm_pair"),
             SourceType::AnchorMarket { .. } => write!(f, "anchor_market"),
             SourceType::Native { .. } => write!(f, "native"),
         }

--- a/packages/mirror_protocol/src/collector.rs
+++ b/packages/mirror_protocol/src/collector.rs
@@ -14,6 +14,8 @@ pub struct InstantiateMsg {
     // bLuna params
     pub bluna_token: String,
     pub bluna_swap_denom: String,
+    // when set, use this address instead of querying from terraswap
+    pub mir_ust_pair: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
@@ -29,6 +31,7 @@ pub enum ExecuteMsg {
         anchor_market: Option<String>,
         bluna_token: Option<String>,
         bluna_swap_denom: Option<String>,
+        mir_ust_pair: Option<String>,
     },
     Convert {
         asset_token: String,
@@ -44,7 +47,6 @@ pub enum QueryMsg {
     Config {},
 }
 
-// TODO: Delete when moneymarket is upgraded to std 0.14
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum MoneyMarketCw20HookMsg {
@@ -65,6 +67,7 @@ pub struct ConfigResponse {
     pub anchor_market: String,
     pub bluna_token: String,
     pub bluna_swap_denom: String,
+    pub mir_ust_pair: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/packages/mirror_protocol/src/collector.rs
+++ b/packages/mirror_protocol/src/collector.rs
@@ -72,4 +72,6 @@ pub struct ConfigResponse {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-pub struct MigrateMsg {}
+pub struct MigrateMsg {
+    pub mir_ust_pair: String,
+}

--- a/packages/mirror_protocol/src/collector.rs
+++ b/packages/mirror_protocol/src/collector.rs
@@ -20,6 +20,7 @@ pub struct InstantiateMsg {
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
+#[allow(clippy::large_enum_variant)]
 pub enum ExecuteMsg {
     UpdateConfig {
         owner: Option<String>,

--- a/packages/mirror_protocol/src/factory.rs
+++ b/packages/mirror_protocol/src/factory.rs
@@ -39,8 +39,8 @@ pub enum ExecuteMsg {
         name: String,
         /// asset symbol used to create token contract
         symbol: String,
-        /// authorized asset oracle feeder
-        oracle_feeder: String,
+        /// oracle proxy that will provide prices for this asset
+        oracle_proxy: String,
         /// used to create all necessary contract or register asset
         params: Params,
     },
@@ -48,17 +48,10 @@ pub enum ExecuteMsg {
         contract_addr: String,
         msg: Binary,
     },
-
-    //////////////////////
-    /// Feeder Operations
-    /// //////////////////
-
     /// Revoke asset from MIR rewards pool
     /// and register end_price to mint contract
-    /// Only feeder can set end_price
     RevokeAsset {
         asset_token: String,
-        end_price: Option<Decimal>,
     },
     /// Migrate asset to new asset by registering
     /// end_price to mint contract and add
@@ -66,8 +59,8 @@ pub enum ExecuteMsg {
     MigrateAsset {
         name: String,
         symbol: String,
+        oracle_proxy: String,
         from_token: String,
-        end_price: Decimal,
     },
 
     ///////////////////
@@ -125,4 +118,6 @@ pub struct Params {
     pub min_collateral_ratio_after_ipo: Option<Decimal>,
     /// For pre-IPO assets, fixed price during minting period
     pub pre_ipo_price: Option<Decimal>,
+    /// For pre-IPO assets, address authorized to trigger the ipo event
+    pub ipo_trigger_addr: Option<String>,
 }

--- a/packages/mirror_protocol/src/gov.rs
+++ b/packages/mirror_protocol/src/gov.rs
@@ -98,17 +98,13 @@ pub struct PollConfig {
 #[allow(clippy::large_enum_variant)]
 pub enum PollAdminAction {
     /// Updates migration manager owner
-    UpdateOwner {
-        owner: String,
-    },
+    UpdateOwner { owner: String },
     /// Executes a set of migrations. The poll can be executes as soon as it reaches the quorum and threshold
     ExecuteMigrations {
         migrations: Vec<(String, u64, Binary)>,
     },
     /// Transfer admin privileges over Mirror contracts to the authorized_addr
-    AuthorizeClaim {
-        authorized_addr: String,
-    },
+    AuthorizeClaim { authorized_addr: String },
     /// Updates Governace contract configuration
     UpdateConfig {
         owner: Option<String>,

--- a/packages/mirror_protocol/src/gov.rs
+++ b/packages/mirror_protocol/src/gov.rs
@@ -60,6 +60,7 @@ pub enum ExecuteMsg {
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
+#[allow(clippy::large_enum_variant)]
 pub enum Cw20HookMsg {
     /// StakeVotingTokens a user can stake their mirror token to receive rewards
     /// or do vote on polls
@@ -94,15 +95,30 @@ pub struct PollConfig {
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
+#[allow(clippy::large_enum_variant)]
 pub enum PollAdminAction {
+    /// Updates migration manager owner
     UpdateOwner {
         owner: String,
     },
+    /// Executes a set of migrations. The poll can be executes as soon as it reaches the quorum and threshold
     ExecuteMigrations {
         migrations: Vec<(String, u64, Binary)>,
     },
+    /// Transfer admin privileges over Mirror contracts to the authorized_addr
     AuthorizeClaim {
         authorized_addr: String,
+    },
+    /// Updates Governace contract configuration
+    UpdateConfig {
+        owner: Option<String>,
+        effective_delay: Option<u64>,
+        default_poll_config: Option<PollConfig>,
+        migration_poll_config: Option<PollConfig>,
+        auth_admin_poll_config: Option<PollConfig>,
+        voter_weight: Option<Decimal>,
+        snapshot_period: Option<u64>,
+        admin_manager: Option<String>,
     },
 }
 

--- a/packages/mirror_protocol/src/gov.rs
+++ b/packages/mirror_protocol/src/gov.rs
@@ -9,28 +9,29 @@ use crate::common::OrderBy;
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct InstantiateMsg {
     pub mirror_token: String,
-    pub quorum: Decimal,
-    pub threshold: Decimal,
-    pub voting_period: u64,
     pub effective_delay: u64,
-    pub proposal_deposit: Uint128,
+    pub default_poll_config: PollConfig,
+    pub migration_poll_config: PollConfig,
+    pub auth_admin_poll_config: PollConfig,
     pub voter_weight: Decimal,
     pub snapshot_period: u64,
+    pub admin_manager: String,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
+#[allow(clippy::large_enum_variant)]
 pub enum ExecuteMsg {
     Receive(Cw20ReceiveMsg),
     UpdateConfig {
         owner: Option<String>,
-        quorum: Option<Decimal>,
-        threshold: Option<Decimal>,
-        voting_period: Option<u64>,
         effective_delay: Option<u64>,
-        proposal_deposit: Option<Uint128>,
+        default_poll_config: Option<PollConfig>,
+        migration_poll_config: Option<PollConfig>,
+        auth_admin_poll_config: Option<PollConfig>,
         voter_weight: Option<Decimal>,
         snapshot_period: Option<u64>,
+        admin_manager: Option<String>,
     },
     CastVote {
         poll_id: u64,
@@ -69,6 +70,7 @@ pub enum Cw20HookMsg {
         description: String,
         link: Option<String>,
         execute_msg: Option<PollExecuteMsg>,
+        admin_action: Option<PollAdminAction>,
     },
     /// Deposit rewards to be distributed among stakers and voters
     DepositReward {},
@@ -79,6 +81,29 @@ pub enum Cw20HookMsg {
 pub struct PollExecuteMsg {
     pub contract: String,
     pub msg: Binary,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub struct PollConfig {
+    pub proposal_deposit: Uint128,
+    pub voting_period: u64,
+    pub quorum: Decimal,
+    pub threshold: Decimal,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum PollAdminAction {
+    UpdateOwner {
+        owner: String,
+    },
+    ExecuteMigrations {
+        migrations: Vec<(String, u64, Binary)>,
+    },
+    AuthorizeClaim {
+        authorized_addr: String,
+    },
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
@@ -119,13 +144,13 @@ pub enum QueryMsg {
 pub struct ConfigResponse {
     pub owner: String,
     pub mirror_token: String,
-    pub quorum: Decimal,
-    pub threshold: Decimal,
-    pub voting_period: u64,
     pub effective_delay: u64,
-    pub proposal_deposit: Uint128,
+    pub default_poll_config: PollConfig,
+    pub migration_poll_config: PollConfig,
+    pub auth_admin_poll_config: PollConfig,
     pub voter_weight: Decimal,
     pub snapshot_period: u64,
+    pub admin_manager: String,
 }
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema)]
@@ -198,7 +223,11 @@ pub struct VotersResponse {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-pub struct MigrateMsg {}
+pub struct MigrateMsg {
+    pub migration_poll_config: PollConfig,
+    pub auth_admin_poll_config: PollConfig,
+    pub admin_manager: String,
+}
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct VoterInfo {

--- a/packages/mirror_protocol/src/gov.rs
+++ b/packages/mirror_protocol/src/gov.rs
@@ -16,6 +16,7 @@ pub struct InstantiateMsg {
     pub voter_weight: Decimal,
     pub snapshot_period: u64,
     pub admin_manager: String,
+    pub poll_gas_limit: u64,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
@@ -32,6 +33,7 @@ pub enum ExecuteMsg {
         voter_weight: Option<Decimal>,
         snapshot_period: Option<u64>,
         admin_manager: Option<String>,
+        poll_gas_limit: Option<u64>,
     },
     CastVote {
         poll_id: u64,
@@ -163,6 +165,7 @@ pub struct ConfigResponse {
     pub voter_weight: Decimal,
     pub snapshot_period: u64,
     pub admin_manager: String,
+    pub poll_gas_limit: u64,
 }
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema)]
@@ -239,6 +242,7 @@ pub struct MigrateMsg {
     pub migration_poll_config: PollConfig,
     pub auth_admin_poll_config: PollConfig,
     pub admin_manager: String,
+    pub poll_gas_limit: u64,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/packages/mirror_protocol/src/lib.rs
+++ b/packages/mirror_protocol/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod admin_manager;
 pub mod collateral_oracle;
 pub mod collector;
 pub mod common;

--- a/packages/mirror_protocol/src/mint.rs
+++ b/packages/mirror_protocol/src/mint.rs
@@ -104,6 +104,7 @@ pub struct IPOParams {
     pub mint_end: u64,
     pub pre_ipo_price: Decimal,
     pub min_collateral_ratio_after_ipo: Decimal,
+    pub trigger_addr: String,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/packages/mirror_protocol/src/staking.rs
+++ b/packages/mirror_protocol/src/staking.rs
@@ -34,6 +34,10 @@ pub enum ExecuteMsg {
         asset_token: String,
         staking_token: String,
     },
+    DeprecateStakingToken {
+        asset_token: String,
+        new_staking_token: String,
+    },
 
     ////////////////////////
     /// User operations ///
@@ -139,6 +143,8 @@ pub struct PoolInfoResponse {
     pub premium_rate: Decimal,
     pub short_reward_weight: Decimal,
     pub premium_updated_time: u64,
+    pub migration_index_snapshot: Option<Decimal>,
+    pub migration_deprecated_staking_token: Option<String>,
 }
 
 // We define a custom struct for each query response
@@ -154,4 +160,7 @@ pub struct RewardInfoResponseItem {
     pub bond_amount: Uint128,
     pub pending_reward: Uint128,
     pub is_short: bool,
+    // returns true if the position should be closed to keep receiving rewards
+    // with the new lp token
+    pub should_migrate: Option<bool>,
 }

--- a/packages/mirror_protocol/src/staking.rs
+++ b/packages/mirror_protocol/src/staking.rs
@@ -96,11 +96,8 @@ pub enum Cw20HookMsg {
 /// We currently take no arguments for migrations
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct MigrateMsg {
-    pub mint_contract: String,
-    pub oracle_contract: String,
-    pub terraswap_factory: String,
-    pub base_denom: String,
-    pub premium_min_update_interval: u64,
+    pub asset_token_to_deprecate: String,
+    pub new_staking_token: String,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/packages/tefi_oracle/Cargo.toml
+++ b/packages/tefi_oracle/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "tefi-oracle"
+version = "0.1.0"
+authors = ["Terraform Labs, PTE."]
+edition = "2018"
+description = "Common TeFi oracle types"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+cosmwasm-std = { version = "0.16.2" }
+schemars = "0.8.1"
+serde = { version = "1.0.103", default-features = false, features = ["derive"] }
+thiserror = { version = "1.0.23" }
+cosmwasm-bignumber = "2.2.0"

--- a/packages/tefi_oracle/src/de.rs
+++ b/packages/tefi_oracle/src/de.rs
@@ -1,0 +1,47 @@
+use cosmwasm_std::{Addr, StdError, StdResult};
+use std::array::TryFromSliceError;
+use std::convert::TryInto;
+
+/// This code is mostly just a copy of the necessary functions from storage-plus
+/// but not introduced until cw-storage-plus 0.10.0.  Can remove this
+/// file entirely once we upgrade cw-storage-plus and use the prefix_de/range_de
+/// methods instead.
+
+pub fn deserialize_key<K: KeyDeserialize>(key: Vec<u8>) -> StdResult<K::Output> {
+    K::from_vec(key)
+}
+
+pub trait KeyDeserialize {
+    type Output: Sized;
+
+    fn from_vec(value: Vec<u8>) -> StdResult<Self::Output>;
+}
+
+impl KeyDeserialize for u64 {
+    type Output = u64;
+
+    #[inline(always)]
+    fn from_vec(value: Vec<u8>) -> StdResult<Self::Output> {
+        Ok(u64::from_be_bytes(value.as_slice().try_into().map_err(
+            |err: TryFromSliceError| StdError::generic_err(err.to_string()),
+        )?))
+    }
+}
+
+impl KeyDeserialize for String {
+    type Output = String;
+
+    #[inline(always)]
+    fn from_vec(value: Vec<u8>) -> StdResult<Self::Output> {
+        String::from_utf8(value).map_err(StdError::invalid_utf8)
+    }
+}
+
+impl KeyDeserialize for Addr {
+    type Output = Addr;
+
+    #[inline(always)]
+    fn from_vec(value: Vec<u8>) -> StdResult<Self::Output> {
+        Ok(Addr::unchecked(String::from_vec(value)?))
+    }
+}

--- a/packages/tefi_oracle/src/errors.rs
+++ b/packages/tefi_oracle/src/errors.rs
@@ -1,0 +1,29 @@
+use cosmwasm_std::{OverflowError, StdError};
+use thiserror::Error;
+
+#[derive(Error, Debug, PartialEq)]
+pub enum ContractError {
+    #[error("{0}")]
+    Std(#[from] StdError),
+
+    #[error("{0}")]
+    OverflowError(#[from] OverflowError),
+
+    #[error("Sender is not authorized to execute this operation")]
+    Unauthorized {},
+
+    #[error("The proxy address is not registered")]
+    ProxyNotRegistered {},
+
+    #[error("The asset token is not registered")]
+    AssetNotRegistered {},
+
+    #[error("Quote asset not supported")]
+    InvalidQuote {},
+
+    #[error("There is no price available with the requested constrains")]
+    PriceNotAvailable {},
+
+    #[error("Proxy error: {reason}")]
+    ProxyError { reason: String },
+}

--- a/packages/tefi_oracle/src/hub.rs
+++ b/packages/tefi_oracle/src/hub.rs
@@ -1,0 +1,99 @@
+use cosmwasm_bignumber::Decimal256;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use cosmwasm_std::Decimal;
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct InstantiateMsg {
+    pub owner: String,
+    pub base_denom: String,
+}
+
+#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
+#[serde(rename_all = "snake_case")]
+pub enum HubExecuteMsg {
+    /// Owner operation to update the owner parameter
+    UpdateOwner { owner: String },
+    /// Registers a new proxy contract for an asset_token
+    RegisterProxy {
+        asset_token: String,
+        proxy_addr: String,
+        priority: Option<u8>,
+    },
+    /// Updates the priority paramter of an existing proxy
+    UpdatePriority {
+        asset_token: String,
+        proxy_addr: String,
+        priority: u8,
+    },
+    /// Remves an already whitelisted proxy
+    RemoveProxy {
+        asset_token: String,
+        proxy_addr: String,
+    },
+}
+
+#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
+#[serde(rename_all = "snake_case")]
+pub enum HubQueryMsg {
+    /// Queries contract configuration
+    Config {},
+    /// Queries the information of all registered proxies for the provided asset_token
+    ProxyList { asset_token: String },
+    /// Queries the highes priority available price within the timeframe
+    /// If timeframe is not provided, it will ignore the price age
+    Price {
+        asset_token: String,
+        timeframe: Option<u64>,
+    },
+    /// Queries all registered proxy prices for the provied asset_token
+    PriceList { asset_token: String },
+    /// Anchor legacy query interface for oracle prices
+    LegacyPrice { base: String, quote: String },
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct ConfigResponse {
+    pub owner: String,
+    pub base_denom: String,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct PriceResponse {
+    pub rate: Decimal,
+    pub last_updated: u64,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub enum PriceQueryResult {
+    Success(PriceResponse),
+    Fail,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct PriceListResponse {
+    pub price_list: Vec<(u8, PriceQueryResult)>, // (priority, result)
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct ProxyListResponse {
+    pub asset_token: String,
+    pub proxies: Vec<(u8, String)>,
+}
+
+impl From<crate::proxy::ProxyPriceResponse> for PriceResponse {
+    fn from(proxy_res: crate::proxy::ProxyPriceResponse) -> Self {
+        PriceResponse {
+            rate: proxy_res.rate,
+            last_updated: proxy_res.last_updated,
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct LegacyPriceResponse {
+    pub rate: Decimal256,
+    pub last_updated_base: u64,
+    pub last_updated_quote: u64,
+}

--- a/packages/tefi_oracle/src/lib.rs
+++ b/packages/tefi_oracle/src/lib.rs
@@ -1,0 +1,5 @@
+pub mod de;
+pub mod errors;
+pub mod hub;
+pub mod proxy;
+pub mod querier;

--- a/packages/tefi_oracle/src/proxy.rs
+++ b/packages/tefi_oracle/src/proxy.rs
@@ -1,0 +1,15 @@
+use cosmwasm_std::Decimal;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
+#[serde(rename_all = "snake_case")]
+pub enum ProxyQueryMsg {
+    Price { asset_token: String },
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema, Default)]
+pub struct ProxyPriceResponse {
+    pub rate: Decimal,     // rate denominated in base_denom
+    pub last_updated: u64, // timestamp in seconds
+}

--- a/packages/tefi_oracle/src/querier.rs
+++ b/packages/tefi_oracle/src/querier.rs
@@ -1,0 +1,43 @@
+use cosmwasm_std::{to_binary, Addr, QuerierWrapper, QueryRequest, StdResult, WasmQuery};
+
+use crate::hub::{HubQueryMsg, PriceResponse};
+use crate::proxy::{ProxyPriceResponse, ProxyQueryMsg};
+
+/// @dev Queries an asset token price from the orcle proxy contract, price is given in the base denomination
+/// @param proxy_addr : Proxy contract address
+/// @param asset_token : Asset token address. Native assets are not supported
+pub fn query_proxy_asset_price(
+    querier: &QuerierWrapper,
+    proxy_addr: &Addr,
+    asset_token: &Addr,
+) -> StdResult<ProxyPriceResponse> {
+    let res: ProxyPriceResponse = querier.query(&QueryRequest::Wasm(WasmQuery::Smart {
+        contract_addr: String::from(proxy_addr),
+        msg: to_binary(&ProxyQueryMsg::Price {
+            asset_token: String::from(asset_token),
+        })?,
+    }))?;
+
+    Ok(res)
+}
+
+/// @dev Queries an asstet token price from hub. Hub contract will redirect the query to the corresponding price source.
+/// @param oracle_hub_addr : Oracle hub contract address
+/// @param asset_token : Asset token address. Native assets are not supported
+/// @param timeframe : (optional) Valid price timeframe in seconds
+pub fn query_asset_price(
+    querier: &QuerierWrapper,
+    oracle_hub_addr: &Addr,
+    asset_token: &Addr,
+    timeframe: Option<u64>,
+) -> StdResult<PriceResponse> {
+    let res: PriceResponse = querier.query(&QueryRequest::Wasm(WasmQuery::Smart {
+        contract_addr: String::from(oracle_hub_addr),
+        msg: to_binary(&HubQueryMsg::Price {
+            asset_token: String::from(asset_token),
+            timeframe,
+        })?,
+    }))?;
+
+    Ok(res)
+}


### PR DESCRIPTION
I suggest introducing the following 3 main features:

### 1. First round of preparations for Astroport migration (#80)
- Update collector to be able to change the MIR/UST pair (since it will be the first pool to be migrated)
- Add a LP token deprecation mechanism to staking contract

### 2. Allow governance voters to execute migrations with a new admin_manager contract (#81)
- New admin manager contract to execute contract migrations
- Admin manager contract integrated with governance
  - Ability to have different poll types with different parameters
  - Fast track polls to execute emergency migrations

### 3. Integrate with the new oracle contracts (#81)
Mirror will be using a new set of oracle contracts [TeFi Oracle contracts](https://github.com/terra-money/tefi-oracle-contracts) that will allow easier integrations with different price sources such as Band Protocol or Chainlink.
- Whitelist process updated to work with the new oracle contracts
- No longer rely on feeder address to migrate, revoke or trigger IPO events
- Now preIPO assets need to specify a trigger address authorized to execute the IPO trigger on mint contract
- Collateral oracle and other price dependent contracts now query prices form the new oracle using the timeframe constrain feature

## Migrations

Feature 1 will be added before 2 and 3, that is the reason why staking contract still depends on deprecated oracle.
Since Astroport and Terraswap share the relevant interfaces, no package update yet.
Another release will be needed when all mAsset pools are migrated to Astroport, to update the dependency as well as the whitelist process.