### PR TITLE
Add Lunax as collateral on mirror protocol

### DIFF
--- a/contracts/mirror_collateral_oracle/src/querier.rs
+++ b/contracts/mirror_collateral_oracle/src/querier.rs
@@ -2,7 +2,8 @@ use crate::math::decimal_multiplication;
 use crate::state::Config;
 use cosmwasm_bignumber::{Decimal256, Uint256};
 use cosmwasm_std::{
-    to_binary, Decimal, Deps, Env, QuerierWrapper, QueryRequest, StdError, StdResult, WasmQuery,
+    to_binary, Addr, Decimal, Deps, Env, QuerierWrapper, QueryRequest, StdError, StdResult,
+    Timestamp, Uint128, WasmQuery,
 };
 use mirror_protocol::collateral_oracle::SourceType;
 use serde::{Deserialize, Serialize};
@@ -23,6 +24,8 @@ pub enum SourceQueryMsg {
         block_height: Option<u64>,
         distributed_interest: Option<Uint256>,
     },
+    // Query message for lunax
+    State {},
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
@@ -34,6 +37,19 @@ pub struct AMMPairResponse {
 pub struct AnchorMarketResponse {
     // anchor market queries return exchange rate in Decimal256
     pub exchange_rate: Decimal256,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub struct LunaxStateResponse {
+    pub total_staked: Uint128,
+    pub exchange_rate: Decimal,
+    pub last_reconciled_batch_id: u64,
+    pub current_undelegation_batch_id: u64,
+    pub last_undelegation_time: Timestamp,
+    pub last_swap_time: Timestamp,
+    pub last_reinvest_time: Timestamp,
+    pub validators: Vec<Addr>,
+    pub reconciled_funds_to_withdraw: Uint128,
 }
 
 #[allow(clippy::ptr_arg)]
@@ -112,6 +128,24 @@ pub fn query_price(
                 }))?;
             let rate: Decimal = res.exchange_rate.into();
 
+            Ok((rate, u64::MAX))
+        }
+        SourceType::Lunax {
+            staking_contract_addr,
+        } => {
+            let res: LunaxStateResponse =
+                deps.querier.query(&QueryRequest::Wasm(WasmQuery::Smart {
+                    contract_addr: staking_contract_addr.to_string(),
+                    msg: to_binary(&SourceQueryMsg::State {}).unwrap(),
+                }))?;
+            // get lunax price in ust
+            let luna_ust_price: Decimal = query_native_rate(
+                &deps.querier,
+                "uluna".to_string(),
+                config.base_denom.clone(),
+            )?;
+
+            let rate = decimal_multiplication(res.exchange_rate, luna_ust_price);
             Ok((rate, u64::MAX))
         }
         SourceType::Native { native_denom } => {

--- a/contracts/mirror_collateral_oracle/src/testing/mock_querier.rs
+++ b/contracts/mirror_collateral_oracle/src/testing/mock_querier.rs
@@ -1,8 +1,8 @@
 use cosmwasm_bignumber::{Decimal256, Uint256};
 use cosmwasm_std::testing::{MockApi, MockQuerier, MockStorage, MOCK_CONTRACT_ADDR};
 use cosmwasm_std::{
-    from_binary, from_slice, to_binary, Coin, ContractResult, Decimal, OwnedDeps, Querier,
-    QuerierResult, QueryRequest, SystemError, SystemResult, Uint128, WasmQuery,
+    from_binary, from_slice, to_binary, Addr, Coin, ContractResult, Decimal, OwnedDeps, Querier,
+    QuerierResult, QueryRequest, SystemError, SystemResult, Timestamp, Uint128, WasmQuery,
 };
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -113,6 +113,19 @@ pub struct EpochStateResponse {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct LunaxStateResponse {
+    pub total_staked: Uint128,
+    pub exchange_rate: Decimal,
+    pub last_reconciled_batch_id: u64,
+    pub current_undelegation_batch_id: u64,
+    pub last_undelegation_time: Timestamp,
+    pub last_swap_time: Timestamp,
+    pub last_reinvest_time: Timestamp,
+    pub validators: Vec<Addr>,
+    pub reconciled_funds_to_withdraw: Uint128,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum QueryMsg {
     Price {
@@ -124,6 +137,7 @@ pub enum QueryMsg {
         block_heigth: Option<u64>,
         distributed_interest: Option<Uint256>,
     },
+    State {},
 }
 
 impl WasmMockQuerier {
@@ -194,6 +208,19 @@ impl WasmMockQuerier {
                     SystemResult::Ok(ContractResult::from(to_binary(&EpochStateResponse {
                         exchange_rate: Decimal256::from_ratio(10, 3),
                         aterra_supply: Uint256::from_str("123123123").unwrap(),
+                    })))
+                }
+                QueryMsg::State {} => {
+                    SystemResult::Ok(ContractResult::from(to_binary(&LunaxStateResponse {
+                        total_staked: Uint128::new(10000000),
+                        exchange_rate: Decimal::from_ratio(11_u128, 10_u128), // 1 lunax = 1.1 luna
+                        last_reconciled_batch_id: 1,
+                        current_undelegation_batch_id: 3,
+                        last_undelegation_time: Timestamp::from_seconds(1642932518),
+                        last_swap_time: Timestamp::from_seconds(1643116118),
+                        last_reinvest_time: Timestamp::from_seconds(1643105318),
+                        validators: vec![Addr::unchecked("valid0001"), Addr::unchecked("valid0002"), Addr::unchecked("valid0003")],
+                        reconciled_funds_to_withdraw: Uint128::new(150_u128),
                     })))
                 }
             },

--- a/contracts/mirror_collateral_oracle/src/testing/tests.rs
+++ b/contracts/mirror_collateral_oracle/src/testing/tests.rs
@@ -468,6 +468,47 @@ fn get_anchor_market_price() {
 }
 
 #[test]
+fn get_lunax_price() {
+    let mut deps = mock_dependencies(&[]);
+
+    let msg = InstantiateMsg {
+        owner: "owner0000".to_string(),
+        mint_contract: "mint0000".to_string(),
+        base_denom: "uusd".to_string(),
+    };
+
+    let info = mock_info("addr0000", &[]);
+    let _res = instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
+
+    let msg = ExecuteMsg::RegisterCollateralAsset {
+        asset: AssetInfo::Token {
+            contract_addr: "lunax0000".to_string(),
+        },
+        multiplier: Decimal::percent(100),
+        price_source: SourceType::Lunax {
+            staking_contract_addr: "lunaxstaking0000".to_string(),
+        },
+    };
+
+    let info = mock_info("owner0000", &[]);
+    let _res = execute(deps.as_mut(), mock_env(), info, msg).unwrap();
+
+    // attempt to query price
+    let query_res =
+        query_collateral_price(deps.as_ref(), mock_env(), "lunax0000".to_string(), None).unwrap();
+    assert_eq!(
+        query_res,
+        CollateralPriceResponse {
+            asset: "lunax0000".to_string(),
+            rate: Decimal::from_ratio(55u128, 10u128), // exchange rate = 1.1 i.e 1 ulunax = 1.1 uluna and 1 uluna = 5 uusd
+            last_updated: u64::MAX,
+            multiplier: Decimal::percent(100),
+            is_revoked: false,
+        }
+    );
+}
+
+#[test]
 fn get_native_price() {
     let mut deps = mock_dependencies(&[]);
 

--- a/contracts/mirror_collector/src/migration.rs
+++ b/contracts/mirror_collector/src/migration.rs
@@ -18,7 +18,11 @@ pub struct LegacyConfig {
     pub bluna_swap_denom: String,
 }
 
-pub fn migrate_config(storage: &mut dyn Storage) -> StdResult<()> {
+pub fn migrate_config(
+    storage: &mut dyn Storage,
+    lunax_token: CanonicalAddr,
+    lunax_swap_denom: String,
+) -> StdResult<()> {
     let legacy_store: ReadonlySingleton<LegacyConfig> = singleton_read(storage, KEY_CONFIG);
     let legacy_config: LegacyConfig = legacy_store.load()?;
     let config = Config {
@@ -31,6 +35,8 @@ pub fn migrate_config(storage: &mut dyn Storage) -> StdResult<()> {
         anchor_market: legacy_config.anchor_market,
         bluna_token: legacy_config.bluna_token,
         bluna_swap_denom: legacy_config.bluna_swap_denom,
+        lunax_token,
+        lunax_swap_denom,
         mir_ust_pair: None,
     };
     let mut store: Singleton<Config> = singleton(storage, KEY_CONFIG);
@@ -67,7 +73,12 @@ mod migrate_tests {
             })
             .unwrap();
 
-        migrate_config(&mut deps.storage).unwrap();
+        migrate_config(
+            &mut deps.storage,
+            CanonicalAddr::from("lunax_token".as_bytes()),
+            "uluna".to_string(),
+        )
+        .unwrap();
 
         let config: Config = read_config(&deps.storage).unwrap();
         assert_eq!(
@@ -82,6 +93,8 @@ mod migrate_tests {
                 anchor_market: deps.api.addr_canonicalize("anchormarket0000").unwrap(),
                 bluna_token: deps.api.addr_canonicalize("bluna0000").unwrap(),
                 bluna_swap_denom: "uluna".to_string(),
+                lunax_token: CanonicalAddr::from("lunax_token".as_bytes()),
+                lunax_swap_denom: "uluna".to_string(),
                 mir_ust_pair: None,
             }
         )

--- a/contracts/mirror_collector/src/state.rs
+++ b/contracts/mirror_collector/src/state.rs
@@ -19,6 +19,9 @@ pub struct Config {
     // bLuna params
     pub bluna_token: CanonicalAddr,
     pub bluna_swap_denom: String,
+    // Lunax params
+    pub lunax_token: CanonicalAddr,
+    pub lunax_swap_denom: String,
     // when set, use this address instead of querying from terraswap
     pub mir_ust_pair: Option<CanonicalAddr>,
 }

--- a/contracts/mirror_collector/src/testing/tests.rs
+++ b/contracts/mirror_collector/src/testing/tests.rs
@@ -24,6 +24,8 @@ fn proper_initialization() {
         anchor_market: "anchormarket0000".to_string(),
         bluna_token: "bluna0000".to_string(),
         bluna_swap_denom: "uluna".to_string(),
+        lunax_token: "lunax0000".to_string(),
+        lunax_swap_denom: "uluna".to_string(),
         mir_ust_pair: None,
     };
 
@@ -69,6 +71,8 @@ fn test_convert() {
         anchor_market: "anchormarket0000".to_string(),
         bluna_token: "bluna0000".to_string(),
         bluna_swap_denom: "uluna".to_string(),
+        lunax_token: "lunax0000".to_string(),
+        lunax_swap_denom: "uluna".to_string(),
         mir_ust_pair: None,
     };
 
@@ -154,6 +158,8 @@ fn test_convert_aust() {
         anchor_market: "anchormarket0000".to_string(),
         bluna_token: "bluna0000".to_string(),
         bluna_swap_denom: "uluna".to_string(),
+        lunax_token: "lunax0000".to_string(),
+        lunax_swap_denom: "uluna".to_string(),
         mir_ust_pair: None,
     };
 
@@ -182,6 +188,89 @@ fn test_convert_aust() {
 }
 
 #[test]
+fn test_convert_lunax() {
+    let mut deps = mock_dependencies(&[Coin {
+        denom: "uluna".to_string(),
+        amount: Uint128::from(100u128),
+    }]);
+    deps.querier.with_token_balances(&[(
+        &"lunax0000".to_string(),
+        &[(&MOCK_CONTRACT_ADDR.to_string(), &Uint128::from(100u128))],
+    )]);
+
+    deps.querier
+        .with_terraswap_pairs(&[(&"ulunalunax0000".to_string(), &"pairLunax".to_string())]);
+
+    let msg = InstantiateMsg {
+        owner: "owner0000".to_string(),
+        terraswap_factory: "terraswapfactory".to_string(),
+        distribution_contract: "gov0000".to_string(),
+        mirror_token: "mirror0000".to_string(),
+        base_denom: "uusd".to_string(),
+        aust_token: "aust0000".to_string(),
+        anchor_market: "anchormarket0000".to_string(),
+        bluna_token: "bluna0000".to_string(),
+        bluna_swap_denom: "uluna".to_string(),
+        lunax_token: "lunax0000".to_string(),
+        lunax_swap_denom: "uluna".to_string(),
+        mir_ust_pair: None,
+    };
+
+    let info = mock_info("addr0000", &[]);
+    let _res = instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
+
+    let msg = ExecuteMsg::Convert {
+        asset_token: "lunax0000".to_string(),
+    };
+
+    let info = mock_info("addr0000", &[]);
+    let res = execute(deps.as_mut(), mock_env(), info, msg).unwrap();
+    assert_eq!(
+        res.messages,
+        vec![
+            SubMsg::new(CosmosMsg::Wasm(WasmMsg::Execute {
+                contract_addr: "lunax0000".to_string(),
+                msg: to_binary(&Cw20ExecuteMsg::Send {
+                    contract: "pairLunax".to_string(),
+                    amount: Uint128::from(100u128),
+                    msg: to_binary(&TerraswapCw20HookMsg::Swap {
+                        max_spread: None,
+                        belief_price: None,
+                        to: None,
+                    })
+                    .unwrap(),
+                })
+                .unwrap(),
+                funds: vec![],
+            })),
+            SubMsg::new(CosmosMsg::Wasm(WasmMsg::Execute {
+                contract_addr: MOCK_CONTRACT_ADDR.to_string(),
+                msg: to_binary(&ExecuteMsg::LunaSwapHook {}).unwrap(),
+                funds: vec![],
+            })),
+        ]
+    );
+
+    // suppose we sell the lunax for 100uluna
+    let msg = ExecuteMsg::LunaSwapHook {};
+    let info = mock_info("owner0000", &[]);
+    let res = execute(deps.as_mut(), mock_env(), info, msg).unwrap();
+    assert_eq!(
+        res.messages,
+        vec![SubMsg::new(CosmosMsg::Custom(TerraMsgWrapper {
+            route: TerraRoute::Market,
+            msg_data: TerraMsg::Swap {
+                offer_coin: Coin {
+                    amount: Uint128::from(100u128),
+                    denom: "uluna".to_string()
+                },
+                ask_denom: "uusd".to_string(),
+            },
+        }))],
+    )
+}
+
+#[test]
 fn test_convert_bluna() {
     let mut deps = mock_dependencies(&[Coin {
         denom: "uluna".to_string(),
@@ -205,6 +294,8 @@ fn test_convert_bluna() {
         anchor_market: "anchormarket0000".to_string(),
         bluna_token: "bluna0000".to_string(),
         bluna_swap_denom: "uluna".to_string(),
+        lunax_token: "lunax0000".to_string(),
+        lunax_swap_denom: "uluna".to_string(),
         mir_ust_pair: None,
     };
 
@@ -280,6 +371,8 @@ fn test_send() {
         anchor_market: "anchormarket0000".to_string(),
         bluna_token: "bluna0000".to_string(),
         bluna_swap_denom: "uluna".to_string(),
+        lunax_token: "lunax0000".to_string(),
+        lunax_swap_denom: "uluna".to_string(),
         mir_ust_pair: None,
     };
 
@@ -330,6 +423,8 @@ fn test_set_astroport_mir_pair() {
         anchor_market: "anchormarket0000".to_string(),
         bluna_token: "bluna0000".to_string(),
         bluna_swap_denom: "uluna".to_string(),
+        lunax_token: "lunax0000".to_string(),
+        lunax_swap_denom: "uluna".to_string(),
         mir_ust_pair: None,
     };
 

--- a/packages/mirror_protocol/src/collateral_oracle.rs
+++ b/packages/mirror_protocol/src/collateral_oracle.rs
@@ -102,6 +102,9 @@ pub enum SourceType {
     AnchorMarket {
         anchor_market_addr: String,
     },
+    Lunax {
+        staking_contract_addr: String,
+    },
     Native {
         native_denom: String,
     },
@@ -115,6 +118,7 @@ impl fmt::Display for SourceType {
             SourceType::AMMPair { .. } => write!(f, "amm_pair"),
             SourceType::AnchorMarket { .. } => write!(f, "anchor_market"),
             SourceType::Native { .. } => write!(f, "native"),
+            SourceType::Lunax { .. } => write!(f, "lunax"),
         }
     }
 }

--- a/packages/mirror_protocol/src/collector.rs
+++ b/packages/mirror_protocol/src/collector.rs
@@ -14,6 +14,9 @@ pub struct InstantiateMsg {
     // bLuna params
     pub bluna_token: String,
     pub bluna_swap_denom: String,
+    // Lunax params
+    pub lunax_token: String,
+    pub lunax_swap_denom: String,
     // when set, use this address instead of querying from terraswap
     pub mir_ust_pair: Option<String>,
 }
@@ -73,5 +76,6 @@ pub struct ConfigResponse {
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct MigrateMsg {
-    pub mir_ust_pair: String,
+    pub lunax_token: String,
+    pub lunax_swap_denom: String,
 }


### PR DESCRIPTION
* Fetch the exchange rate from the lunax staking contract and use on chain oracle to convert the luna value of lunax to uusd
* Add a lunax_swap function to perform a swap of lunax to luna and pass it on the luna swap hook so that the luna swapped can be converted to ust.