### PR TITLE
Updated mirror_short_reward with 100% short limit.

### DIFF
--- a/contracts/mirror_short_reward/src/contract.rs
+++ b/contracts/mirror_short_reward/src/contract.rs
@@ -42,7 +42,7 @@ pub fn query(_deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
 pub fn query_short_reward_weight(premium_rate: Decimal) -> StdResult<ShortRewardWeightResponse> {
     if premium_rate > Decimal::percent(7) {
         return Ok(ShortRewardWeightResponse {
-            short_reward_weight: Decimal::percent(40),
+            short_reward_weight: Decimal::percent(100),
         });
     }
 
@@ -65,7 +65,7 @@ pub fn query_short_reward_weight(premium_rate: Decimal) -> StdResult<ShortReward
     };
 
     let short_reward_weight: Decimal =
-        decimal_division(erf_plus_one(sign_x, x)?, Decimal::from_ratio(5u128, 1u128));
+        decimal_division(erf_plus_one(sign_x, x)?, Decimal::from_ratio(2u128, 1u128));
 
     Ok(ShortRewardWeightResponse {
         short_reward_weight,

--- a/contracts/mirror_short_reward/src/tests.rs
+++ b/contracts/mirror_short_reward/src/tests.rs
@@ -10,37 +10,37 @@ fn short_reward_weight_test() {
         query_short_reward_weight(Decimal::zero())
             .unwrap()
             .short_reward_weight,
-        Decimal::from_ratio(2618u128, e6)
+        Decimal::from_ratio(6545u128, e6)
     );
     assert_eq!(
         query_short_reward_weight(Decimal::percent(1))
             .unwrap()
             .short_reward_weight,
-        Decimal::from_ratio(634168u128, e7),
+        Decimal::from_ratio(1585420u128, e7),
     );
     assert_eq!(
         query_short_reward_weight(Decimal::percent(2))
             .unwrap()
             .short_reward_weight,
-        Decimal::percent(20)
+        Decimal::percent(50)
     );
     assert_eq!(
         query_short_reward_weight(Decimal::percent(4))
             .unwrap()
             .short_reward_weight,
-        Decimal::from_ratio(3908998u128, e7)
+        Decimal::from_ratio(9772495u128, e7)
     );
     assert_eq!(
         query_short_reward_weight(Decimal::percent(8))
             .unwrap()
             .short_reward_weight,
-        Decimal::percent(40)
+        Decimal::percent(100)
     );
     assert_eq!(
         query_short_reward_weight(Decimal::percent(15))
             .unwrap()
             .short_reward_weight,
-        Decimal::percent(40)
+        Decimal::percent(100)
     );
 }
 


### PR DESCRIPTION
As discussed in https://github.com/Mirror-Protocol/mirror-contracts/issues/96

Terra forum thread: https://forum.mirror.finance/t/simp-3-change-short-farm-maximum-reward-allocation-from-40-to-100/
Community poll: https://mirrorprotocol.app/#/gov/poll/261


Please review changes thoroughly before approving.
