### PR TITLE
Price collateral oracle config migration

### DIFF
--- a/contracts/mirror_admin_manager/Cargo.toml
+++ b/contracts/mirror_admin_manager/Cargo.toml
@@ -42,6 +42,7 @@ schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 cw-storage-plus = { version = "0.8.0", features = ["iterator"]}
 thiserror = { version = "1.0.20" }
+uint = { version = "=0.9.1" }
 
 [dev-dependencies]
 cosmwasm-schema = "0.16.0"

--- a/contracts/mirror_collateral_oracle/Cargo.toml
+++ b/contracts/mirror_collateral_oracle/Cargo.toml
@@ -42,6 +42,7 @@ serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 terraswap = "2.4.0"
 cosmwasm-bignumber = "2.2.0"
 terra-cosmwasm = "2.2.0"
+uint = { version = "=0.9.1" }
 
 [dev-dependencies]
 cosmwasm-schema = "0.16.0"

--- a/contracts/mirror_collateral_oracle/src/contract.rs
+++ b/contracts/mirror_collateral_oracle/src/contract.rs
@@ -1,4 +1,4 @@
-use crate::migration::migrate_collateral_infos;
+use crate::migration::{migrate_collateral_infos, migrate_config};
 use crate::querier::query_price;
 use crate::state::{
     read_collateral_info, read_collateral_infos, read_config, store_collateral_info, store_config,
@@ -323,6 +323,12 @@ pub fn query_collateral_infos(deps: Deps) -> StdResult<CollateralInfosResponse> 
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn migrate(deps: DepsMut, _env: Env, msg: MigrateMsg) -> StdResult<Response> {
+    let mirror_oracle = deps.api.addr_canonicalize(msg.mirror_oracle.as_str())?;
+    let anchor_oracle = deps.api.addr_canonicalize(msg.anchor_oracle.as_str())?;
+    let band_oracle = deps.api.addr_canonicalize(msg.band_oracle.as_str())?;
+
+    migrate_config(deps.storage, mirror_oracle, anchor_oracle, band_oracle)?;
+
     // migrate collateral infos to inclue new source type
     migrate_collateral_infos(deps.storage)?;
 

--- a/contracts/mirror_collateral_oracle/src/state.rs
+++ b/contracts/mirror_collateral_oracle/src/state.rs
@@ -5,7 +5,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 pub static PREFIX_COLLATERAL_ASSET_INFO: &[u8] = b"collateral_asset_info";
-static KEY_CONFIG: &[u8] = b"config";
+pub static KEY_CONFIG: &[u8] = b"config";
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct Config {

--- a/contracts/mirror_collector/Cargo.toml
+++ b/contracts/mirror_collector/Cargo.toml
@@ -34,7 +34,7 @@ overflow-checks = true
 backtraces = ["cosmwasm-std/backtraces"]
 
 [dependencies]
-cw20 = { version = "0.8.0" } 
+cw20 = { version = "0.8.0" }
 cosmwasm-std = { version = "0.16.0" }
 cosmwasm-storage = { version = "0.16.0" }
 mirror-protocol = { version = "2.1.1", path = "../../packages/mirror_protocol" }
@@ -43,6 +43,7 @@ serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 terra-cosmwasm = "2.2.0"
 terraswap = "2.4.0"
 thiserror = { version = "1.0.20" }
+uint = { version = "=0.9.1" }
 
 [dev-dependencies]
 cosmwasm-schema = "0.16.0"

--- a/contracts/mirror_community/Cargo.toml
+++ b/contracts/mirror_community/Cargo.toml
@@ -34,12 +34,13 @@ overflow-checks = true
 backtraces = ["cosmwasm-std/backtraces"]
 
 [dependencies]
-cw20 = { version = "0.8.0" } 
+cw20 = { version = "0.8.0" }
 cosmwasm-std = { version = "0.16.0" }
 cosmwasm-storage = { version = "0.16.0" }
 mirror-protocol = { version = "2.1.1", path = "../../packages/mirror_protocol" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
+uint = { version = "=0.9.1" }
 
 [dev-dependencies]
 cosmwasm-schema = "0.16.0"

--- a/contracts/mirror_factory/Cargo.toml
+++ b/contracts/mirror_factory/Cargo.toml
@@ -34,7 +34,7 @@ overflow-checks = true
 backtraces = ["cosmwasm-std/backtraces"]
 
 [dependencies]
-cw20 = { version = "0.8.0" } 
+cw20 = { version = "0.8.0" }
 cosmwasm-std = { version = "0.16.0", features = ["iterator"] }
 cosmwasm-storage = { version = "0.16.0", features = ["iterator"] }
 mirror-protocol = { version = "2.1.1", path = "../../packages/mirror_protocol" }
@@ -42,6 +42,7 @@ protobuf = { version = "2", features = ["with-bytes"] }
 terraswap = "2.4.0"
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
+uint = { version = "=0.9.1" }
 
 [dev-dependencies]
 cosmwasm-schema = "0.16.0"

--- a/contracts/mirror_gov/Cargo.toml
+++ b/contracts/mirror_gov/Cargo.toml
@@ -35,13 +35,14 @@ overflow-checks = true
 backtraces = ["cosmwasm-std/backtraces"]
 
 [dependencies]
-cw20 = { version = "0.8.0" } 
+cw20 = { version = "0.8.0" }
 cosmwasm-std = { version = "0.16.0" }
 cosmwasm-storage = { version = "0.16.0" }
 mirror-protocol = { version = "2.1.1", path = "../../packages/mirror_protocol" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 hex = "0.4"
+uint = { version = "=0.9.1" }
 
 [dev-dependencies]
 cosmwasm-schema = "0.16.0"

--- a/contracts/mirror_limit_order/Cargo.toml
+++ b/contracts/mirror_limit_order/Cargo.toml
@@ -34,7 +34,7 @@ overflow-checks = true
 backtraces = ["cosmwasm-std/backtraces"]
 
 [dependencies]
-cw20 = { version = "0.8.0" } 
+cw20 = { version = "0.8.0" }
 cosmwasm-std = { version = "0.16.0" }
 cosmwasm-storage = { version = "0.16.0" }
 integer-sqrt = "0.1.5"
@@ -43,6 +43,7 @@ terraswap = "2.4.0"
 terra-cosmwasm = "2.2.0"
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
+uint = { version = "=0.9.1" }
 
 [dev-dependencies]
 cosmwasm-schema = "0.16.0"

--- a/contracts/mirror_lock/Cargo.toml
+++ b/contracts/mirror_lock/Cargo.toml
@@ -41,6 +41,7 @@ mirror-protocol = { version = "2.1.1", path = "../../packages/mirror_protocol" }
 terraswap = "2.4.0"
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
+uint = { version = "=0.9.1" }
 
 [dev-dependencies]
 terra-cosmwasm = { version = "2.2.0" }

--- a/contracts/mirror_mint/Cargo.toml
+++ b/contracts/mirror_mint/Cargo.toml
@@ -41,6 +41,7 @@ mirror-protocol = { version = "2.1.1", path = "../../packages/mirror_protocol" }
 terraswap = "2.4.0"
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
+uint = { version = "=0.9.1" }
 
 [dev-dependencies]
 terra-cosmwasm = { version = "2.2.0" }

--- a/contracts/mirror_oracle/Cargo.toml
+++ b/contracts/mirror_oracle/Cargo.toml
@@ -39,6 +39,7 @@ cosmwasm-storage = { version = "0.16.0", features = ["iterator"] }
 mirror-protocol = { version = "2.1.1", path = "../../packages/mirror_protocol" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
+uint = { version = "=0.9.1" }
 
 [dev-dependencies]
 cosmwasm-schema = "0.16.0"

--- a/contracts/mirror_short_reward/Cargo.toml
+++ b/contracts/mirror_short_reward/Cargo.toml
@@ -38,6 +38,7 @@ cosmwasm-std = { version = "0.16.0" }
 mirror-protocol = { version = "2.1.1", path = "../../packages/mirror_protocol" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
+uint = { version = "=0.9.1" }
 
 [dev-dependencies]
 cosmwasm-schema = "0.16.0"

--- a/contracts/mirror_staking/Cargo.toml
+++ b/contracts/mirror_staking/Cargo.toml
@@ -34,13 +34,14 @@ overflow-checks = true
 backtraces = ["cosmwasm-std/backtraces"]
 
 [dependencies]
-cw20 = { version = "0.8.0" } 
+cw20 = { version = "0.8.0" }
 terraswap = "2.4.0"
 cosmwasm-std = { version = "0.16.0" }
 cosmwasm-storage = { version = "0.16.0" }
 mirror-protocol = { version = "2.1.1", path = "../../packages/mirror_protocol" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
+uint = { version = "=0.9.1" }
 
 [dev-dependencies]
 terra-cosmwasm = { version = "2.2.0" }

--- a/packages/mirror_protocol/Cargo.toml
+++ b/packages/mirror_protocol/Cargo.toml
@@ -17,12 +17,13 @@ documentation = "https://docs.mirror.finance"
 backtraces = ["cosmwasm-std/backtraces"]
 
 [dependencies]
-cw20 = { version = "0.8.0" } 
+cw20 = { version = "0.8.0" }
 cosmwasm-std = { version = "0.16.0", default-features = false, features = ["iterator"] }
 cosmwasm-storage = { version = "0.16.0", default-features = false, features = ["iterator"] }
 terraswap = { version = "2.4.0" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
+uint = { version = "0.9.1" }
 
 [profile.release]
 overflow-checks = true

--- a/packages/mirror_protocol/src/collateral_oracle.rs
+++ b/packages/mirror_protocol/src/collateral_oracle.rs
@@ -94,6 +94,9 @@ pub struct MigrateMsg {
     pub lunax_token_addr: String,
     pub lunax_staking_contract: String,
     pub multiplier: Decimal,
+    pub mirror_oracle: String,
+    pub anchor_oracle: String,
+    pub band_oracle: String,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/packages/tefi_oracle/Cargo.toml
+++ b/packages/tefi_oracle/Cargo.toml
@@ -13,3 +13,4 @@ schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.23" }
 cosmwasm-bignumber = "2.2.0"
+uint = { version = "=0.9.1" }


### PR DESCRIPTION
Migrate the config when migrating the collateral price oracle.
Override uint crate with version 0.9.1 to fix build issues with workspace optimizer. long term solution should be to enable 2021 rust compiler version in the workspace optimizer.