### PR TITLE
Collector astro spread fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
-# 2.1.2
+# 2.1.3
 
 * Migration for collateral oracle and collector to support LunaX as collateral #88
+* Fixed max spread issue with Astroport pairs on Collector

--- a/contracts/mirror_collector/Cargo.toml
+++ b/contracts/mirror_collector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mirror-collector"
-version = "2.1.2"
+version = "2.1.3"
 authors = ["Terraform Labs, PTE."]
 edition = "2018"
 description = "A Collector contract for Mirror Protocol - collect all swap rewards and send it to staking contract"

--- a/contracts/mirror_collector/src/swap.rs
+++ b/contracts/mirror_collector/src/swap.rs
@@ -1,6 +1,10 @@
+use std::str::FromStr;
+
 use crate::errors::ContractError;
 use crate::state::{read_config, Config};
-use cosmwasm_std::{attr, to_binary, Addr, Coin, CosmosMsg, DepsMut, Env, Response, WasmMsg};
+use cosmwasm_std::{
+    attr, to_binary, Addr, Coin, CosmosMsg, Decimal, DepsMut, Env, Response, WasmMsg,
+};
 use cw20::Cw20ExecuteMsg;
 use mirror_protocol::collector::ExecuteMsg;
 use schemars::JsonSchema;
@@ -11,6 +15,7 @@ use terraswap::pair::{Cw20HookMsg as TerraswapCw20HookMsg, ExecuteMsg as Terrasw
 use terraswap::querier::{query_balance, query_pair_info, query_token_balance};
 
 const LUNA_DENOM: &str = "uluna";
+const AMM_MAX_ALLOWED_SLIPPAGE: &str = "0.5";
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
@@ -98,7 +103,7 @@ fn direct_swap(
                         amount,
                         ..swap_asset
                     },
-                    max_spread: None,
+                    max_spread: Some(Decimal::from_str(AMM_MAX_ALLOWED_SLIPPAGE)?), // currently need to set max_allowed_slippage for Astroport
                     belief_price: None,
                     to: None,
                 })?,
@@ -119,7 +124,7 @@ fn direct_swap(
                     contract: pair_addr,
                     amount,
                     msg: to_binary(&TerraswapCw20HookMsg::Swap {
-                        max_spread: None,
+                        max_spread: None, // currently all mAsset swaps are on terraswap, so we set max_spread to None
                         belief_price: None,
                         to: None,
                     })?,

--- a/contracts/mirror_collector/src/testing/tests.rs
+++ b/contracts/mirror_collector/src/testing/tests.rs
@@ -120,7 +120,7 @@ fn test_convert() {
                     },
                     amount: Uint128::from(99u128),
                 },
-                max_spread: None,
+                max_spread: Some(Decimal::percent(50)), // astroport swap
                 belief_price: None,
                 to: None,
             })
@@ -437,7 +437,7 @@ fn test_set_astroport_mir_pair() {
                     },
                     amount: Uint128::from(99u128),
                 },
-                max_spread: None,
+                max_spread: Some(Decimal::percent(50)),
                 belief_price: None,
                 to: None,
             })
@@ -487,7 +487,7 @@ fn test_set_astroport_mir_pair() {
                     },
                     amount: Uint128::from(99u128),
                 },
-                max_spread: None,
+                max_spread: Some(Decimal::percent(50)), // astroport swap
                 belief_price: None,
                 to: None,
             })


### PR DESCRIPTION
- Because the default spread on Astroport is very low. For UST->MIR swaps on collector we set the maximum allowed spread (50%)

See [Astroport code](https://github.com/astroport-fi/astroport-core/blob/7f24416e0ceaa60c193c22e3434d2151faa1e657/packages/astroport/src/pair.rs#L12)