### PR TITLE
Update CHANGELOG and update uint dependency to use 0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,3 @@
-# 2.1.1
+# 2.1.2
 
-* Fixed issues found through code review and integration testing #75
+* Migration for collateral oracle and collector to support LunaX as collateral #88

--- a/packages/mirror_protocol/Cargo.toml
+++ b/packages/mirror_protocol/Cargo.toml
@@ -23,6 +23,7 @@ cosmwasm-storage = { version = "0.16.0", default-features = false, features = ["
 terraswap = { version = "2.4.0" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
+uint = { version = "=0.9.1" }
 
 [profile.release]
 overflow-checks = true


### PR DESCRIPTION
- Need to use uint 0.9.1 to prevent the optimizer from failing